### PR TITLE
Fixed order and rsync version checks.

### DIFF
--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,60 +1,4 @@
 ---
-- name: Check if rsync >= 3.1.2 is installed on the control host.
-  shell: |
-         rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
-  args:
-    warn: no
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: rsync_version
-
-- name: Abort when modern rsync >= 3.1.2 is missing on control host.
-  debug:
-    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version.stdout }}."
-  when:         'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
-  failed_when: 'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
-  delegate_to: localhost
-
-- name: Add custom config files to /etc/skel/.
-  synchronize:
-    src: "{{ playbook_dir }}/roles/cluster/files/skel/./{{ item.src }}"
-    dest: '/etc/skel/'
-    owner: 'no'
-    group: 'no'
-    use_ssh_args: 'yes'
-    rsync_opts:
-      # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
-      #                   for file systems like NFS mounts that cannot handle setting dir times properly.
-      # --omit-link-times Is required to prevent "sync error: some files/attrs were not transferred"
-      #                   for file systems like NFS mounts that cannot handle setting dir times properly.
-      #                   Requires rsync >= 3.1.2 (default on Enterprise Linux >= 7.x).
-      # --chmod           Is required to prevent errors when the perms on the source are not what is required/expected on the destination.
-      #                   Fixing perms on the source would be good, but that may be out of our control.
-      #                   In that case --chmod ensures we get what we want on the destination.
-      #                   Works only when combined with --perms.
-      # --force           Is required when symlinks have changed into dirs/files or vice versa.
-      #                   In that case the wrong outdated stuff has to be deleted on the destination first before the new stuff can be created.
-      #                   Deleting the outdated stuff may fail without --force.
-      # --relative        In combination with a "source_server:some/path/not/created/on/destination/./path/created/on/destination/some_file" (dot dir)
-      #                   recreates a partial dir structure on the destination relative to the /./ dir, when it does not already exist.
-      #                   Without this combination of --relative and dot dir rsync will error when the path does not exist on the destination.
-      #                   IMPORTANT: src and dest paths must be absolute paths. Otherwise Ansible will expand the path itself which will remove the /./ dir.
-      - '--relative'
-      - '--omit-dir-times'
-      - '--omit-link-times'
-      - "--chmod={{ item.mode }}"
-      - '--perms'
-      - '--force'
-  with_items:
-    - src: '.bashrc'
-      mode: 'Du=rwx,Dgo=rx,Fu=rw,Fgo=r'
-    - src: '.screenrc'
-      mode: 'Du=rwx,Dgo=rx,Fu=rw,Fgo=r'
-    - src: '.ssh'
-      mode: 'Du=rwx,Dgo-rwx,Fu=rw,Fgo-rwx'
-  become: true
-
 - name: Set hostname to inventory_hostname
   hostname:
     name: "{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}"
@@ -103,5 +47,78 @@
       - wget
   tags:
     - software
+  become: true
+
+- name: Check if rsync >= 3.1.2 is installed on the managed hosts.
+  shell: |
+         rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
+  args:
+    warn: no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: rsync_version_managed_host
+
+- name: Abort when modern rsync >= 3.1.2 is missing on the managed hosts.
+  debug:
+    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version.stdout }}."
+  when:         'rsync_version_managed_host is failed or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))'
+  failed_when: 'rsync_version_managed_host is failed or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))'
+
+- name: Check if rsync >= 3.1.2 is installed on the control host.
+  shell: |
+         rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
+  args:
+    warn: no
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  register: rsync_version_control_host
+  delegate_to: localhost
+
+- name: Abort when modern rsync >= 3.1.2 is missing on control host.
+  debug:
+    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version.stdout }}."
+  when:         'rsync_version_control_host is failed or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))'
+  failed_when: 'rsync_version_control_host is failed or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))'
+  delegate_to: localhost
+
+- name: Add custom config files to /etc/skel/.
+  synchronize:
+    src: "{{ playbook_dir }}/roles/cluster/files/skel/./{{ item.src }}"
+    dest: '/etc/skel/'
+    owner: 'no'
+    group: 'no'
+    use_ssh_args: 'yes'
+    rsync_opts:
+      # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
+      #                   for file systems like NFS mounts that cannot handle setting dir times properly.
+      # --omit-link-times Is required to prevent "sync error: some files/attrs were not transferred"
+      #                   for file systems like NFS mounts that cannot handle setting dir times properly.
+      #                   Requires rsync >= 3.1.2 (default on Enterprise Linux >= 7.x).
+      # --chmod           Is required to prevent errors when the perms on the source are not what is required/expected on the destination.
+      #                   Fixing perms on the source would be good, but that may be out of our control.
+      #                   In that case --chmod ensures we get what we want on the destination.
+      #                   Works only when combined with --perms.
+      # --force           Is required when symlinks have changed into dirs/files or vice versa.
+      #                   In that case the wrong outdated stuff has to be deleted on the destination first before the new stuff can be created.
+      #                   Deleting the outdated stuff may fail without --force.
+      # --relative        In combination with a "source_server:some/path/not/created/on/destination/./path/created/on/destination/some_file" (dot dir)
+      #                   recreates a partial dir structure on the destination relative to the /./ dir, when it does not already exist.
+      #                   Without this combination of --relative and dot dir rsync will error when the path does not exist on the destination.
+      #                   IMPORTANT: src and dest paths must be absolute paths. Otherwise Ansible will expand the path itself which will remove the /./ dir.
+      - '--relative'
+      - '--omit-dir-times'
+      - '--omit-link-times'
+      - "--chmod={{ item.mode }}"
+      - '--perms'
+      - '--force'
+  with_items:
+    - src: '.bashrc'
+      mode: 'Du=rwx,Dgo=rx,Fu=rw,Fgo=r'
+    - src: '.screenrc'
+      mode: 'Du=rwx,Dgo=rx,Fu=rw,Fgo=r'
+    - src: '.ssh'
+      mode: 'Du=rwx,Dgo-rwx,Fu=rw,Fgo-rwx'
   become: true
 ...


### PR DESCRIPTION
* Need to check rsync version on both control host as well as on the managed hosts.
* Fixed order: install rsync using yum on the managed hosts first before checking the rsync version. 