### PR TITLE
Fix/security hardening

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -163,5 +163,20 @@
   roles:
     - admin-users
     - ssh_host_signer
+    - yum-repos
+    - {role: geerlingguy.repo-epel, become: true}
+    - sshd
+    - {role: geerlingguy.security, become: true}
     - online_docs
+  tasks:
+    - name: 'Install cron job to reboot server regularly to activate kernel updates.'
+      cron:
+        name: 'Reboot to load new kernel.'
+        weekday: '1'
+        minute: '45'
+        hour: '11'
+        user: root
+        job: /bin/needs-restarting -r >/dev/null 2>&1 || /sbin/shutdown -r +60 "Restarting to apply updates..."
+        cron_file: reboot
+      become: true
 ...

--- a/group_vars/docs.yml
+++ b/group_vars/docs.yml
@@ -1,0 +1,9 @@
+---
+#
+# Configure allowed network ports for geerlingguy.firewall role
+#
+firewall_allowed_tcp_ports:
+  - '22'   # SSH
+  - '80'   # HTTP
+  - '443'  # HTTPS
+...


### PR DESCRIPTION
Security hardening for documentation server:
* Specify allowed firewall ports for documentation servers.
* Apply additional roles for security hardening just like for jumphosts, because docs servers are accessible directly from the internet like the jumphosts.

