### PR TITLE
Beefing up the user interface.

### DIFF
--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -45,9 +45,9 @@ vcompute_ethernet_interfaces:
   - 'eth1'
   - 'eth2'
 ui_hostnames: "{{ slurm_cluster_name }}"
-ui_sockets: 2
+ui_sockets: 24
 ui_cores_per_socket: 1
-ui_real_memory: 3789
+ui_real_memory: 221501
 ui_local_disk: 0
 ui_features: 'prm03,tmp01'
 ui_ethernet_interfaces:

--- a/heat/heat_cluster.yml
+++ b/heat/heat_cluster.yml
@@ -15,7 +15,7 @@ resources:
     properties:
       key_name: adminkey
       image: {get_param: image_name}
-      flavor: 4C-8GB
+      flavor: 24C-240GB
       networks:
         - network: vlan983
           fixed_ip: 172.23.40.33


### PR DESCRIPTION
We changed the specs of the login node to that of a compute node minus the volume on /local.
