### PR TITLE
Fix/various

### DIFF
--- a/roles/logins/tasks/main.yml
+++ b/roles/logins/tasks/main.yml
@@ -6,7 +6,7 @@
     # Need DBus 1.11.10 for a fix, but CentOS 7.6 is stuck on dbus 1.10.24.
     #
     name: 'Restart systemd-logind'
-    minute: '/10'
+    minute: '*/10'
     user: root
     job: '/bin/systemctl restart systemd-logind'
     cron_file: restart_logind

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -67,6 +67,14 @@
   failed_when: false
   register: root_pwd_check
 
+- name: 'Install dependencies to interface with MariaDB/MySQL databases/services.'
+  yum:
+    name:
+      - 'MySQL-python'
+    state: 'latest'
+    update_cache: yes
+  become: true
+
 - name: 'Set MariaDB/MySQL root user password.'
   mysql_user:
     name: 'root'

--- a/roles/subgroup_directories/tasks/create_subgroup_directories.yml
+++ b/roles/subgroup_directories/tasks/create_subgroup_directories.yml
@@ -54,7 +54,7 @@
         mode: "{{ mode_version }}"
         state: 'directory'
       with_items: "{{ versioned_subgroups_list }}"
-      ignore_errors: yes # Continue of this specific subgroup failed and try to create other subgroup folders.
+      ignore_errors: yes # Continue if this specific subgroup failed and try to create other subgroup folders.
   when: versioned_subgroups_list | length > 0
   become: true
   become_user: "{{ group }}-dm"
@@ -76,7 +76,7 @@
         mode: "{{ mode_project }}"
         state: 'directory'
       with_items: "{{ unversioned_subgroups_list }}"
-      ignore_errors: yes # Continue of this specific subgroup failed and try to create other subgroup folders.
+      ignore_errors: yes # Continue if this specific subgroup failed and try to create other subgroup folders.
   when: unversioned_subgroups_list | length > 0
   become: true
   become_user: "{{ group }}-dm"

--- a/roles/swap/defaults/main.yml
+++ b/roles/swap/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
-swap_space: 4  # 4 GiB
+swap_file_path: /swapfile.swap
+swap_file_size: 4  # Size in GiB
+swap_swappiness: 1
+swap_file_state: enabled
+...

--- a/roles/swap/handlers/main.yml
+++ b/roles/swap/handlers/main.yml
@@ -1,0 +1,24 @@
+---
+#
+# Important: maintain correct handler order.
+# Handlers are executed in the order in which they are defined 
+# and not in the order in which they are listed in a "notify: handler_name" statement!
+#
+- name: Disable swap file using swapon.
+  command:
+    cmd: swapoff {{ swap_file_path | quote }}
+  listen: disable_swap_file
+  become: true
+
+- name: Format swap file.
+  command:
+    cmd: mkswap {{ swap_file_path | quote }}
+  listen: format_swap_file
+  become: true
+
+- name: Enable swap file using swapon.
+  command:
+    cmd: swapon {{ swap_file_path | quote }}
+  listen: enable_swap_file
+  become: true
+...

--- a/roles/swap/tasks/disable_swap.yml
+++ b/roles/swap/tasks/disable_swap.yml
@@ -1,0 +1,27 @@
+---
+- name: Check if swap is active.
+  command:
+    cmd: /usr/bin/grep "{{ swap_file_path }}" /proc/swaps
+  register: proc_swaps
+  changed_when: swap_file_path in proc_swaps.stdout
+  failed_when: proc_swaps.rc >= 2
+  notify: disable_swap_file
+
+- name: Flush handlers.
+  meta: flush_handlers
+
+- name: Remove swap file entry from fstab.
+  mount:
+    path: none
+    src: "{{ swap_file_path }}"
+    fstype: swap
+    opts: sw
+    state: absent
+  become: true
+
+- name: Remove swap file.
+  file:
+    path: "{{ swap_file_path }}"
+    state: absent
+  become: true
+...

--- a/roles/swap/tasks/enable_swap.yml
+++ b/roles/swap/tasks/enable_swap.yml
@@ -1,0 +1,48 @@
+---
+#
+# fallocate doesn't work on centos7, see
+# https://unix.stackexchange.com/questions/294600/i-cant-enable-swap-space-on-centos-7
+#
+- name: "Create swap file {{ swap_file_path }}."
+  command:
+    cmd: |
+      dd if=/dev/zero bs=1MiB count={{ swap_file_size * 1024 }} of={{ swap_file_path | quote }}
+    creates: "{{ swap_file_path | quote }}"
+  notify:
+    - format_swap_file
+    - enable_swap_file
+  become: true
+
+- name: Set permissions on swap file.
+  file:
+    path: "{{ swap_file_path }}"
+    owner: root
+    group: root
+    mode: 0600
+  become: true
+
+- name: Add swap file entry to fstab.
+  mount:
+    path: none
+    src: "{{ swap_file_path }}"
+    fstype: swap
+    opts: sw
+    state: present
+  become: true
+
+- name: Check if swap is active.
+  command:
+    cmd: /usr/bin/grep "{{ swap_file_path }}" /proc/swaps
+  register: proc_swaps
+  changed_when: swap_file_path not in proc_swaps.stdout
+  failed_when: proc_swaps.rc >= 2
+  notify:
+    - format_swap_file
+    - enable_swap_file
+
+- name: Set swapiness.
+  sysctl:
+    name: vm.swappiness
+    value: "{{ swap_swappiness | int }}"
+  become: true
+...

--- a/roles/swap/tasks/main.yml
+++ b/roles/swap/tasks/main.yml
@@ -1,47 +1,7 @@
 ---
-# https://gist.github.com/manuelmeurer/a2c0a8c24a0bb5092250
+- include_tasks: enable_swap.yml
+  when: swap_file_state == 'enabled'
 
-- name: set swap_file variable
-  set_fact:
-    swap_file: /swapfile.swap
-
-- name: check if swap file exists
-  stat:
-    path: "{{ swap_file }}"
-  register: swap_file_check
-
-
-# fallocate doesn't work on centos7, see
-# https://unix.stackexchange.com/questions/294600/i-cant-enable-swap-space-on-centos-7
-- name: create swap file
-  become: yes
-  command: dd if=/dev/zero bs=1MiB count={{ swap_space  * 1024 }} of={{ swap_file }}
-  when: not swap_file_check.stat.exists
-
-- name: set permissions on swap file
-  become: yes
-  file:
-    path: "{{ swap_file }}"
-    mode: 0600
-
-- name: format swap file
-  become: yes
-  command: mkswap {{ swap_file }}
-  when: not swap_file_check.stat.exists
-
-- name: add to fstab
-  become: yes
-  lineinfile:
-    dest: /etc/fstab
-    regexp: "{{ swap_file }}"
-    line: "{{ swap_file }} none swap sw 0 0"
-
-- name: turn on swap
-  become: yes
-  command: swapon -a
-
-- name: set swapiness
-  become: yes
-  sysctl:
-    name: vm.swappiness
-    value: "1"
+- include_tasks: disable_swap.yml
+  when: swap_file_state != 'enabled'
+...


### PR DESCRIPTION
* Fixed cronjob error: `(CRON) bad minute (/etc/cron.d/restart_logind)`
* ```swap``` role:
   * Made all tasks idempotent.
   * Added option to disable swap and remove the swap file.
   * Moved several hard-coded values to defaults.
* Fixed typo in comments in `subgroup_directories/tasks/create_subgroup_directories.yml`
* `MySQL-Python` was installed to late in play: fixes the `The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required.` error.

