### PR TITLE
Increase timeout as workaround for known DBus bug.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 retry_files_enabled = False
 stdout_callback = debug
+timeout = 30
 #
 # Do not use a hard-code vault_password_file file here:
 # we have multiple .vault_pass.txt.clustername files with specific passwords for each cluster.

--- a/roles/logins/handlers/main.yml
+++ b/roles/logins/handlers/main.yml
@@ -12,10 +12,11 @@
 #
 # Notes:
 # * OddJob has a dependency on DBus.
-# * Due to a bug systemd-logind may enter a broken state when DBus is restarted
+# * Due to a bug in DBus systemd-logind may enter a broken state when DBus is restarted
 #   making logins via SSH and or sudo commands very slow.
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1532105
 #   Workaround for now is to always restart systemd-logind after DBus is restarted.
+#   Is fixed in DBus 1.11.x, but that is not available yet for CentOS 7.x.
 #
 - name: 'Restart oddjobd service and its dependencies.'
   service:


### PR DESCRIPTION
We use a cronjob to regulary restart DBus and systemd-logind in the correct order as workaround for a known bug that will delay logins and privilege escalation using sudo by ~22 seconds. However you may get an Ansible error:
```
Timeout (12s) waiting for privilege escalation prompt.
```
when the playbook needs privilege escalation before it managed to deploy the workaround. Increasing the timeout makes sure it won't fail in that case.