### PR TITLE
Updated slurm config.

### DIFF
--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -3,6 +3,7 @@ slurm_cluster_name: 'talos'
 slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'tl'
 slurm_version: '18.08.8-1.el7.umcg'
+slurm_allow_jobs_to_span_nodes: true
 mailhub: '172.23.34.34'
 rewrite_domain: "{{ stack_prefix }}-sai{% if slurm_cluster_domain | length %}.{{ slurm_cluster_domain }}{% endif %}"
 motd: |

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -5,61 +5,61 @@
   delegate_facts: true
   with_items: "{{ groups['slurm-management'] }}"
 
-- name: Include Slurm vars.
+- name: 'Include Slurm defaults from "slurm-management" role.'
   include_vars:
-    file: ../../slurm-management/defaults/main.yml
-    name: slurm
+    file: '../../slurm-management/defaults/main.yml'
+    name: 'slurm'
 
-- name: Add Slurm group.
+- name: 'Add Slurm group.'
   group:
-    name: slurm
+    name: 'slurm'
     gid: "{{ slurm['slurm_gid'] }}"
   notify:
-    - restart_slurmd
+    - 'restart_slurmd'
   become: true
 
-- name: Add Munge group.
+- name: 'Add Munge group.'
   group:
-    name: munge
+    name: 'munge'
     gid: "{{ slurm['munge_gid'] }}"
   notify:
-    - restart_munge
-    - restart_slurmd
+    - 'restart_munge'
+    - 'restart_slurmd'
   become: true
 
-- name: Add Slurm user.
+- name: 'Add Slurm user.'
   user:
-    name: slurm
+    name: 'slurm'
     uid: "{{ slurm['slurm_uid'] }}"
-    group: slurm
+    group: 'slurm'
   notify:
-    - restart_slurmd
+    - 'restart_slurmd'
   become: true
 
-- name: Add Munge user.
+- name: 'Add Munge user.'
   user:
-    name: munge
+    name: 'munge'
     uid: "{{ slurm['munge_uid'] }}"
-    group: munge
+    group: 'munge'
   notify:
-    - restart_munge
-    - restart_slurmd
+    - 'restart_munge'
+    - 'restart_slurmd'
   become: true
 
-- name: Install the Slurm client with yum.
+- name: 'Install the Slurm client with yum.'
   yum:
-    state: installed
+    state: 'installed'
     update_cache: yes
     allow_downgrade: yes
     name:
       - "slurm*{{ slurm_version }}"
       - "slurm-slurmd*{{ slurm_version }}"
   notify:
-    - restart_munge
-    - restart_slurmd
+    - 'restart_munge'
+    - 'restart_slurmd'
   become: true
 
-- name: Patch slurm daemon systemd service files to use custom sub dir for PID files.
+- name: 'Patch slurm daemon systemd service files to use custom sub dir for PID files.'
   lineinfile:
     path: "/usr/lib/systemd/system/{{ item }}.service"
     regexp: '^PIDFile='
@@ -67,58 +67,58 @@
   with_items:
     - 'slurmd'
   notify:
-    - restart_slurmd
+    - 'restart_slurmd'
   become: true
 
-- name: Install NHC with yum.
+- name: 'Install NHC with yum.'
   yum:
-    state: latest
+    state: 'latest'
     update_cache: yes
     name:
       - 'lbnl-nhc'
   notify:
-    - restart_slurmd
+    - 'restart_slurmd'
   become: true
 
-- name: Install munge_keyfile.
+- name: 'Install munge_keyfile.'
   copy:
-    src: roles/slurm-management/files/{{ slurm_cluster_name }}_munge.key
-    owner: munge
-    group: munge
-    mode: 0600
-    dest: /etc/munge/munge.key
+    src: "roles/slurm-management/files/{{ slurm_cluster_name }}_munge.key"
+    owner: 'munge'
+    group: 'munge'
+    mode: '0600'
+    dest: '/etc/munge/munge.key'
   notify:
-    - restart_munge
-    - restart_slurmd
+    - 'restart_munge'
+    - 'restart_slurmd'
   become: true
 
-- name: Create folders for Slurm and NHC.
+- name: 'Create folders for Slurm and NHC.'
   file:
     name: "{{ item.name }}"
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
-    state: directory
+    state: 'directory'
   with_items:
-    - name: /etc/slurm
-      owner: root
-      group: root
+    - name: '/etc/slurm'
+      owner: 'root'
+      group: 'root'
       mode: '0755'
-    - name: /etc/nhc
-      owner: root
-      group: root
+    - name: '/etc/nhc'
+      owner: 'root'
+      group: 'root'
       mode: '0755'
-    - name: /var/log/slurm
-      owner: slurm
-      group: root
+    - name: '/var/log/slurm'
+      owner: 'slurm'
+      group: 'root'
       mode: '0750'
-    - name: /var/spool/slurm
-      owner: slurm
-      group: root
+    - name: '/var/spool/slurm'
+      owner: 'slurm'
+      group: 'root'
       mode: '0750'
-    - name: /var/spool/slurmd
-      owner: root
-      group: root
+    - name: '/var/spool/slurmd'
+      owner: 'root'
+      group: 'root'
       mode: '0755'
     - name: '/var/run/slurm'
       owner: 'slurm'
@@ -126,69 +126,69 @@
       mode: '0775'
   become: true
 
-- name: Deploy slurm prolog/epilog scripts.
+- name: 'Deploy slurm prolog/epilog scripts.'
   copy:
-    src: roles/slurm-management/files/{{ item }}
-    dest: /etc/slurm/
-    owner: root
-    group: root
-    mode: 0755
+    src: "roles/slurm-management/files/{{ item }}"
+    dest: '/etc/slurm/'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
   with_items:
-    - slurm.prolog
-    - slurm.epilog
-    - slurm.taskprolog
+    - 'slurm.prolog'
+    - 'slurm.epilog'
+    - 'slurm.taskprolog'
   become: true
 
-- name: Deploy slurm.conf.
+- name: 'Deploy slurm.conf.'
   template:
-    src: roles/slurm-management/templates/slurm.conf
-    dest: /etc/slurm/slurm.conf
-    owner: root
-    group: root
-    mode: 0644
+    src: 'roles/slurm-management/templates/slurm.conf'
+    dest: '/etc/slurm/slurm.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
   notify:
-    - reload_slurmd
+    - 'reload_slurmd'
   become: true
 
-- name: Configure cgroups.
+- name: 'Configure cgroups.'
   copy:
-    src: roles/slurm-management/files/cgroup.conf
-    dest: /etc/slurm/cgroup.conf
-    owner: root
-    group: root
-    mode: 0644
+    src: 'roles/slurm-management/files/cgroup.conf'
+    dest: '/etc/slurm/cgroup.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
   notify:
-    - reload_slurmd
+    - 'reload_slurmd'
   become: true
 
-- name: Deploy UI nhc.conf.
+- name: 'Deploy UI nhc.conf.'
   template:
-    src: templates/user-interface_nhc.conf
-    dest: /etc/nhc/nhc.conf
-    owner: root
-    group: root
-    mode: 0644
+    src: 'templates/user-interface_nhc.conf'
+    dest: '/etc/nhc/nhc.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
   when: inventory_hostname in groups['user-interface']
   become: true
 
-- name: Deploy compute-vm nhc.conf.
+- name: 'Deploy compute-vm nhc.conf.'
   template:
-    src: templates/compute-vm_nhc.conf
-    dest: /etc/nhc/nhc.conf
-    owner: root
-    group: root
-    mode: 0644
+    src: 'templates/compute-vm_nhc.conf'
+    dest: '/etc/nhc/nhc.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
   when: inventory_hostname in groups['compute-vm']
   become: true
 
-- name: Start slurm and munge services.
+- name: 'Start slurm and munge services.'
   systemd:
     name: "{{ item }}"
     enabled: 'yes'
     state: 'started'
     daemon_reload: 'yes'
   with_items:
-    - munge.service
-    - slurmd.service
+    - 'munge.service'
+    - 'slurmd.service'
   become: true
 ...

--- a/roles/slurm-management/defaults/main.yml
+++ b/roles/slurm-management/defaults/main.yml
@@ -4,4 +4,17 @@ slurm_uid: 497
 slurm_gid: 497
 munge_uid: 498
 munge_gid: 498
+#
+# slurm_allow_jobs_to_span_nodes
+#
+# We always use fast network interconnects nodes <-> large shared storage devices,
+# but do not always have fast, low latency network interconnects between nodes.
+#   false (default) Should be used when fast, low latency network interconnects between nodes are not available.
+#                   This will set MaxNodes = 1 for all nodes of all partitions in slurm.conf,
+#                   which limits (MPI) jobs to max the amount of cores on a single node.
+#   true            Should be used when fast, low latency network interconnects between nodes are present.
+#                   Allows (MPI) jobs to use multiple nodes.
+#                   Will set MaxNodes in slurm.conf to the total amount of compute nodes in the Slurm cluster.
+#
+slurm_allow_jobs_to_span_nodes: false
 ...

--- a/roles/slurm-management/tasks/main.yml
+++ b/roles/slurm-management/tasks/main.yml
@@ -2,50 +2,50 @@
 ---
 - name: 'Add Slurm group.'
   group:
-    name: slurm
+    name: 'slurm'
     gid: "{{ slurm_gid }}"
   notify:
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Add Munge group.'
   group:
-    name: munge
+    name: 'munge'
     gid: "{{ munge_gid }}"
   notify:
-    - restart_munge
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_munge'
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Add Slurm user.'
   user:
-    name: slurm
+    name: 'slurm'
     uid: "{{ slurm_uid }}"
-    group: slurm
+    group: 'slurm'
   notify:
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Add Munge user.'
   user:
-    name: munge
+    name: 'munge'
     uid: "{{ munge_uid }}"
-    group: munge
+    group: 'munge'
   notify:
-    - restart_munge
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_munge'
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Install munge.'
   yum:
-    state: latest
+    state: 'latest'
     update_cache: yes
     name:
-      - munge
+      - 'munge'
   become: true
 
 - name: 'Install a logrotate file for slurm.'
@@ -65,27 +65,27 @@
     mode: '0600'
     dest: '/etc/munge/munge.key'
   notify:
-    - restart_munge
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_munge'
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Install Slurm management dependencies with yum.'
   yum:
-    state: latest
+    state: 'latest'
     update_cache: yes
     name:
       - 'MySQL-python'
       - 'lua-posix'
   notify:
-    - restart_munge
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_munge'
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Install Slurm management deamons with yum.'
   yum:
-    state: installed
+    state: 'installed'
     update_cache: yes
     allow_downgrade: yes
     name:
@@ -94,9 +94,9 @@
       - "slurm-slurmdbd*{{ slurm_version }}"
       - "slurm-perlapi*{{ slurm_version }}"
   notify:
-    - restart_munge
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_munge'
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Patch slurm daemon systemd service files to use custom sub dir for PID files.'
@@ -108,8 +108,8 @@
     - 'slurmctld'
     - 'slurmdbd'
   notify:
-    - restart_slurmdbd
-    - restart_slurmctld
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
   become: true
 
 - name: 'Create a database for Slurm accounting.'
@@ -120,9 +120,10 @@
     login_unix_socket: "/var/lib/mysql/mysql.sock"
     name: "{{ slurm_database_name }}"
     state: 'present'
-  no_log: True
+  no_log: true
   notify:
-    - restart_slurmdbd
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
 
 - name: 'Make sure the slurm database user is present and grant privileges on the Slurm accounting DB.'
   mysql_user:
@@ -135,9 +136,10 @@
     host: 'localhost'
     priv: "{{ slurm_database_name }}.*:ALL"
     connect_timeout: 120
-  no_log: True
+  no_log: true
   notify:
-    - restart_slurmdbd
+    - 'restart_slurmdbd'
+    - 'restart_slurmctld'
 
 - name: 'Create folders for Slurm.'
   file:
@@ -145,7 +147,7 @@
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
-    state: directory
+    state: 'directory'
   with_items:
     - name: '/etc/slurm'
       owner: 'root'
@@ -172,10 +174,9 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: reload_slurmctld
+  notify: 'reload_slurmctld'
+  tags: 'slurm.conf'
   become: true
-  tags:
-    - slurm.conf
 
 - name: 'Install Slurm DBD config file.'
   template:
@@ -184,7 +185,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: reload_slurmdbd
+  notify: 'reload_slurmdbd'
   become: true
 
 - name: 'Install Slurm scripts.'
@@ -216,6 +217,7 @@
     owner: 'root'
     group: 'root'
     mode: '0700'
+  tags: 'create_database'
   become: true
 
 #
@@ -226,8 +228,6 @@
 - name: 'Execute Slurm DB initialization script on host running slurmdbd.'
   shell: |
          /etc/slurm/configure_slurm_accounting_db.bash
-  tags:
-    - create_database
   register: command_result
   retries: 3
   delay: 5
@@ -239,6 +239,7 @@
   #       something that already exists. This results in "Nothing new added." on STDOUT, but no message on STDERR.
   #       In case something is really wrong there will be messags printed to STDERR.
   failed_when: command_result.stderr != ''
+  tags: 'create_database'
   become: true
 
 - name: 'Make sure slurmctld service is enabled and started now that the cluster DB is present.'
@@ -256,8 +257,7 @@
     owner: 'root'
     group: 'root'
     mode: '0700'
-  tags:
-    - backup
+  tags: 'backup'
   become: true
 
 - name: 'Create Slurm accounting DB backup now.'
@@ -266,8 +266,7 @@
              -uroot -p{{ MYSQL_ROOT_PASSWORD }} \
              -h localhost --protocol=socket \
              > /root/slurm/backup/slurm.sql
-  tags:
-    - backup
+  tags: 'backup'
   no_log: true
   become: true
 
@@ -281,8 +280,7 @@
       && mysqldump --all-databases -uroot -p{{ MYSQL_ROOT_PASSWORD }} -h localhost --protocol=socket
       > /root/slurm/backup/slurm.sql
       && /bin/find /root/slurm/backup/slurm_bak.sql.* -mtime 7 -delete
-  tags:
-    - backup
+  tags: 'backup'
   no_log: true
   become: true
 ...

--- a/roles/slurm-management/templates/slurm.conf
+++ b/roles/slurm-management/templates/slurm.conf
@@ -133,14 +133,8 @@ HealthCheckInterval=300
 #
 # Partitions
 #
-# Configure maxnodes = 1 for all nodes of all partitions, 
-# because we hardly use MPI and when we do never between nodes,
-# but only with max the amount of cores on a single node.
-# Therefore we don't have fast network interconnects between nodes.
-# (We use the fast network interconnects only for nodes <-> large shared storage devices)
-#
 EnforcePartLimits=YES
-PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes=1 MaxTime=7-00:00:01
+PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and true %}{{ groups['compute-vm']|list|length }}{% else %}1{% endif %} MaxTime=7-00:00:01
 PartitionName=regular Default=YES MaxNodes=1 Nodes={{ vcompute_hostnames }} MaxCPUsPerNode={{ vcompute_max_cpus_per_node }} MaxMemPerNode={{ vcompute_max_mem_per_node }} TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long
 PartitionName=ds      Default=No  MaxNodes=1 Nodes={{ ui_hostnames }} MaxCPUsPerNode=1 MaxMemPerNode=1024 TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long
 #


### PR DESCRIPTION
* Consistent quoting of strings in tasks of `slurm-*` roles.
* Always restart `slurmctld` after a restart of `slurmdbd` to fix "_user does not exist error_".
* Added `slurm_allow_jobs_to_span_nodes` variable to control whether jobs can span multiple nodes or not.

