### PR TITLE
turn off SElinux to allow home dirs of admin users to be located in /…

### DIFF
--- a/roles/admin-users/tasks/main.yml
+++ b/roles/admin-users/tasks/main.yml
@@ -44,4 +44,10 @@
     exclusive: yes
   with_items: "{{ local_admin_users }}"
   become: true
+- name: Set selinux in permissive mode
+  selinux:
+    policy: targeted
+    state: permissive
+  become: true
+
 ...

--- a/roles/admin-users/tasks/main.yml
+++ b/roles/admin-users/tasks/main.yml
@@ -1,5 +1,10 @@
 # Create local admin groups & users and allow admin group to use sudo on all hosts.
 ---
+- name: Set selinux in permissive mode
+  selinux:
+    policy: targeted
+    state: permissive
+  become: true
 - name: Create admin groups for local admin users.
   group:
     name: "{{ item }}"
@@ -44,10 +49,4 @@
     exclusive: yes
   with_items: "{{ local_admin_users }}"
   become: true
-- name: Set selinux in permissive mode
-  selinux:
-    policy: targeted
-    state: permissive
-  become: true
-
 ...


### PR DESCRIPTION
turn off SElinux to allow home dirs of admin users to be located in /admin .