### PR TITLE
Various assorted bugfixes

### DIFF
--- a/group_vars/administration.yml
+++ b/group_vars/administration.yml
@@ -1,3 +1,3 @@
 ---
-
 volume_mount_point: "/apps"
+...

--- a/host_vars/all.yml
+++ b/host_vars/all.yml
@@ -1,3 +1,3 @@
 ---
-
 ansible_python_interpreter: /usr/bin/python2.7
+...

--- a/inventory.py
+++ b/inventory.py
@@ -104,10 +104,9 @@ class ProxiedInventory(object):
 
         # Get inventory file name from ENV VAR.
         self.inventory_file = os.getenv('AI_INVENTORY')
-        if self.inventory_file:
-            self.inventory_path = os.path.dirname(os.path.realpath(__file__)) + '/' + self.inventory_file
-        else:
-            self.inventory_path = os.path.dirname(os.path.realpath(__file__)) + '/inventory.ini'
+        if not self.inventory_file:
+            self.inventory_file = 'inventory.ini'
+        self.inventory_path = os.path.dirname(os.path.realpath(__file__)) + '/' + self.inventory_file
         if not (os.path.isfile(self.inventory_path) and os.access(self.inventory_path, os.R_OK)):
             print('FATAL: The static inventory file ' + self.inventory_path + "\n"
                   '       is either missing or not readable: Check path and permissions.\n' +

--- a/proxy.yml
+++ b/proxy.yml
@@ -1,5 +1,0 @@
----
-- hosts: proxy
-  become: True
-  roles:
-     - ldap

--- a/roles/cluster/defaults/main.yml
+++ b/roles/cluster/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+sshd_moduli_minimum: 3072
+...

--- a/roles/cluster/files/skel/.bashrc
+++ b/roles/cluster/files/skel/.bashrc
@@ -4,15 +4,14 @@
 # Source global definitions. (DO NOT EDIT!)
 #
 if [ -f /etc/bashrc ]; then
-  . /etc/bashrc
+  source /etc/bashrc
 fi
 
-#
-# Shared HPC environment. (DO NOT EDIT!)
-#
-if [ -f /apps/modules/modules.bashrc ]; then
-  . /apps/modules/modules.bashrc
+# BEGIN ANSIBLE MANAGED BLOCK - Setup environment for Lua, Lmod & EasyBuild.
+if [ -f "/apps/modules//modules.bashrc" ]; then
+  source "/apps/modules//modules.bashrc"
 fi
+# END ANSIBLE MANAGED BLOCK - Setup environment for Lua, Lmod & EasyBuild.
 
 #
 # User specific personal settings, aliases and functions below this comment.

--- a/roles/ldap/defaults/main.yml
+++ b/roles/ldap/defaults/main.yml
@@ -6,5 +6,4 @@ uri_ldap: ''
 uri_ldaps: ''
 ldap_base: ''
 ldap_binddn: ''
-sshd_moduli_minimum: 3072
 ...

--- a/roles/mount-volume/defaults/main.yml
+++ b/roles/mount-volume/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-
 volume_mount_point: "/local"
+...

--- a/roles/mount-volume/tasks/main.yml
+++ b/roles/mount-volume/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Make mount point for the cinder volume.
-  file:
-    path: "{{volume_mount_point}}"
-    mode: 0755
-    state: directory
-    owner: root
-    group: root
-
 - name: Check the local mount point.
   command: mountpoint {{volume_mount_point}}
   register: mount_local
@@ -14,23 +6,42 @@
 
 - name: Create an ext4 filesystem on /dev/vdb.
   filesystem:
-    fstype: ext4
-    dev: /dev/vdb
-  when:
-    mount_local.rc == 1
+    fstype: 'ext4'
+    dev: '/dev/vdb'
+  when: mount_local.rc == 1
+  become: true
 
 - name: Mount the volume.
   mount:
     path: "{{volume_mount_point}}"
-    src: /dev/vdb
-    fstype: ext4
-    opts: rw,relatime
-    state: present
+    src: '/dev/vdb'
+    fstype: 'ext4'
+    opts: 'rw,relatime'
+    state: 'mounted'
+  become: true
 
-- name: Mount all mountpoints from fstab.
-  command: mount -a
-  args:
-    warn: false
-  when:
-    mount_local.rc == 1
+- name: Recheck the local mount point.
+  command: mountpoint {{volume_mount_point}}
+  register: mount_local
+  failed_when: false
+
+- name: Configure permissions for root.
+  file:
+    path: "{{volume_mount_point}}"
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: mount_local.rc == 0 and inventory_hostname in groups['compute-vm']
+  become: true
+
+- name: Configure permissions for deploy admins.
+  file:
+    path: "{{volume_mount_point}}"
+    state: 'directory'
+    owner: 'root'
+    group: "{{ envsync_group }}"
+    mode: '2775'
+  when: mount_local.rc == 0 and inventory_hostname in groups['deploy-admin-interface']
+  become: true
 ...

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -14,7 +14,7 @@
   delegate_to: localhost
 - name: Abort when modern rsync >= 3.1.2 is missing on control host.
   debug:
-    msg: 'Will install Lua from source as it is either missing or present in a different version. (Detected {{ lua_installed_version.stdout }} and need {{ easybuild_lua_version }}.)'
+    msg: "FATAL: Need rsync >= 3.1.2 on the control host, but detected {{ rsync_version.stdout }}."
   when:         'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
   failed_when: 'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
   delegate_to: localhost

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -48,7 +48,7 @@
     path: "/mnt/{{ item.0.pfs }}/{{ item.0.lfs | regex_replace('GROUP', item.1) | regex_replace('((tmp)|(prm))[0-9]+$', '') }}"
     owner: 'root'
     group: "{{ item.1 }}"
-    mode: 2750
+    mode: '2750'
     state: 'directory'
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', '((tmp)|(prm))[0-9]+$') | list }}"


### PR DESCRIPTION
* Bugfix for ```online_docs``` role: fixed wrong error message when rsync is too old.
* Removed unused playbook file ```proxy.yml```
* Relocated ```sshd_moduli_minimum``` default from ```ldap``` to ```cluster``` role, because the rest of the sshd config was already relocated to that role.
* Bugfix: default name for inventory file was not parsed correctly by dynamic inventory script.
* Updated ```skel/.bashrc``` for changes in HPC environment deployed with ```ansible-pipelines``` repo.
* Bugfix for ```mount-volume ```role: make sure local volumes are mounted with the correct permissions for the users that need to work with these mounts.
* Bugfix for ```shared_storage``` role: fix wrong permissions due to missing quotes.
