### PR TITLE
Fix signed host key of docs server.

### DIFF
--- a/group_vars/docs.yml
+++ b/group_vars/docs.yml
@@ -6,4 +6,13 @@ firewall_allowed_tcp_ports:
   - '22'   # SSH
   - '80'   # HTTP
   - '443'  # HTTPS
+extra_jumphosts_for_docs_server:
+  - 'airlock'     # Gearshift
+  - 'reception'   # Talos
+  - 'portal'      # Hyperchicken/Nibbler
+  - 'corridor'    # Fender
+  - 'dockingport' # Marvin
+ssh_host_signer_hostnames: "{{ ansible_fqdn }},{{ ansible_hostname }}\
+    {% for jumphost_for_this_cluster in groups['jumphost'] %},{{ jumphost_for_this_cluster }}+{{ ansible_hostname }}{% endfor %}\
+    {% for extra_jumphost in extra_jumphosts_for_docs_server %},{{ extra_jumphost }}+{{ ansible_hostname }}{% endfor %}"
 ...


### PR DESCRIPTION
Add `jumphost+docs` as valid server names to the signed host key of the `docs` server for all `jumphosts` we use as the `docs` server is shared for all clusters. Without this fix, the host key is resigned for a different `jumphost+docs` combination each time the `ssh_host_signer` role is executed for another cluster, which will then cause issues when trying to deploy the online_docs role for any of the other clusters.