### PR TITLE
Added changes for federated login. 

### DIFF
--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -21,7 +21,7 @@ uri_ldap: 172.23.40.249
 uri_ldaps: comanage-in.id.rug.nl
 ldap_port: 389
 ldaps_port: 636
-ldap_base: ou=umcg,o=asds
+ldap_base: ou=research,o=asds
 ldap_binddn: cn=clusteradminumcg,o=asds
 filter_passwd: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'
 filter_shadow: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'

--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -23,6 +23,10 @@ ldap_port: 389
 ldaps_port: 636
 ldap_base: ou=umcg,o=asds
 ldap_binddn: cn=clusteradminumcg,o=asds
+filter_passwd: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'
+filter_shadow: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'
+pam_authz_search: '(|(&(objectClass=posixGroup)(cn=co_bbmri_g-GRP_Gearshift)(memberUid=$username))(&(cn=$username)(rugpersonentitlementvalue=umcg)))'
+
 nameservers: [
   '172.23.40.244', # Order is important: local DNS for Isilon storage first!
   '8.8.4.4',       # Google DNS.

--- a/roles/ldap/templates/ldap.conf
+++ b/roles/ldap/templates/ldap.conf
@@ -6,7 +6,7 @@
 #
 
 uri ldap://{{ uri_ldap }}
-base ou=umcg,o=asds
+base {{ ldap_base }}
 ssl no
 tls_cacertdir /etc/openldap/cacerts
 binddn {{ ldap_binddn }}

--- a/roles/ldap/templates/nslcd.conf
+++ b/roles/ldap/templates/nslcd.conf
@@ -4,5 +4,14 @@ ssl no
 tls_cacertdir /etc/openldap/cacerts
 uri ldap://{{ uri_ldap }}
 base {{ ldap_base }}
+{% if filter_passwd is defined %}
+filter passwd {{ filter_passwd }}
+{% endif %}
+{% if filter_shadow is defined %}
+filter shadow {{ filter_shadow }}
+{% endif %}
+{% if pam_authz_search is defined %}
+pam_authz_search  {{ pam_authz_search }}
+{% endif %}
 binddn {{ ldap_binddn }}
 bindpw {{ bindpw }}

--- a/single_role_playbooks/ldap.yml
+++ b/single_role_playbooks/ldap.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install ldap role.
+  hosts: cluster
+  become: true
+  tasks:
+  roles:
+     - ldap


### PR DESCRIPTION
tested on gs-vcompute01
```
[egon@gs-vcompute01 ~]$ id umcg-hjtest
uid=50100844(umcg-hjtest) gid=50100844(umcg-hjtest) groups=50100844(umcg-hjtest)

```
Aanpassingen in /etc/nscld.conf

base ou=research,o=asds
#filter op scz entitlement of umcg
filter passwd (|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))
filter shadow (|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))
#extra check om alleen umcg mensen toe te laten en SCZ mensen die in de groep gearshift zitten
pam_authz_search (|(&(objectClass=posixGroup)(cn=co_bbmri_g-GRP_Gearshift)(memberUid=$username))(&(cn=$username)(rugpersonentitlementvalue=umcg)))

Aanpassingen in /etc/ssh/ldap.conf
base ou=research,o=asds
```

