### PR TITLE
Develop more

### DIFF
--- a/group_vars/gearshift/vars.yml
+++ b/group_vars/gearshift/vars.yml
@@ -1,5 +1,6 @@
 ---
 slurm_cluster_name: 'gearshift'
+slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'gs'
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-11]"
 vcompute_sockets: 2

--- a/group_vars/hyperchicken/vars.yml
+++ b/group_vars/hyperchicken/vars.yml
@@ -1,5 +1,6 @@
 ---
 slurm_cluster_name: 'hyperchicken'
+#slurm_cluster_domain: ''
 stack_prefix: 'hc'
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-05]"
 vcompute_sockets: 1

--- a/group_vars/jumphost.yml
+++ b/group_vars/jumphost.yml
@@ -4,4 +4,5 @@ firewall_allowed_tcp_ports:
   - "80"
 firewall_additional_rules:
   - "iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 80 -j REDIRECT --to-port 22"
-ssh_host_signer_hostnames: "airlock.hpc.rug.nl,{{ ansible_hostname }}"
+ssh_host_signer_hostnames: "{{ ansible_hostname }}.{{ slurm_cluster_domain }},{{ ansible_hostname }}"
+...

--- a/group_vars/talos/vars.yml
+++ b/group_vars/talos/vars.yml
@@ -1,5 +1,6 @@
 ---
 slurm_cluster_name: 'talos'
+slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'tl'
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-03]"
 vcompute_sockets: 2

--- a/heat/talos.yml
+++ b/heat/talos.yml
@@ -20,6 +20,18 @@ resources:
         - network: vlan983
           fixed_ip: 172.23.40.92
 
+  reception:
+    type: OS::Nova::Server
+    properties:
+      key_name: adminkey
+      image: {get_param: image_name}
+      flavor: 2C-4GB
+      networks:
+        - network: vlan983
+          fixed_ip: 172.23.40.???
+        - network: vlan13
+          fixed_ip: 129.125.60.???
+
   tl-sai_volume:
     type: OS::Cinder::Volume
     properties:

--- a/hyperchicken_hosts
+++ b/hyperchicken_hosts
@@ -1,5 +1,5 @@
 [slurm]
-hc-slurm
+hc-sai
 
 [jumphost]
 portal
@@ -11,7 +11,7 @@ hyperchicken
 hc-dai
 
 [administration]
-hc-slurm
+hc-sai
 hc-dai
 hyperchicken
 

--- a/roles/cluster/templates/gearshift_hosts
+++ b/roles/cluster/templates/gearshift_hosts
@@ -18,6 +18,7 @@
 # Proxy servers.
 #
 172.23.40.36       airlock
+#172.23.40.???     reception
 
 #
 # Admin / Management machines.

--- a/roles/cluster/templates/hyperchicken_hosts
+++ b/roles/cluster/templates/hyperchicken_hosts
@@ -17,24 +17,26 @@
 
 #
 # Admin / Management machines.
+# DAI = Deploy Admin Interface
+# SAI = Sys Admin Interface
 #
+192.168.0.5             hc-sai
 192.168.0.9             hc-dai
 
 #
 # Cluster User Interfaces (UIs).
 #
+192.168.0.12            hyperchicken
 
 #
 # Shared network storage servers.
 #
 
 #
-# Hyperchicken (Solve-RD cluster)
+# Cluster nodes.
 #
-192.168.0.12            hyperchicken
-192.168.0.5             hc-slurm
 192.168.0.11            hc-vcompute01
 192.168.0.19            hc-vcompute02
 192.168.0.14            hc-vcompute03
 192.168.0.8             hc-vcompute04
-192.168.0.9             hc-dai
+

--- a/roles/slurm/files/configure_slurm_accounting_db.bash
+++ b/roles/slurm/files/configure_slurm_accounting_db.bash
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+#
+##
+### Create Slurm DB for the accounting info of this cluster.
+##
+#
+sacctmgr add cluster {{ slurm_cluster_name }}
+
+#
+##
+### Create Quality of Service (QoS) levels.
+##
+#
+
+#
+# QoS leftover
+#
+sacctmgr -i create qos set \
+        Name='leftover' \
+        Priority=0 \
+        UsageFactor=0 \
+        Description='Go Dutch: Quality of Service level for cheapskates with zero priority, but resources consumed do not impact your Fair Share.' \
+        GrpSubmit=30000 MaxSubmitJobsPU=10000 \
+        GrpTRES=cpu=0,mem=0
+
+sacctmgr -i create qos set \
+        Name='leftover-short' \
+        Priority=0 \
+        UsageFactor=0 \
+        Description='leftover-short' \
+        GrpSubmit=30000 MaxSubmitJobsPU=10000 MaxWall=06:00:00
+
+sacctmgr -i create qos set \
+        Name='leftover-medium' \
+        Priority=0 \
+        UsageFactor=0 \
+        Description='leftover-medium' \
+        GrpSubmit=30000 MaxSubmitJobsPU=10000 MaxWall=1-00:00:00
+
+sacctmgr -i create qos set \
+        Name='leftover-long' \
+        Priority=0 \
+        UsageFactor=0 \
+        Description='leftover-long' \
+        GrpSubmit=3000 MaxSubmitJobsPU=1000  MaxWall=7-00:00:00
+
+#
+# QoS regular
+#
+sacctmgr -i create qos set \
+        Name='regular' \
+        Priority=10 \
+        Description='Standard Quality of Service level with default priority and corresponding impact on your Fair Share.' \
+        GrpSubmit=30000 MaxSubmitJobsPU=5000 \
+        GrpTRES=cpu=0,mem=0
+
+sacctmgr -i create qos set \
+        Name='regular-short' \
+        Priority=10 \
+        Description='regular-short' \
+        GrpSubmit=30000 MaxSubmitJobsPU=5000  MaxWall=06:00:00 
+
+sacctmgr -i create qos set \
+        Name='regular-medium' \
+        Priority=10 \
+        Description='regular-medium' \
+        GrpSubmit=30000 MaxSubmitJobsPU=5000  MaxWall=1-00:00:00 \
+        MaxTRESPU=cpu={{ (cluster_cores_total * 0.4) | int }},mem={{ (cluster_mem_total * 0.4) | int }}
+
+sacctmgr -i create qos set \
+        Name='regular-long' \
+        Priority=10 \
+        Description='regular-long' \
+        GrpSubmit=3000 MaxSubmitJobsPU=1000  MaxWall=7-00:00:00 \
+        GrpTRES=cpu={{ (cluster_cores_total * 0.3) | int }},mem={{ (cluster_mem_total * 0.3) | int }} \
+        MaxTRESPU=cpu={{ (cluster_cores_total * 0.15) | int }},mem={{ (cluster_mem_total * 0.15) | int }}
+
+#
+# QoS priority
+#
+sacctmgr -i create qos set \
+        Name='priority' \
+        Priority=20 \
+        UsageFactor=2 \
+        Description='High priority Quality of Service level with corresponding higher impact on your Fair Share.' \
+        GrpSubmit=5000  MaxSubmitJobsPU=1000 \
+        GrpTRES=cpu=0,mem=0
+
+sacctmgr -i create qos set \
+        Name='priority-short' \
+        Priority=20 \
+        UsageFactor=2 \
+        Description='priority-short' \
+        GrpSubmit=5000  MaxSubmitJobsPU=1000   MaxWall=06:00:00 \
+        MaxTRESPU=cpu={{ (cluster_cores_total * 0.25) | int }},mem={{ (cluster_mem_total * 0.25) | int }}
+
+sacctmgr -i create qos set \
+        Name='priority-medium' \
+        Priority=20 \
+        UsageFactor=2 \
+        Description='priority-medium' \
+        GrpSubmit=2500  MaxSubmitJobsPU=500   MaxWall=1-00:00:00 \
+        GrpTRES=cpu={{ (cluster_cores_total * 0.5) | int }},mem={{ (cluster_mem_total * 0.5) | int }} \
+        MaxTRESPU=cpu={{ (cluster_cores_total * 0.2) | int }},mem={{ (cluster_mem_total * 0.2) | int }}
+
+sacctmgr -i create qos set \
+        Name='priority-long' \
+        Priority=20 \
+        UsageFactor=2 \
+        Description='priority-long' \
+        GrpSubmit=250   MaxSubmitJobsPU=50   MaxWall=7-00:00:00 \
+        GrpTRES=cpu={{ (cluster_cores_total * 0.2) | int }},mem={{ (cluster_mem_total * 0.2) | int }} \
+        MaxTRESPU=cpu={{ (cluster_cores_total * 0.1) | int }},mem={{ (cluster_mem_total * 0.1) | int }}
+
+#
+# QoS ds
+#
+sacctmgr -i create qos set \
+        Name='ds' \
+        Priority=10 \
+        UsageFactor=1 \
+        Description='Data Staging Quality of Service level for jobs with access to prm storage.' \
+        GrpSubmit=5000  MaxSubmitJobsPU=1000 \
+        GrpTRES=cpu=0,mem=0
+
+sacctmgr -i create qos set \
+        Name='ds-short' \
+        Priority=10 \
+        UsageFactor=1 \
+        Description='ds-short' \
+        GrpSubmit=5000  MaxSubmitJobsPU=1000   MaxWall=06:00:00 \
+        MaxTRESPU=cpu=4,mem=4096
+
+sacctmgr -i create qos set \
+        Name='ds-medium' \
+        Priority=10 \
+        UsageFactor=1 \
+        Description='ds-medium' \
+        GrpSubmit=2500  MaxSubmitJobsPU=500   MaxWall=1-00:00:00 \
+        GrpTRES=cpu=2,mem=2048 \
+        MaxTRESPU=cpu=2,mem=2048
+
+sacctmgr -i create qos set \
+        Name='ds-long' \
+        Priority=10 \
+        UsageFactor=1 \
+        Description='ds-long' \
+        GrpSubmit=250   MaxSubmitJobsPU=50   MaxWall=7-00:00:00 \
+        GrpTRES=cpu=1,mem=1024 \
+        MaxTRESPU=cpu=1,mem=1024
+
+#
+# List all QoS.
+#
+#sacctmgr show qos format=Name%15,Priority,UsageFactor,GrpTRES%30,GrpSubmit,GrpJobs,MaxTRESPerUser%30,MaxSubmitJobsPerUser,MaxJobsPerUser,MaxTRESPerJob,MaxWallDurationPerJob
+
+#
+##
+### Create accounts and assign QoS to accounts.
+##
+#
+
+#
+# Create 'users' account in addition to the default 'root' account.
+#
+sacctmgr -i create account users \
+         Descr=scientists Org=various
+
+#
+# Assign QoS to the root account.
+#
+sacctmgr -i modify account root set \
+         QOS=priority,priority-short,priority-medium,priority-long
+
+sacctmgr -i modify account root set \
+         QOS+=leftover,leftover-short,leftover-medium,leftover-long
+
+sacctmgr -i modify account root set \
+         QOS+=regular,regular-short,regular-medium,regular-long
+
+sacctmgr -i modify account root set \
+         QOS+=dev,dev-short,dev-medium,dev-long
+
+sacctmgr -i modify account root set \
+         QOS+=ds,ds-short,ds-medium,ds-long
+
+sacctmgr -i modify account root set \
+         DefaultQOS=priority
+
+#
+# Assign QoS to the users account.
+#
+sacctmgr -i modify account users set \
+         QOS=regular,regular-short,regular-medium,regular-long
+
+sacctmgr -i modify account users set \
+         QOS+=priority,priority-short,priority-medium,priority-long
+
+sacctmgr -i modify account users set \
+         QOS+=leftover,leftover-short,leftover-medium,leftover-long
+
+sacctmgr -i modify account users set \
+         QOS+=dev,dev-short,dev-medium,dev-long
+
+sacctmgr -i modify account users set \
+         QOS+=ds,ds-short,ds-medium,ds-long
+
+sacctmgr -i modify account users set \
+         DefaultQOS=regular
+
+#
+# List all associations to verify the required accounts exist and the right (default) QoS.
+#
+#sacctmgr show assoc tree format=Cluster%8,Account,User%-30,Share%5,QOS%-222,DefaultQOS%-8
+
+#
+# Allow QoS priority to pre-empt jobs in QoS leftover.
+#
+sacctmgr -i modify qos Name='priority-short'  set Preempt='leftover-short,leftover-medium,leftover-long'
+sacctmgr -i modify qos Name='priority-medium' set Preempt='leftover-short,leftover-medium,leftover-long'
+sacctmgr -i modify qos Name='priority-long'   set Preempt='leftover-short,leftover-medium,leftover-long'
+
+#
+# Allow QoS regular to pre-empt jobs in QoS leftover.
+#
+sacctmgr -i modify qos Name='regular-short'   set Preempt='leftover-short,leftover-medium,leftover-long'
+sacctmgr -i modify qos Name='regular-medium'  set Preempt='leftover-short,leftover-medium,leftover-long'
+sacctmgr -i modify qos Name='regular-long'    set Preempt='leftover-short,leftover-medium,leftover-long'
+
+#
+# List all QoS and verify pre-emption settings.
+#
+#sacctmgr show qos format=Name%15,Priority,UsageFactor,GrpTRES%30,GrpSubmit,GrpJobs,MaxTRESPerUser%30,MaxSubmitJobsPerUser,Preempt%45,MaxWallDurationPerJob
+

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -1,5 +1,11 @@
 # Build and install a docker image for slurm.
 ---
+- name: Determine cluster size (number of vcompute nodes, cores per node, mem per node, etc.)
+  set_fact:
+    vcompute_host_count: "{{ groups['compute-vm'] | length }}"
+    cluster_cores_total: "{{ vcompute_host_count * vcompute_max_cpus_per_node }}"
+    cluster_mem_total: "{{ vcompute_host_count * vcompute_max_mem_per_node }}"
+
 - name: Install yum dependencies
   yum:
     state: latest
@@ -177,8 +183,8 @@
 
 - name: Copy QOS script to cluster.
   template:
-    src: files/{{ slurm_cluster_name }}_qos_level.bash
-    dest: /srv/slurm/volumes/scripts/qos.bash
+    src: files/configure_slurm_accounting_db.bash
+    dest: /srv/slurm/volumes/scripts/configure_slurm_accounting_db.bash
     mode: 0700
 
 - name: Create QOS levels in Slurm database.
@@ -188,7 +194,7 @@
     --volume /srv/slurm/volumes/etc/slurm:/etc/slurm
     --volume /srv/slurm/volumes/scripts/:/scripts/
     --volumes-from munge.service
-    hpc/slurm /scripts/qos.bash
+    hpc/slurm /scripts/configure_slurm_accounting_db.bash
   tags:
     - create_database
   register: command_result

--- a/talos_hosts
+++ b/talos_hosts
@@ -1,3 +1,6 @@
+[jumphost]
+reception
+
 [slurm]
 tl-sai
 


### PR DESCRIPTION
* Made configuration of Slurm DB flexible: determine QoS settings based on cluster size as derived from inventory and group_vars.
* Made jumphost config more generic which allows removal of the host specific airlock vars in hosts_vars.
* Cleanup of Hyperchicken hosts and renamed hc-slurm -> hc-sai for naming consistency.
* Added new "reception" jumphost for Talos cluster (requires IP addresses assigned by sys admin).