### PR TITLE
Prm03

### DIFF
--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -49,7 +49,7 @@ ui_sockets: 2
 ui_cores_per_socket: 1
 ui_real_memory: 3789
 ui_local_disk: 0
-ui_features: 'prm01,tmp01'
+ui_features: 'prm03,tmp01'
 ui_ethernet_interfaces:
   - 'eth0'
   - 'eth1'

--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -13,11 +13,11 @@ motd: |
           ###################################
           # Date                 EOS        #
           ###################################
-          # Friday 2019-09-06    Sprint 142 #
-          # Friday 2019-10-18    Sprint 144 #
-          # Friday 2019-11-08    Sprint 146 #
-          # Friday 2019-11-29    Sprint 148 #
-          # Friday 2019-12-20    Sprint 150 #
+          # Friday 2020-03-12    Sprint 152 #
+          # Friday 2020-04-24    Sprint 154 #
+          # Friday 2020-06-05    Sprint 156 #
+          # Friday 2020-07-16    Sprint 158 #
+          # Friday 2020-08-27    Sprint 160 #
           ###################################
           You have been warned!!!
 additional_etc_hosts: |
@@ -217,10 +217,14 @@ pfs_mounts: [
     type: 'nfs4',
     rw_options: 'defaults,_netdev,vers=4.0,noatime,nodiratime',
     ro_options: 'defaults,_netdev,vers=4.0,noatime,nodiratime,ro' },
+  { pfs: 'dh2/groups',
+    source: '172.23.57.203@tcp12:172.23.57.204@tcp12:/dh2/groups',
+    type: 'lustre',
+    rw_options: 'defaults,lazystatfs,flock',
+    ro_options: 'defaults,lazystatfs,ro' },
 ]
 #
-# During public beta phase we only use tmp* folders/mounts for 'production' groups.
-# Only anlysis team development (umcg-atd) group, which is exclusively used for testing has prm* folder/mount for now.
+# Only anlysis team development (umcg-atd) group, which is exclusively used for testing has prm01 folder/mount for now.
 #
 lfs_mounts: [
   { lfs: 'home',
@@ -228,18 +232,29 @@ lfs_mounts: [
   { lfs: 'groups/GROUP/tmp01',
     pfs: 'umcgst10',
     groups: [
-        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama', 
-        'umcg-bios', 'umcg-dag3', 'umcg-datateam', 'umcg-franke-scrna', 
-        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl', 
-        'umcg-griac', 'umcg-gsad', 'umcg-hofker', 'umcg-lifelines', 'umcg-lld', 
-        'umcg-llnext', 'umcg-micompany', 'umcg-msb', 'umcg-oncogenetics', 
-        'umcg-pub', 'umcg-radicon', 'umcg-tifn', 'umcg-ugli', 
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama',
+        'umcg-bios', 'umcg-dag3', 'umcg-datateam', 'umcg-franke-scrna',
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
+        'umcg-griac', 'umcg-gsad', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
+        'umcg-llnext', 'umcg-micompany', 'umcg-msb', 'umcg-oncogenetics',
+        'umcg-pub', 'umcg-radicon', 'umcg-tifn', 'umcg-ugli',
         'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
       ]},
   { lfs: 'groups/GROUP/prm01',
     pfs: 'umcgst10',
     groups: [
         'umcg-atd'
+      ]},
+  { lfs: 'groups/GROUP/prm03',
+    pfs: 'dh2/groups',
+    groups: [
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama',
+        'umcg-bios', 'umcg-dag3', 'umcg-datateam',
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
+        'umcg-griac', 'umcg-gsad', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
+        'umcg-llnext', 'umcg-micompany', 'umcg-msb', 'umcg-oncogenetics',
+        'umcg-pub', 'umcg-radicon', 'umcg-tifn', 'umcg-ugli',
+        'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
       ]},
   { lfs: 'env01',
     pfs: 'umcgst10',

--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -13,11 +13,11 @@ motd: |
           ###################################
           # Date                 EOS        #
           ###################################
-          # Friday 2019-09-06    Sprint 142 #
-          # Friday 2019-10-18    Sprint 144 #
-          # Friday 2019-11-08    Sprint 146 #
-          # Friday 2019-11-29    Sprint 148 #
-          # Friday 2019-12-20    Sprint 150 #
+          # Friday 2020-03-12    Sprint 152 #
+          # Friday 2020-04-24    Sprint 154 #
+          # Friday 2020-06-05    Sprint 156 #
+          # Friday 2020-07-16    Sprint 158 #
+          # Friday 2020-08-27    Sprint 160 #
           ###################################
           You have been warned!!!
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-03]"

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: 'Create "home" Logical File System (LFS) on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.pfs }}/{{ item.lfs }}"
+    path: "/mnt/{{ item.pfs | regex_replace('/.+$', '') }}/{{ item.lfs }}"
     owner: 'root'
     group: 'root'
     mode: '0755'
@@ -33,7 +33,7 @@
 
 - name: 'Create root groups folder for "tmp" and "prm" Logical File Systems (LFSs) on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.pfs }}/{{ item.lfs | regex_replace('GROUP.*', '') }}"
+    path: "/mnt/{{ item.pfs | regex_replace('/.+$', '') }}/{{ item.lfs | regex_replace('GROUP.*', '') }}"
     owner: 'root'
     group: 'root'
     mode: '0755'
@@ -45,7 +45,7 @@
 
 - name: 'Create folder for each group on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.0.pfs }}/{{ item.0.lfs | regex_replace('GROUP', item.1) | regex_replace('((tmp)|(prm))[0-9]+$', '') }}"
+    path: "/mnt/{{ item.0.pfs | regex_replace('/.+$', '') }}/{{ item.0.lfs | regex_replace('GROUP', item.1) | regex_replace('((tmp)|(prm))[0-9]+$', '') }}"
     owner: 'root'
     group: "{{ item.1 }}"
     mode: '2750'
@@ -58,7 +58,7 @@
 
 - name: 'Create "tmp" Logical File Systems (LFSs) for each group on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.0.pfs }}/{{ item.0.lfs | regex_replace('GROUP', item.1) }}"
+    path: "/mnt/{{ item.0.pfs | regex_replace('/.+$', '') }}/{{ item.0.lfs | regex_replace('GROUP', item.1) }}"
     owner: 'root'
     group: "{{ item.1 }}"
     mode: '2770'
@@ -71,7 +71,7 @@
 
 - name: 'Create "prm" Logical File Systems (LFSs) for each group on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.0.pfs }}/{{ item.0.lfs | regex_replace('GROUP', item.1) }}"
+    path: "/mnt/{{ item.0.pfs | regex_replace('/.+$', '') }}/{{ item.0.lfs | regex_replace('GROUP', item.1) }}"
     owner: "{{ item.1 }}-dm"
     group: "{{ item.1 }}"
     mode: '2750'
@@ -84,7 +84,7 @@
 
 - name: 'Create "apps" Logical File Systems (LFSs) on Physical File Systems (PFSs) mounted on SAIs.'
   file:
-    path: "/mnt/{{ item.pfs }}/{{ item.lfs }}/apps"
+    path: "/mnt/{{ item.pfs | regex_replace('/.+$', '') }}/{{ item.lfs }}/apps"
     owner: "{{ envsync_user }}"
     group: "{{ envsync_group }}"
     mode: '2755'


### PR DESCRIPTION
* **Gearshift** and **Talos**: Updated list of EOS dates on which the development clusters may get redeployed.
* **Gearshift**: Added LFS prm03 from PFS dh2/groups.
* ```roles/shared_storage/tasks/main.yml```: Added regex to remove PFS subfolder when specified to prevent redundant overlap with first folder of LFS.

