### PR TITLE
Add the epel repo to the jumphost.

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -13,6 +13,7 @@
   hosts: jumphost
   become: true
   roles:
+     - geerlingguy.repo-epel
      - ldap
      - cluster
      - geerlingguy.security

--- a/galaxy-requirements.yml
+++ b/galaxy-requirements.yml
@@ -1,6 +1,7 @@
 ---
+- src: chrisgavin.ansible-ssh-host-signer
 - src: geerlingguy.firewall
   version: 2.4.0
 - src: geerlingguy.postfix
-- src: chrisgavin.ansible-ssh-host-signer
+- src: geerlingguy.repo-epel
 - src: geerlingguy.security


### PR DESCRIPTION
Add the epel repo to the jumphost.

This is nessecary as it has no spacewalk connection.
