### PR TITLE
Bugfix: Updated cgroup.conf for Slurm

### DIFF
--- a/roles/slurm-management/files/cgroup.conf
+++ b/roles/slurm-management/files/cgroup.conf
@@ -1,19 +1,32 @@
-###
+#######################################################
 #
 # Slurm cgroup support configuration file
 #
 # See man slurm.conf and man cgroup.conf for further
 # information on cgroup configuration parameters
+#######################################################
 
-#CgroupMountpoint=/etc/slurm/cgroup
-CgroupReleaseAgentDir="/etc/slurm/cgroup"
 CgroupAutomount=yes
-
 ConstrainCores=yes
 ConstrainRAMSpace=yes
 ConstrainSWAPSpace=yes
+#
+# Lustre / GPFS / NFS clients or daemons tend to use large buffers allocated in kernel memory space.
+# Those buffers count as kernel memory used by the cgroup of a job.
+# Unaware users might have their jobs exceed this kernel memory limit simply by reading large files.
+# The "plain RAM" limit is not affected by this option.
+# Note: we limit the total amount of RAM that can be assigned to Slurm jobs to be less than the system total
+# in the slurm.conf file to make sure the OS, file system daemons, etc. have enough RAM available.
+#
+ConstrainKmemSpace=no
 
 # Set the allowable swap space to 100% of the requested memory
 # The virtual memory space of a job should be 2 times the requested amount
-TaskAffinity=yes
 
+#
+# Bind job tasks to a subset of the allocated cores using sched_setaffinity
+# to prevent them from swapping to other cores during job execution,
+# which would decrease performance.
+# Requires the Portable Hardware Locality (hwloc) library.
+#
+TaskAffinity=yes


### PR DESCRIPTION
* Do not constrain kernel memory space as this causes issues with shared storage clients.
* Removed settings from older Slurm versions that are longer used.