### PR TITLE
Slurm fixes

### DIFF
--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -27,7 +27,7 @@ vcompute_cores_per_socket: 1
 vcompute_real_memory: 7821
 vcompute_max_cpus_per_node: "{{ vcompute_sockets * vcompute_cores_per_socket - 2 }}"
 vcompute_max_mem_per_node: "{{ vcompute_real_memory - vcompute_sockets * vcompute_cores_per_socket * 512 }}"
-vcompute_local_disk: 0
+vcompute_local_disk: 2700
 vcompute_features: 'tmp08'
 vcompute_ethernet_interfaces:
   - 'eth0'

--- a/group_vars/talos-cluster/vars.yml
+++ b/group_vars/talos-cluster/vars.yml
@@ -27,7 +27,7 @@ vcompute_cores_per_socket: 1
 vcompute_real_memory: 7821
 vcompute_max_cpus_per_node: "{{ vcompute_sockets * vcompute_cores_per_socket - 2 }}"
 vcompute_max_mem_per_node: "{{ vcompute_real_memory - vcompute_sockets * vcompute_cores_per_socket * 512 }}"
-vcompute_local_disk: 2700
+vcompute_local_disk: 270000
 vcompute_features: 'tmp08'
 vcompute_ethernet_interfaces:
   - 'eth0'

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -147,7 +147,7 @@
     group: 'root'
     mode: '0644'
   notify:
-    - 'reload_slurmd'
+    - 'restart_slurmd'
   become: true
 
 - name: 'Configure cgroups.'

--- a/roles/slurm-management/tasks/main.yml
+++ b/roles/slurm-management/tasks/main.yml
@@ -174,7 +174,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: 'reload_slurmctld'
+  notify: 'restart_slurmctld'
   tags: 'slurm.conf'
   become: true
 

--- a/roles/slurm-management/templates/slurm.conf
+++ b/roles/slurm-management/templates/slurm.conf
@@ -135,7 +135,7 @@ HealthCheckInterval=300
 #
 EnforcePartLimits=YES
 PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and true %}{{ groups['compute-vm']|list|length }}{% else %}1{% endif %} MaxTime=7-00:00:01
-PartitionName=regular Default=YES MaxNodes=1 Nodes={{ vcompute_hostnames }} MaxCPUsPerNode={{ vcompute_max_cpus_per_node }} MaxMemPerNode={{ vcompute_max_mem_per_node }} TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long
+PartitionName=regular Default=YES MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and true %}{{ groups['compute-vm']|list|length }}{% else %}1{% endif %} Nodes={{ vcompute_hostnames }} MaxCPUsPerNode={{ vcompute_max_cpus_per_node }} MaxMemPerNode={{ vcompute_max_mem_per_node }} TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long
 PartitionName=ds      Default=No  MaxNodes=1 Nodes={{ ui_hostnames }} MaxCPUsPerNode=1 MaxMemPerNode=1024 TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long
 #
 # COMPUTE NODES


### PR DESCRIPTION
* Fixed missing new `MaxNodes` definition for partition regular.
* Always `restart` Slurm daemons when `slurm.conf` has changed. (For some changes a `reload` is enough, but for others like changes to nodes or partitions a `restart` is required.)
* Added missing local disk space value for Talos slurm config. 