### PR TITLE
Slurm admins without root

### DIFF
--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -191,4 +191,14 @@
     - 'munge.service'
     - 'slurmd.service'
   become: true
+
+- name: 'Allow passwordless sudo to slurm user for users in the functional_admins_group.'
+  template:
+    src: 'roles/slurm-management/templates/91-slurm'
+    dest: "/etc/sudoers.d/91-slurm"
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+  when: functional_admin_group is defined and functional_admin_group | length >= 1
+  become: true
 ...

--- a/roles/slurm-management/tasks/main.yml
+++ b/roles/slurm-management/tasks/main.yml
@@ -283,4 +283,15 @@
   tags: 'backup'
   no_log: true
   become: true
+
+- name: 'Allow passwordless sudo to slurm user for users in the functional_admins_group.'
+  template:
+    src: 'templates/91-slurm'
+    dest: "/etc/sudoers.d/91-slurm"
+    owner: 'root'
+    group: 'root'
+    mode: '0440'
+  when: functional_admin_group is defined and functional_admin_group | length >= 1
+  become: true
+
 ...

--- a/roles/slurm-management/templates/91-slurm
+++ b/roles/slurm-management/templates/91-slurm
@@ -1,0 +1,11 @@
+#
+# This file is deployed with the slurm role from the Ansible playbook of the league-of-robots repo.
+# DO NOT EDIT MANUALLY; update source and re-deploy instead!
+#
+# {{ ansible_managed }}
+#
+# Allow users from the {{ functional_admin_group }} group to become the slurm user.
+# The {{ functional_admin_group }} group must be listed in the Ansible variable functional_admin_group in
+# league-of-robots/group_vars/<name-of-cluster>/vars.yml
+#
+%{{ functional_admin_group }}    ALL=(slurm)    NOPASSWD:ALL


### PR DESCRIPTION
Added sudoers config to allow users from the functional_admins_group to become the slurm user.