### PR TITLE
Fix/monitoring tweaks

### DIFF
--- a/roles/prom_server/templates/etc/alerting.rules
+++ b/roles/prom_server/templates/etc/alerting.rules
@@ -43,7 +43,7 @@ groups:
       description: Instance {{ $labels.instance }} will fill up within 72 hours
       summary: '{{ $labels.instance }} disk almost full'
   - alert: DiskFull
-    expr: node_filesystem_free{job="node",mountpoint!~"/tmp|/net|/cvmfs|/var/lib/nfs/rpc_pipefs|/cvmfs|/misc|/run/docker/netns/.+?|/cgroup.+?", fstype!~"fuse.+?"} < 5.24288e+06
+    expr: node_filesystem_free{job="node",mountpoint!~"/net|/cvmfs|/var/lib/nfs/rpc_pipefs|/cvmfs|/misc|/run/docker/netns/.+?|/cgroup.+?", fstype!~"fuse.+?"} < 5.24288e+06
     for: 5m
     labels:
       severity: page

--- a/roles/prom_server/templates/etc/targets.json
+++ b/roles/prom_server/templates/etc/targets.json
@@ -25,8 +25,7 @@
             "gs-compute07:9100",
             "gs-compute08:9100",
             "gs-compute09:9100",
-            "gs-compute10:9100",
-            "gs-compute11:9100"
+            "gs-compute10:9100"
         ],
         "labels": {
             "env": "gearshift",


### PR DESCRIPTION
We also want warning when /tmp fills.

See: https://trello.com/c/dvxQSqcl/10-gearshift-monitoring-aanscherpen-signaleert-de-problemen-niet-altijd-tijdig-bijv-tmp-loopt-vol

gs-vcompute has been removed because the node has been removed. (its volume space is used for the "talos" test cluster and the cores/memory for a beefed up login node)