### PR TITLE
Bugfixes and improved version of login checks

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -60,7 +60,6 @@ auth_users:
     uid: 1008
     pub_keys: |
               ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDvx1ebTndL/HitD30uNpvESXWUAxT3j0e0CzrBUZ8fHDv+vZTbWBRtWbnLgCnVDPa3GclA1lpnvJD9JBjBhUa8= ger@ger-pc
-
   robin:
     comment: 'Robin Teeninga'
     uid: 1009

--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -12,7 +12,7 @@ vcompute_real_memory: 7822
 vcompute_max_cpus_per_node: "{{ vcompute_sockets * vcompute_cores_per_socket - 2 }}"
 vcompute_max_mem_per_node: "{{ vcompute_real_memory - vcompute_sockets * vcompute_cores_per_socket * 512 }}"
 vcompute_local_disk: 0
-vcompute_features: 'tmp02'
+vcompute_features: 'tmp08'
 vcompute_ethernet_interfaces:
   - 'eth0'
   - 'eth1'

--- a/roles/logins/files/login_checks.sh
+++ b/roles/logins/files/login_checks.sh
@@ -85,9 +85,12 @@ login_actions () {
 # but in the first case there are no SLURM related environment variables defined.
 #
 
-# SOURCE_HPC_ENV variable checking disabled (it is not set ) Egon 30-10-2018
-#if [ ${TERM} == 'dumb' ] && [ -z ${SOURCE_HPC_ENV} ]; then
-if [ ${TERM} == 'dumb' ]; then
+#
+# ToDo: fix this. As of CentOS 7.x interactive session that eventually report ${TERM} == 'bash'
+# report ${TERM} == 'dumb' at the point where this script is executed in the PAM stack :(.
+# Makes it impossible to determine the difference between an SFTP session versus a Bash session.
+#
+if [ ${TERM} == 'dumb' ] && [ -z "${SOURCE_HPC_ENV:-}" ]; then
     $LOGGER "debug: exiting because of dumb terminal"
     exit 0
 fi

--- a/roles/logins/tasks/main.yml
+++ b/roles/logins/tasks/main.yml
@@ -63,7 +63,17 @@
     dest: "/etc/pam-script.d/{{ item }}"
     owner: root
     group: root
-    state: link
+    #
+    # Login checks currently disabled,
+    # because error handling/reporting no longer works on CentOS >= 7.x,
+    # due to changes in the PAM stack.
+    # Login checks were only used to create Slurm accounts in the Slurm accounting DB.
+    # This functionality has been relocated to the Slurm job_submit.lua plugin,
+    # which will now automatically create account, users and associations of slurm users to slurm accounts
+    # upon job submission when they do not already exist.
+    #
+    # state: link
+    state: absent
   with_items:
     - login_checks.sh_ses_open
   when: inventory_hostname in groups['cluster']

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -67,7 +67,7 @@
       group: root
       mode: '0750'
     - name: /var/spool/slurmd
-      owner: slurm
+      owner: root
       group: root
       mode: '0750'
 

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -69,7 +69,7 @@
     - name: /var/spool/slurmd
       owner: root
       group: root
-      mode: '0750'
+      mode: '0755'
 
 - name: Deploy slurm.conf
   template:

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -162,7 +162,7 @@
 - name: Make services reload their configs.
   command: systemctl daemon-reload
 
-- name: Make sure servcies are started.
+- name: Make sure services are started.
   systemd:
     name: "{{item}}"
     state: restarted


### PR DESCRIPTION
* Bugfix: use correct name for tmp LFS on Talos.
* Improved login checks to create users and accounts in the Slurm accounting DB by relocating this functionality from login to job submission time.
* Fixed typo in task name in slurm role.
* Bugfix: /var/spool/slurmd must be owned by root.
* Bugfix: /var/spool/slurmd must be readable, but not writable for all users.