### PR TITLE
Created role for grafana on the cluster.

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -85,6 +85,7 @@
   roles:
     - slurm-management
     - prom_server
+    - grafana
     - {role: cadvisor, become: true}
   vars:
     # These variables are needed by the mariadb role.

--- a/roles/grafana/handlers/main.yml
+++ b/roles/grafana/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+#
+# Important: maintain correct handler order.
+# Handlers are executed in the order in which they are defined
+# and not in the order in whch they are listed in a "notify: handler_name" statement!
+#
+# Restart before reload: an reload after a restart may be redundant but should not fail,
+# but the other way around may fail when the impact of changes was too large for a reload.
+#
+- name: Restart grafana service.
+  systemd:
+    name: 'grafana.service'
+    state: restarted
+    daemon_reload: yes
+  become: true
+  listen: restart_grafana
+...

--- a/roles/grafana/meta/main.yml
+++ b/roles/grafana/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: grafana
+  author: Pieter Neerincx (UMCG)  Egon Rijpkema (UG)
+  description: runs grafana in a docker container.
+  min_ansible_version: 2.4
+  license: "license (GPLv3)"
+  platforms:
+    - name: CentOS
+      versions:
+        - all
+
+
+dependencies:
+  - {role: docker}
+...

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Create directories for grafana.
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: '65534'
+  with_items:
+    - '/srv/grafana/lib'
+  notify:
+    - restart_grafana
+  become: true
+
+- name: Install service files.
+  template:
+    src: 'templates/grafana.service'
+    dest: '/etc/systemd/system/grafana.service'
+    mode: 0644
+    owner: root
+    group: root
+  tags:
+    - service-files
+  notify:
+    - restart_grafana
+  become: true
+
+- name: Make sure grafana service is started and enabled on (re)boot.
+  systemd:
+    name: grafana.service
+    enabled: yes
+    state: started
+    daemon_reload: yes
+  tags:
+    - start-service
+  become: true
+...

--- a/roles/grafana/templates/grafana.service
+++ b/roles/grafana/templates/grafana.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Grafana monitoring dashboard
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker kill grafana
+ExecStartPre=-/usr/bin/docker rm grafana
+ExecStart=/usr/bin/docker run --rm --name=grafana --network host \
+     -v /srv/grafana/lib:/var/lib/grafana \
+     -e GF_PATHS_DATA=/var/lib/grafana  \
+     grafana/grafana

--- a/single_role_playbooks/grafana.yml
+++ b/single_role_playbooks/grafana.yml
@@ -1,0 +1,5 @@
+---
+- hosts: slurm-management
+  roles:
+     - grafana
+...


### PR DESCRIPTION
I wanted to have grafana to make it easier to compare system stats between the virtual compute nodes.
Running it alongside Prometheus, inside the cluster means we don't need to punch holes in the firewall.
For now, to view the website we do need a ssh tunnel, however.

For more information, see here, for instance:
https://linuxize.com/post/how-to-setup-ssh-tunneling/