### PR TITLE
Made python scripts compatible with Python 3 and improved figlet + motd

### DIFF
--- a/callback_plugins/homsaplog.py
+++ b/callback_plugins/homsaplog.py
@@ -23,7 +23,8 @@ try:
 except ImportError:
     import json
 import sys
-reload(sys).setdefaultencoding('utf-8')
+if sys.version_info < (3,0,0):
+    reload(sys).setdefaultencoding('utf-8')
 
 __metaclass__ = type
 

--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -4,7 +4,21 @@ slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'gs'
 mailhub: '172.23.34.34'
 rewrite_domain: "imperator.{{ slurm_cluster_domain }}"
-motd: Vare, Vare, redde legiones!
+motd: |
+      !!! WARNING: This cluster is in beta testing
+          and may be redeployed from scratch, which
+          may result in complete data loss starting
+          on 09:00 on the following EOS Fridays:
+          ###################################
+          # Date                 EOS        #
+          ###################################
+          # Friday 2019-05-03    Sprint 136 #
+          # Friday 2019-06-14    Sprint 138 #
+          # Friday 2019-07-26    Sprint 140 #
+          # Friday 2019-09-06    Sprint 142 #
+          # Friday 2019-10-18    Sprint 144 #
+          ###################################
+          You have been warned!!!
 additional_etc_hosts: |
   172.23.40.21       gs-compute01        gs-compute01.hpc.local
   172.23.40.22       gs-compute02        gs-compute02.hpc.local

--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -4,7 +4,21 @@ slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'tl'
 mailhub: '172.23.34.34'
 rewrite_domain: "{{ stack_prefix }}-sai.{{ slurm_cluster_domain }}"
-motd: "It's highly addictive"
+motd: |
+      !!! WARNING: This cluster is in beta testing
+          and may be redeployed from scratch, which
+          may result in complete data loss starting
+          on 09:00 on the following EOS Fridays:
+          ###################################
+          # Date                 EOS        #
+          ###################################
+          # Friday 2019-05-03    Sprint 136 #
+          # Friday 2019-06-14    Sprint 138 #
+          # Friday 2019-07-26    Sprint 140 #
+          # Friday 2019-09-06    Sprint 142 #
+          # Friday 2019-10-18    Sprint 144 #
+          ###################################
+          You have been warned!!!
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-03]"
 vcompute_sockets: 4
 vcompute_cores_per_socket: 1

--- a/inventory.py
+++ b/inventory.py
@@ -41,12 +41,12 @@ which will match the 'Host lobby+*' rule from the ~/.ssh/config file.
 =============================================================
 '''
 import argparse
-try:
-    # For Python >= 3.x
-    import configparser
-except:
-    # For Python 2.x
-    import ConfigParser as configparser
+#try:
+#    # For Python >= 3.x
+#    import configparser
+#except:
+#    # For Python 2.x
+#    import ConfigParser as configparser
 try:
     import json
 except ImportError:
@@ -55,12 +55,24 @@ import os
 import re
 import sys
 from test.test_sax import start
+if sys.version_info >= (3,2,0):
+    from configparser import ConfigParser
+elif sys.version_info >= (3,0,0):
+    from configparser import SafeConfigParser as ConfigParser
+else:
+    # For Python 2.x
+    from ConfigParser import SafeConfigParser as ConfigParser
 
 """
 Modified ConfigParser that allows ':' in keys and only uses '=' as separator.
 We need the : to be able to specify groups of Ansible hosts like this: compute_nodes[01:16]
 """
-class MyConfigParser(configparser.SafeConfigParser):
+cp_classname = 'SafeConfigParser'
+if sys.version_info >= (3,2,0):
+    cp_classname = 'ConfigParser'
+
+#class MyConfigParser(configparser.SafeConfigParser):
+class MyConfigParser(ConfigParser):
     OPTCRE = re.compile(
         r'(?P<option>[^=\s][^=]*)'      # very permissive!
         r'\s*(?P<vi>[=])\s*'            # any number of space/tab,
@@ -125,6 +137,16 @@ class ProxiedInventory(object):
         #_config.optionxform = self.prepend_proxy
         _config = MyConfigParser(allow_no_value=True)
         _config.read(os.path.dirname(os.path.realpath(__file__)) + '/' + self.inventory_file)
+        
+        #
+        # This dynamic inventory script does not (yet) support execution with a --host argument to get the hostvars for an inventory item.
+        # From: https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#script-conventions
+        # To satisfy the requirements of using _meta, to prevent ansible from calling your inventory with --host you must at least populate _meta with an empty hostvars dictionary.
+        #
+        _meta = dict()
+        _hostvars = dict()
+        self.add(_meta, 'hostvars', _hostvars)
+        self.add(self.inventory, '_meta', _meta)
         
         for _section in _config.sections():
             if re.search(':children', _section):

--- a/roles/figlet_hostname/tasks/main.yml
+++ b/roles/figlet_hostname/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
-- name: generate figlet text
+- name: Install figlet.
+  yum:
+    state: latest
+    update_cache: yes
+    name:
+      - figlet
+  become: true
+
+- name: Generate figlet ascii art.
   # shell: figlet -f {{ role_path }}/files/doh.flf -w 180 {{ ansible_hostname }}
-  shell: figlet {{ ansible_hostname }}
+  shell: |
+         figlet {{ ansible_hostname }}
   register: figlet
-  delegate_to: localhost
 
-
-# Should be conver
 - name: Insert figlet in /etc/motd
   template:
     src: templates/motd
@@ -15,3 +21,4 @@
     group: root
     mode: 0644
   become: true
+...


### PR DESCRIPTION
* Python 2 -> 3 upgrade compatibility fixes / workarounds for:
   * callback_plugins/homsaplog.py
   * inventory.py dynamic inventory script.
* Added scheduled maintenance warning + dates to motd for Talos and Gearshift
* Use figlet on deploy target as opposed to Ansible control machine.