### PR TITLE
Prevent the playbook from locking you out.

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -58,6 +58,13 @@
         cron_file: reboot
       become: true
 
+    - name: Add
+      yum_repository:
+        name: umcg-centos7
+        description: EPEL YUM repo
+        baseurl: http://spacewalk02.hpc.rug.nl/umcg-centos7
+      become: true
+
 - name: 'B. Roles for SAIs.'
   hosts:
      - sys-admin-interface

--- a/cluster.yml
+++ b/cluster.yml
@@ -35,17 +35,6 @@
 
 - name: 'A. Roles for jumphosts.'
   hosts: jumphost
-  roles:
-    - admin-users 
-    - ssh_host_signer
-    - ssh_known_hosts
-    - logins
-    - { role: geerlingguy.repo-epel, become: true }
-    - ldap
-    - static-hostname-lookup
-    - sshd
-    - node_exporter
-    - { role: geerlingguy.security, become: true }
   tasks:
     - name: 'Install cron job to reboot jumphost regularly to activate kernel updates.'
       cron:
@@ -58,12 +47,23 @@
         cron_file: reboot
       become: true
 
-    - name: Add
+    - name: Add umcg centos repo
       yum_repository:
         name: umcg-centos7
         description: EPEL YUM repo
         baseurl: http://spacewalk02.hpc.rug.nl/umcg-centos7
       become: true
+  roles:
+    - admin-users
+    - ssh_host_signer
+    - ssh_known_hosts
+    - logins
+    - { role: geerlingguy.repo-epel, become: true }
+    - ldap
+    - static-hostname-lookup
+    - sshd
+    - node_exporter
+    - { role: geerlingguy.security, become: true }
 
 - name: 'B. Roles for SAIs.'
   hosts:

--- a/roles/sshd/templates/sshd_config
+++ b/roles/sshd/templates/sshd_config
@@ -73,13 +73,6 @@ ChallengeResponseAuthentication no
 GSSAPIAuthentication no
 GSSAPICleanupCredentials no
 PubkeyAuthentication yes
-{% if use_ldap %}
-AuthorizedKeysCommand /usr/libexec/openssh/ssh_ldap_wrapper.py
-AuthorizedKeysCommandUser root
-AuthorizedKeysFile /dev/null
-{% else %}
-AuthorizedKeysFile .ssh/authorized_keys
-{% endif %}
 
 #
 # Connection settings.
@@ -93,4 +86,14 @@ ClientAliveInterval 300
 #
 Subsystem sftp /usr/libexec/openssh/sftp-server -f AUTHPRIV -l INFO
 
+{% if use_ldap %}
+AuthorizedKeysCommand /usr/libexec/openssh/ssh_ldap_wrapper.py
+AuthorizedKeysCommandUser root
+AuthorizedKeysFile /dev/null
 
+Match Group admin
+    AuthorizedKeysFile .ssh/authorized_keys
+
+{% else %}
+AuthorizedKeysFile .ssh/authorized_keys
+{% endif %}


### PR DESCRIPTION
Gerben found that the new ldap wrapper could lead to a situation where both local and ldap accounts are locked out from logging in. 
This branch fixes this by
1) Ensuring the dependencies of the ldap wrapper are installed even on the jumphost which is not on spacewalk.
2) In the case of failure of the ldap wrapper, sshd should look up the local keys for local admin users.