### PR TITLE
Set isilon DNS as upstream for hpc.local domain on gearshift

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -68,6 +68,9 @@ nameservers: [
   '8.8.4.4',       # Google DNS.
   '8.8.8.8',       # Google DNS.
 ]
+nameserver_domain_overrides:
+  - domain: hpc.local
+    nameserver: 172.23.40.244
 local_admin_groups:
   - 'admin'
   - 'docker'

--- a/roles/resolver/defaults/main.yml
+++ b/roles/resolver/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+nameserver_domain_overrides: []

--- a/roles/resolver/templates/dnsmasq.conf.j2
+++ b/roles/resolver/templates/dnsmasq.conf.j2
@@ -1,3 +1,7 @@
 {% for nameserver in nameservers %}
 server={{ nameserver }}
 {% endfor %}
+
+{% for override in nameserver_domain_overrides %}
+server=/{{ override.domain }}/{{ override.nameserver }}
+{% endfor %}


### PR DESCRIPTION
Make sure dnsmasq only sends dns queries for the hpc.local domain to the DNS server that knows about it

If it sends it to one of the other upstream nameservers we could be caching an nxdomain or incorrect response