### PR TITLE
Allow incoming slurm traffic.

### DIFF
--- a/roles/firewall/vars/main.yml
+++ b/roles/firewall/vars/main.yml
@@ -6,6 +6,7 @@ networks:
 
 firewall_allowed_tcp_ports:
   - "22"
+  - "6818"
 
 firewall_log_dropped_packets: true
 

--- a/roles/grafana_proxy/templates/nginx.conf
+++ b/roles/grafana_proxy/templates/nginx.conf
@@ -36,7 +36,7 @@ http {
     include /etc/nginx/conf.d/*.conf;
 
 server {
-         listen 443 ssl http2;
+         listen 3000 ssl http2;
          server_name  airlock.hpc.rug.nl;
 
          ssl_certificate /etc/certificates/live/airlock.hpc.rug.nl/cert.pem;


### PR DESCRIPTION
443 was reserved for incoming ssh on airlock, so we're listening at 3000.