### PR TITLE
The package warewulf-nhc has been renamed into lbnl-nhc.

### DIFF
--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -53,7 +53,7 @@
     name:
       - slurm
       - slurm-slurmd
-      - warewulf-nhc
+      - lbnl-nhc
   notify:
     - restart_munge
     - restart_slurmd


### PR DESCRIPTION
The package warewulf-nhc has been renamed into lbnl-nhc in newer versions.