### PR TITLE
Fix/jumphost firewall

### DIFF
--- a/group_vars/jumphost.yml
+++ b/group_vars/jumphost.yml
@@ -1,11 +1,9 @@
 ---
 firewall_allowed_tcp_ports:
-  - "22"
-  - "80"
+  - "22"    # SSH.
+  - "443"   # SSH fallback when 22 is blocked.
   - "3000"  # Grafana server.
 firewall_additional_rules:
-  - "iptables -t nat -A PREROUTING -i eth1 -p tcp --dport 80 -j REDIRECT --to-port 22"
   - "iptables -A INPUT -i eth1 -p tcp -s 129.125.2.233,129.125.2.225,129.125.2.226 --dport 9090 -j ACCEPT -m comment --comment 'prometheus server'"
-
 ssh_host_signer_hostnames: "{{ ansible_hostname }}{% if slurm_cluster_domain | length %}.{{ slurm_cluster_domain }}{% endif %},{{ ansible_hostname }}{% if public_ip_addresses is defined and public_ip_addresses[ansible_hostname] | length %},{{ public_ip_addresses[ansible_hostname] }}{% endif %}"
 ...

--- a/roles/sshd/templates/sshd_config
+++ b/roles/sshd/templates/sshd_config
@@ -1,7 +1,13 @@
-Port 22
 {% if inventory_hostname in groups['jumphost'] %}
+#
+# Extra ports where sshd will listen in addition to the default 22
+# must be listed before the default of 22,
+# because the geerlingly.security role will modify the last listed Port value
+# and we use the geerlingly.security role with the default of 22.
+#
 Port 443
 {% endif %}
+Port 22
 
 UseDNS no
 


### PR DESCRIPTION
* Updated jumphost firewall canfig changing fallback SSH port `80` -> `443`.
* Changed order of ports in `roles/sshd/templates/sshd_config` to prevent geerlinguy.security role from destroying the setup for jumphosts.

