### PR TITLE
Install additional standard software on all cluster machines.

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -71,6 +71,7 @@
     state: latest
     update_cache: yes
     name:
+      - bc
       - bzip2
       - curl
       - figlet

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -74,6 +74,7 @@
       - bc
       - bzip2
       - curl
+      - dos2unix
       - figlet
       - git
       - git-core


### PR DESCRIPTION
Required for various scripts/tools/monitoring tools:
 * bc
 * dos2unix (includes also mac2unix)