### PR TITLE
This enforces both ssh public keys and passwords.

### DIFF
--- a/roles/sshd/templates/sshd_config
+++ b/roles/sshd/templates/sshd_config
@@ -65,9 +65,10 @@ LogLevel VERBOSE
 #    * Fetch public keys from LDAP
 #    * Disable local keys stored in ~/.ssh/ folders except for local admin accounts.
 #
+AuthenticationMethods "publickey,password" "publickey,keyboard-interactive"
 UsePAM yes
 PermitRootLogin no
-PasswordAuthentication no
+PasswordAuthentication yes
 PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 GSSAPIAuthentication no


### PR DESCRIPTION
This seems actually pretty simple.

I'm not completely sure if the effect would be desirable. With this configuration, we need to set ansible to provide keys and passwords as well, for instance....