### PR TITLE
Allow incoming traffic to node_exporter

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -12,6 +12,7 @@ ai_jumphost: "{{ lookup('env','AI_PROXY') }}"
 #
 firewall_allowed_tcp_ports:
   - '22'   # SSH
+  - '9100'   # Node Exporter
 #
 # Local user account specs.
 # Note:


### PR DESCRIPTION
I still think a double firewall (openstack and local iptables) is very cumbersome.
And I still think the openstack firewall is much more user-friendly.
But in the meantime i'd like to access my metrics.