### PR TITLE
Make bash the default shell.

### DIFF
--- a/roles/ldap/templates/nslcd.conf
+++ b/roles/ldap/templates/nslcd.conf
@@ -15,3 +15,4 @@ pam_authz_search  {{ pam_authz_search }}
 {% endif %}
 binddn {{ ldap_binddn }}
 bindpw {{ bindpw }}
+map passwd loginShell "/bin/bash"


### PR DESCRIPTION
This sets the default shell to bash for all ldap users.