### PR TITLE
Prevent getting locked out of account for default cloud image user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ roles/hpc-cloud
 roles/HPCplaybooks
 roles/HPCplaybooks/*
 ssh-host-ca/umcg-hpc-ca
+ssh-host-ca/*production*

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -19,6 +19,13 @@ firewall_allowed_tcp_ports:
 #  * Never ever change nor recycle a UID value here unless you are in for a surprise...
 #
 auth_users:
+  centos:
+    comment: 'Cloud User'
+    uid: 1000
+    pub_keys: |
+              ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCdOt9U8m3oa/ka8vRTOWxU9uh13hR9F5FoW7SRbrQMWX3XYCEF1mFSTU0WHqYlkOm5atbkqRnR2WUOuG2YjCDJ6KqvpYGjITqHilBCINkWuXozoT5HkGbMtcN1nYDh4b+lGhg3ttfTBKBPusLz0Mca68EL6MjmSsgbRSIceNqFrfbjcc/YhJo7Kn769RW6W/ToClVHNHqgC47ZGXDc5acUrcfiaPNFSlyUjqCMKyO7sGOm/o4TTLffznH4A4iNn+/IX+7dGZRlwcmPjsBlpMk8zjQQqDE6l/UykbwKgYBJRO02PeNg3bqDAwSGR5+e4raJ3/mN3tkQqC/cAD3h4eWaRTBJdnLltkOFFeXux4jvuMFCjLYslxHK/LH//GziarA0OQVqA+9LWkwtLx1rKtNW6OaZd45iandwUuDVzlbADxwXtqjjnoy1ZUsAR83YVyhN/fqgOe2i34Q48h27rdkwRwAINuqnoJLufaXyZdYi4QintKOScp3ps/lSXUJq+zn7yh54JCz2l/MhDNUBpBWvZevJTXxqQBszAp5gv0KE2VuPOyrmzo+QeBxKqglMSonguoVolfb9sEYT5Xhu1zR6thRtoBT813kzpeVSzMUAr/KOD+ILSjWKUNT0JuiCXsEDD7Zqx/kspTsHpi/+2irAdcXgAEA+fiJqxsNfV4cpQw== pneerincx
+              ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBzwniHWpMcGx0Pj3rZvXuaJbZa+iNbNpIhuARXW/GV0 pneerincx ED25519
+              ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCUfwAhBD4vCDYgsr04Kxn1e+vIcx7EzOEJrwi4Bv1Fc329TAifMTLeXXjPlehNvDvxq1Eb6I0v0CA01OwtD2QH+jnKGK7/RXwOfKHZQDsfZ1qL725So8z2rLfTOiIBn01zwSZTPoMC0NoDEj1H7RUpuSTSWazRmZJAi4S9aWU7DK+aWp0vR4UzvxWNFuzhhSJPOrHBx0O6st67oVRyhhIFo67dIfgI/fDwuT7+hAfAzGtuWAW1SI33ucDtaSSs3CT6ndPIU1jzRwrK/Xoq2vzyso6ptj9N/qJfauVUtwhQs//9hGjIP7H2m4maUDR60qDveUy4QNbRoJQuT28FrZxdYjEWyU7E3/yuBSX5Lggk9GuolpGBTj3EDLth0LUsB/hjjGNSebNL/pF5wQR9Usu9omXf4f3dPfU/X0SaWjeY1ukU4saRefn9FIu1ZV3w6TQUybM/2ZcHzbS2JDieirMTZ2uGUVZyAX4TID40Pc84bcFbfQULkqBGPmp2X3rrfJgg8GmmX92qT/OEEPQ6tsA909dxvXGMYzb/7B5MjiAjdkhhIlRzjFz8zy0dkTAMopxwHPI4Fr1z/LhP8Or7pv31HfG/RIW8pOcanvvRRzqoSohDrfxobzczce42S/qrD0sE2gQdwbnAh0JlPmB7erSrqhxEjw0pHXd8CWx4yH3oJQ== gvdvries
   pieter:
     comment: 'Pieter Neerincx'
     uid: 1001
@@ -65,13 +72,11 @@ auth_users:
     uid: 1009
     pub_keys: |
               # Revoked: key format not compliant with requirements.
-
   kees:
     comment: 'Kees Visser'
     uid: 1010
     pub_keys: |
               ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGbGIEjuURXEI2rPUzLzQSsH/OvZJQwCPFO7w0Uls9Xy stealth@operator
-
   gvdvries:
     comment: 'Gerben van der Vries'
     uid: 1011

--- a/group_vars/fender-cluster/vars.yml
+++ b/group_vars/fender-cluster/vars.yml
@@ -50,6 +50,7 @@ local_admin_groups:
   - 'admin'
   - 'docker'
 local_admin_users:
+  - 'centos'
   - 'egon'
   - 'gerben'
   - 'henkjan'

--- a/group_vars/hyperchicken-cluster/vars.yml
+++ b/group_vars/hyperchicken-cluster/vars.yml
@@ -50,6 +50,7 @@ local_admin_groups:
   - 'admin'
   - 'docker'
 local_admin_users:
+  - 'centos'
   - 'egon'
   - 'gerben'
   - 'henkjan'


### PR DESCRIPTION
* Updated .gitignore to exclude key pairs with "production" in their file names.
* Added standard cloud image user named "centos" for CentOS based images.
* Added "centos" user with home relocated to /admin/centos to config for Hyperchicken and Fender to rescue this local admin user when home dirs from shared storage are mounted in /home.