### PR TITLE
Since December 12 logrotation of slurm was broken.

### DIFF
--- a/roles/slurm-management/files/logrotate_slurm
+++ b/roles/slurm-management/files/logrotate_slurm
@@ -16,4 +16,5 @@
            postrotate
             systemctl reload slurmctld.service
             systemctl reload slurmdbd.service
+           endscript
        }


### PR DESCRIPTION
During debugging i found out that logrotation was not working since december 12.
An attempt at manual rotation learned that an endscript entry was needed.
This pull request adds that entry. 


root@imperator 0 $ logrotate -vdf  /etc/logrotate.d/slurm
reading config file /etc/logrotate.d/slurm
error: /etc/logrotate.d/slurm:prerotate, postrotate or preremove without endscript
removing last 1 log configs
