### PR TITLE
Swappiness

### DIFF
--- a/roles/slurm-management/files/cgroup.conf
+++ b/roles/slurm-management/files/cgroup.conf
@@ -23,6 +23,7 @@ ConstrainKmemSpace=no
 #
 # Don't let Slurm jobs swap as swapping kills performance taking the H out of HPC.
 #
+AllowedSwapSpace=0
 MemorySwappiness=0
 
 #

--- a/roles/slurm-management/files/cgroup.conf
+++ b/roles/slurm-management/files/cgroup.conf
@@ -20,8 +20,10 @@ ConstrainSWAPSpace=yes
 #
 ConstrainKmemSpace=no
 
-# Set the allowable swap space to 100% of the requested memory
-# The virtual memory space of a job should be 2 times the requested amount
+#
+# Don't let Slurm jobs swap as swapping kills performance taking the H out of HPC.
+#
+MemorySwappiness=0
 
 #
 # Bind job tasks to a subset of the allocated cores using sched_setaffinity


### PR DESCRIPTION
Tweak `swappiness` for Slurm's cgroups:
 * Override OS default `swappiness` for Slurm cgroups and set it to `zero`.
 * Explicitly set default of 0 for `AllowedSwapSpace`.