### PR TITLE
Mariadb depends on docker & munge needs to be setup on the slurm-management node.

### DIFF
--- a/roles/slurm-management/meta/main.yml
+++ b/roles/slurm-management/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
+    - { role: docker }
     - { role: mariadb }
 ...

--- a/roles/slurm-management/tasks/main.yml
+++ b/roles/slurm-management/tasks/main.yml
@@ -40,6 +40,14 @@
     - restart_slurmctld
   become: true
 
+- name: Install munge
+  yum:
+    state: latest
+    update_cache: yes
+    name:
+      - munge
+  become: true
+
 - name: Install munge.key file.
   copy:
     src: "files/{{ slurm_cluster_name }}_munge.key"


### PR DESCRIPTION
Mariadb depends on docker & munge needs to be setup on the slurm-management node.