### PR TITLE
New vars for new ui.

### DIFF
--- a/group_vars/gearshift-cluster/vars.yml
+++ b/group_vars/gearshift-cluster/vars.yml
@@ -47,9 +47,9 @@ vcompute_ethernet_interfaces:
   - 'eth1'
   - 'eth2'
 ui_hostnames: "{{ slurm_cluster_name }}"
-ui_sockets: 24
-ui_cores_per_socket: 1
-ui_real_memory: 221501
+ui_sockets: 2
+ui_cores_per_socket: 12
+ui_real_memory: 221500
 ui_local_disk: 0
 ui_features: 'prm03,tmp01'
 ui_ethernet_interfaces:


### PR DESCRIPTION
We changed the socket count to two. By doing 

openstack flavor set  24C-220GB     --property hw:cpu_sockets=2

Hopefully this will improve perfomance as the guest kernel can take the numa layout into account.
The first machine rolled out with this setting is gearshift, hence this pull request.
And of course, a new vm wouldn't be complete without a minute change in available ram.