### PR TITLE
Improved robutness and more consistent syntax.

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -79,10 +79,9 @@
     - shared_storage
 
 - hosts: slurm-management
-  become: true
   roles:
      - slurm-management
-     - { role: prom_server, become: true }
+     - prom_server
      - { role: cadvisor, become: true }
   vars:
      # These variables are needed by the mariadb role.

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -6,6 +6,10 @@
       - python2-pip
     state: latest
     update_cache: yes
-- name: Install docker-py
+  become: true
+
+- name: Install docker-py.
   pip:
     name: docker
+  become: true
+...

--- a/roles/prom_server/handlers/main.yml
+++ b/roles/prom_server/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+#
+# Important: maintain correct handler order.
+# Handlers are executed in the order in which they are defined 
+# and not in the order in whch they are listed in a "notify: handler_name" statement!
+#
+# Restart before reload: an reload after a restart may be redundant but should not fail,
+# but the other way around may fail when the impact of changes was too large for a reload.
+#
+- name: Restart prometheus service.
+  systemd:
+    name: 'prometheus.service'
+    state: restarted
+    daemon_reload: yes
+  become: true
+  listen: restart_prometheus
+...

--- a/roles/prom_server/meta/main.yml
+++ b/roles/prom_server/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
     - { role: docker }
+...

--- a/roles/prom_server/tasks/main.yml
+++ b/roles/prom_server/tasks/main.yml
@@ -1,56 +1,62 @@
 ---
-- file:
+- name: Create directories for Prometheus.
+  file:
     path: "{{ item }}"
     state: directory
     mode: 0755
-    owner: 65534
+    owner: '65534'
   with_items:
-    - /srv/prometheus/etc/prometheus
-    - /srv/prometheus/prometheus
+    - '/srv/prometheus/etc/prometheus'
+    - '/srv/prometheus/prometheus'
+  notify:
+   - restart_prometheus
+  become: true
 
 - name: Install settings files.
   copy:
-    src: templates/etc/{{ item }}
-    dest: /srv/prometheus/etc/prometheus/{{ item }}
+    src: "templates/etc/{{ item }}"
+    dest: "/srv/prometheus/etc/prometheus/{{ item }}"
     mode: 0644
     owner: root
     group: root
   with_items:
     - alerting.rules
     - targets.json
+  notify:
+   - restart_prometheus
+  become: true
 
-- name: Install settings files.
+- name: Install settings files based on templates.
   template:
-    src: templates/etc/prometheus.yml
-    dest: /srv/prometheus/etc/prometheus/prometheus.yml
+    src: 'templates/etc/prometheus.yml'
+    dest: '/srv/prometheus/etc/prometheus/prometheus.yml'
     mode: 0644
     owner: root
     group: root
-
-  tags:
-    - service-files
+  notify:
+   - restart_prometheus
+  become: true
 
 - name: Install service files.
   template:
-    src: templates/prometheus.service
-    dest: /etc/systemd/system/prometheus.service
+    src: 'templates/prometheus.service'
+    dest: '/etc/systemd/system/prometheus.service'
     mode: 644
     owner: root
     group: root
   tags:
     - service-files
+  notify:
+   - restart_prometheus
+  become: true
 
-- name: install service files
-  command: systemctl daemon-reload
-
-- name: enable service at boot
+- name: Make sure prometheus service is started and enabled on (re)boot.
   systemd:
     name: prometheus.service
     enabled: yes
-
-- name: make sure servcies are started.
-  systemd:
-    name: prometheus.service
-    state: restarted
+    state: started
+    daemon_reload: yes
   tags:
     - start-service
+  become: true
+...

--- a/single_role_playbooks/prom_server.yml
+++ b/single_role_playbooks/prom_server.yml
@@ -1,0 +1,5 @@
+---
+- hosts: slurm-management
+  roles:
+     - prom_server
+...


### PR DESCRIPTION
* Use explicit become for all tasks in ```prom_server``` and ```docker``` roles.
* Added single_role playbook for ```prom_server``` role.
* Added handler from restarting ```prometheus.service```.