### PR TITLE
Improved sudoers role and minor related updates.

### DIFF
--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -13,11 +13,11 @@ motd: |
           ###################################
           # Date                 EOS        #
           ###################################
-          # Friday 2019-05-03    Sprint 136 #
-          # Friday 2019-06-14    Sprint 138 #
-          # Friday 2019-07-26    Sprint 140 #
           # Friday 2019-09-06    Sprint 142 #
           # Friday 2019-10-18    Sprint 144 #
+          # Friday 2019-11-08    Sprint 146 #
+          # Friday 2019-11-29    Sprint 148 #
+          # Friday 2019-12-20    Sprint 150 #
           ###################################
           You have been warned!!!
 additional_etc_hosts: |
@@ -81,6 +81,136 @@ local_admin_users:
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 hpc_env_prefix: '/apps'
+regular_groups:
+  - 'umcg-aad'
+  - 'umcg-as'
+  - 'umcg-atd'
+  - 'umcg-biogen'
+  - 'umcg-bionic-mdd-gwama'
+  - 'umcg-bios'
+  - 'umcg-dag3'
+  - 'umcg-datateam'
+  - 'umcg-depad'
+  - 'umcg-franke-scrna'
+  - 'umcg-gaf'
+  - 'umcg-gap'
+  - 'umcg-gastrocol'
+  - 'umcg-gcc
+  - 'umcg-gdio'
+  - 'umcg-gonl'
+  - 'umcg-griac'
+  - 'umcg-gsad'
+  - 'umcg-hofker'
+  - 'umcg-lifelines'
+  - 'umcg-lld'
+  - 'umcg-llnext'
+  - 'umcg-micompany'
+  - 'umcg-msb'
+  - 'umcg-oncogenetics'
+  - 'umcg-pub'
+  - 'umcg-radicon'
+  - 'umcg-tifn'
+  - 'umcg-ugli'
+  - 'umcg-verbeek'
+  - 'umcg-weersma'
+  - 'umcg-wijmenga'
+regular_users:
+  - user: 'umcg-aad-dm'
+    groups: ['umcg-aad']
+    sudoers: '%umcg-aad'
+  - user: 'umcg-capicebot'
+    groups: ['umcg-as']
+    sudoers: '%umcg-as'
+  - user: 'umcg-atd-ateambot'
+    groups: ['umcg-atd']
+    sudoers: '%umcg-atd'
+  - user: 'umcg-atd-dm'
+    groups: ['umcg-atd']
+    sudoers: '%umcg-atd'
+  - user: 'umcg-biogen-dm'
+    groups: ['umcg-biogen']
+    sudoers: 'umcg-hwestra,umcg-ndeklein'
+  - user: 'umcg-bionic-mdd-gwama-dm'
+    groups: ['umcg-bionic-mdd-gwama']
+    sudoers: 'umcg-fhuider,umcg-ifedko'
+  - user: 'umcg-bios-dm'
+    groups: ['umcg-bios']
+    sudoers: '%umcg-bios'
+  - user: 'umcg-dag3-dm'
+    groups: ['umcg-dag3']
+    sudoers: 'umcg-avich,umcg-akurilshchikov,umcg-rgacesa'
+  - user: 'umcg-datateam-dm'
+    groups: ['umcg-datateam']
+    sudoers: 'umcg-mbijlsma'
+  - user: 'umcg-franke-scrna-dm'
+    groups: ['umcg-franke-scrna']
+    sudoers: 'umcg-ddevries,umcg-hbrugge,umcg-mvdwijst'
+  - user: 'umcg-gaf-dm'
+    groups: ['umcg-gaf']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gap-dm'
+    groups: ['umcg-gap']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gastrocol-dm'
+    groups: ['umcg-gastrocol']
+    sudoers: 'umcg-avich,umcg-hushixian'
+  - user: 'umcg-gcc-dm'
+    groups: ['umcg-gcc']
+    sudoers: '%umcg-gcc'
+  - user: 'umcg-gdio-dm'
+    groups: ['umcg-gdio']
+    sudoers: 'umcg-cvandiemen'
+  - user: 'umcg-gonl-dm'
+    groups: ['umcg-gonl']
+    sudoers: 'umcg-pneerincx'
+  - user: 'umcg-griac-dm'
+    groups: ['umcg-griac']
+    sudoers: 'umcg-cvermeulen umcg-cxu umcg-ndijk umcg-mdevries umcg-mberg'
+  - user: 'umcg-gsad-dm'
+    groups: ['umcg-gsad']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-hofker-dm'
+    groups: ['umcg-hofker']
+    sudoers: '%umcg-hofker'
+  - user: 'umcg-lifelines-dm'
+    groups: ['umcg-lifelines']
+    sudoers: '%umcg-lifelines-dms'
+  - user: 'umcg-lld-dm'
+    groups: ['umcg-lld']
+    sudoers: 'umcg-hwestra,umcg-hbrugge'
+  - user: 'umcg-llnext-dm'
+    groups: ['umcg-llnext']
+    sudoers: 'umcg-tsinha,umcg-sgarmaeva'
+  - user: 'umcg-micompany-dm'
+    groups: ['umcg-micompany']
+    sudoers: 'umcg-cxu,umcg-cvermeulen'
+  - user: 'umcg-msb-dm'
+    groups: ['umcg-msb']
+    sudoers: '%umcg-msb'
+  - user: 'umcg-oncogenetics-dm'
+    groups: ['umcg-oncogenetics']
+    sudoers: '%umcg-mterpstra'
+  - user: 'umcg-pub-dm'
+    groups: ['umcg-pub']
+    sudoers: 'umcg-pneerincx'
+  - user: 'umcg-radicon-dm'
+    groups: ['umcg-radicon']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-tifn-dm'
+    groups: ['umcg-tifn']
+    sudoers: 'umcg-akurilshchikov,umcg-jfu'
+  - user: 'umcg-ugli-dm'
+    groups: ['umcg-ugli']
+    sudoers: 'umcg-pdeelen umcg-mbenjamins umcg-pneerincx'
+  - user: 'umcg-verbeek-dm'
+    groups: ['umcg-verbeek']
+    sudoers: '%umcg-verbeek'
+  - user: 'umcg-weersma-dm'
+    groups: ['umcg-weersma']
+    sudoers: 'umcg-avich,umcg-hushixian'
+  - user: 'umcg-wijmenga-dm'
+    groups: ['umcg-wijmenga']
+    sudoers: 'umcg-jgelderloos,umcg-aclaringbould,umcg-rmodderman,umcg-hwestra,umcg-avich,umcg-obakker,umcg-ddevries'
 pfs_mounts: [
   { pfs: 'umcgst10',
     source: 'gcc-storage001.stor.hpc.local:/ifs/rekencluster/umcgst10',
@@ -97,10 +227,20 @@ lfs_mounts: [
     pfs: 'umcgst10' },
   { lfs: 'groups/GROUP/tmp01',
     pfs: 'umcgst10',
-    groups: ['umcg-atd', 'umcg-biogen', 'umcg-bios', 'umcg-dag3', 'umcg-gastrocol', 'umcg-gcc', 'umcg-lld', 'umcg-tifn', 'umcg-weersma', 'umcg-wijmenga' ] },
+    groups: [
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama', 
+        'umcg-bios', 'umcg-dag3', 'umcg-datateam', 'umcg-franke-scrna', 
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl', 
+        'umcg-griac', 'umcg-gsad', 'umcg-hofker', 'umcg-lifelines', 'umcg-lld', 
+        'umcg-llnext', 'umcg-micompany', 'umcg-msb', 'umcg-oncogenetics', 
+        'umcg-pub', 'umcg-radicon', 'umcg-tifn', 'umcg-ugli', 
+        'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
+      ]},
   { lfs: 'groups/GROUP/prm01',
     pfs: 'umcgst10',
-    groups: ['umcg-atd'] },
+    groups: [
+        'umcg-atd'
+      ]},
   { lfs: 'env01',
     pfs: 'umcgst10',
     machines: "{{ groups['compute-vm'] + groups['user-interface'] }}" },

--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -95,7 +95,7 @@ regular_groups:
   - 'umcg-gaf'
   - 'umcg-gap'
   - 'umcg-gastrocol'
-  - 'umcg-gcc
+  - 'umcg-gcc'
   - 'umcg-gdio'
   - 'umcg-gonl'
   - 'umcg-griac'

--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -165,7 +165,7 @@ regular_users:
     sudoers: 'umcg-pneerincx'
   - user: 'umcg-griac-dm'
     groups: ['umcg-griac']
-    sudoers: 'umcg-cvermeulen umcg-cxu umcg-ndijk umcg-mdevries umcg-mberg'
+    sudoers: 'umcg-cvermeulen,umcg-cxu,umcg-ndijk,umcg-mdevries,umcg-mberg'
   - user: 'umcg-gsad-dm'
     groups: ['umcg-gsad']
     sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'

--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -13,11 +13,11 @@ motd: |
           ###################################
           # Date                 EOS        #
           ###################################
-          # Friday 2019-05-03    Sprint 136 #
-          # Friday 2019-06-14    Sprint 138 #
-          # Friday 2019-07-26    Sprint 140 #
           # Friday 2019-09-06    Sprint 142 #
           # Friday 2019-10-18    Sprint 144 #
+          # Friday 2019-11-08    Sprint 146 #
+          # Friday 2019-11-29    Sprint 148 #
+          # Friday 2019-12-20    Sprint 150 #
           ###################################
           You have been warned!!!
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-03]"
@@ -68,6 +68,20 @@ local_admin_users:
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 hpc_env_prefix: '/apps'
+regular_groups:
+  - 'umcg-atd'
+  - 'umcg-depad'
+  - 'umcg-gcc'
+regular_users:
+  - user: 'umcg-atd-ateambot'
+    groups: ['umcg-atd']
+    sudoers: '%umcg-atd'
+  - user: 'umcg-atd-dm'
+    groups: ['umcg-atd']
+    sudoers: '%umcg-atd'
+  - user: 'umcg-gcc-dm'
+    groups: ['umcg-gcc']
+    sudoers: '%umcg-gcc'
 pfs_mounts: [
   { pfs: 'umcgst11',
     source: 'gcc-storage001.stor.hpc.local:/ifs/rekencluster/umcgst11',

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -1,14 +1,33 @@
 ---
 #
-# Allow passwordless sudo to the datamanager users for indivual users or %groups.
-# This can be specified in the groupvars regular_users.
+# Allow passwordless sudo to functional accounts (e.g. for datamanager accounts) for indivual users or %groups.
+# Who can become what can be specified in regular_users variable of group_vars/${clustername}/vars.yml.
 #
-- name: 'Allow passwordless sudo to the datamanager users.'
-  lineinfile:
-    dest: '/etc/sudoers'
-    line: "{{ item.1 }}    ALL=({{ item.0.user }})    NOPASSWD:ALL"
+
+- name: 'Find all ansible-managed files in /etc/sudoers.d/.'
+  find:
+    paths: '/etc/sudoers.d/'
+    use_regex: yes
+    patterns: '.*ansible-managed.*'
+  register: ansible_managed_sudoers
   become: true
-  with_subelements:
-    - "{{ regular_users | default([]) | selectattr('sudoers', 'defined')  | list }}"
-    - 'sudoers'
+
+- name: 'Remove outdated ansible-managed files from /etc/sudoers.d/.'
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items: "{{ ansible_managed_sudoers.files | map (attribute='path') | list }}"
+  when: item | regex_replace('.*ansible-managed-','') not in regular_users | default([]) | selectattr('sudoers', 'defined') | map (attribute='user') | list
+  become: true
+
+- name: 'Allow passwordless sudo to functional accounts.'
+  template:
+    src: 'templates/92-ansible-managed'
+    dest: "/etc/sudoers.d/92-ansible-managed-{{ item.user }}"
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+  with_items:
+    - "{{ regular_users | default([]) | selectattr('sudoers', 'defined') | list }}"
+  become: true
 ...

--- a/roles/sudoers/templates/92-ansible-managed
+++ b/roles/sudoers/templates/92-ansible-managed
@@ -1,0 +1,9 @@
+#
+# This file is deployed with the sudoers role from the Ansible playbook of the league-of-robots repo.
+# DO NOT EDIT MANUALLY; update source and re-deploy instead!
+#
+# {{ ansible_managed }}
+#
+# Allow specific users or group to become the {{ item.user }} user.
+#
+{{ item.sudoers }}    ALL=({{ item.user }})    NOPASSWD:ALL


### PR DESCRIPTION
* Improved ```sudoers``` role, so sudo rights will also get revoked when a functional account is no longer specified in ```group_vars/${clustername}/vars.yml```.
* Expanded list of groups, functional accounts and mount points for Gearshift. 
* Updated ```motd``` for clusters in beta with new EOS dates.