### PR TITLE
Updated spacewalk channel for Talos.

### DIFF
--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -4,6 +4,8 @@ slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'tl'
 slurm_version: '18.08.8-1.el7.umcg'
 slurm_allow_jobs_to_span_nodes: true
+rhn_channels:
+  - umcg2020
 mailhub: '172.23.34.34'
 rewrite_domain: "{{ stack_prefix }}-sai{% if slurm_cluster_domain | length %}.{{ slurm_cluster_domain }}{% endif %}"
 figlet_font: 'ogre'


### PR DESCRIPTION
The channel argument does not do anything, but leaving the old value in the group_vars was confusing too.