### PR TITLE
Updated sudoers config for Gearshift.

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -143,10 +143,10 @@ regular_users:
     sudoers: '%umcg-atd'
   - user: 'umcg-biogen-dm'
     groups: ['umcg-biogen']
-    sudoers: 'umcg-hwestra,umcg-ndeklein'
+    sudoers: '%umcg-biogen-dms'
   - user: 'umcg-bionic-mdd-gwama-dm'
     groups: ['umcg-bionic-mdd-gwama']
-    sudoers: 'umcg-fhuider,umcg-ifedko'
+    sudoers: '%umcg-bionic-mdd-gwama-dms'
   - user: 'umcg-bios-dm'
     groups: ['umcg-bios']
     sudoers: '%umcg-bios'
@@ -155,10 +155,10 @@ regular_users:
     sudoers: '%umcg-cineca-dms'
   - user: 'umcg-dag3-dm'
     groups: ['umcg-dag3']
-    sudoers: 'umcg-avich,umcg-akurilshchikov,umcg-rgacesa'
+    sudoers: '%umcg-dag3-dms'
   - user: 'umcg-datateam-dm'
     groups: ['umcg-datateam']
-    sudoers: 'umcg-mbijlsma'
+    sudoers: '%umcg-datateam'
   - user: 'umcg-ejp-rd-dm'
     groups: ['umcg-ejp-rd']
     sudoers: '%umcg-ejp-rd-dms'
@@ -188,13 +188,13 @@ regular_users:
     sudoers: '%umcg-gcc'
   - user: 'umcg-gdio-dm'
     groups: ['umcg-gdio']
-    sudoers: 'umcg-cvandiemen'
+    sudoers: '%umcg-gdio-dms'
   - user: 'umcg-gonl-dm'
     groups: ['umcg-gonl']
-    sudoers: 'umcg-pneerincx'
+    sudoers: '%umcg-gonl-dms'
   - user: 'umcg-griac-dm'
     groups: ['umcg-griac']
-    sudoers: 'umcg-cvermeulen,umcg-cxu,umcg-jvnijnatten,umcg-ndijk,umcg-mdevries,umcg-mberg'
+    sudoers: '%umcg-griac-dms'
   - user: 'umcg-gsad-dm'
     groups: ['umcg-gsad']
     sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
@@ -206,13 +206,13 @@ regular_users:
     sudoers: '%umcg-lifelines-dms'
   - user: 'umcg-lld-dm'
     groups: ['umcg-lld']
-    sudoers: 'umcg-hwestra,umcg-hbrugge'
+    sudoers: '%umcg-lld-dms'
   - user: 'umcg-llnext-dm'
     groups: ['umcg-llnext']
-    sudoers: 'umcg-tsinha,umcg-sgarmaeva'
+    sudoers: '%umcg-llnext-dms'
   - user: 'umcg-micompany-dm'
     groups: ['umcg-micompany']
-    sudoers: 'umcg-cxu,umcg-cvermeulen'
+    sudoers: '%umcg-micompany-dms'
   - user: 'umcg-mmbimg-dm'
     groups: ['umcg-mmbimg']
     sudoers: '%umcg-mmbimg-dms'
@@ -221,34 +221,34 @@ regular_users:
     sudoers: '%umcg-msb'
   - user: 'umcg-oncogenetics-dm'
     groups: ['umcg-oncogenetics']
-    sudoers: '%umcg-mterpstra'
+    sudoers: '%umcg-oncogenetics'
   - user: 'umcg-pub-dm'
     groups: ['umcg-pub']
-    sudoers: 'umcg-pneerincx'
+    sudoers: '%umcg-pub-dms'
   - user: 'umcg-radicon-dm'
     groups: ['umcg-radicon']
     sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
   - user: 'umcg-solve-rd-dm'
     groups: ['umcg-solve-rd']
-    sudoers: 'umcg-gvdvries,umcg-mbijlsma,umcg-pneerincx'
+    sudoers: '%umcg-solve-rd-dms'
   - user: 'umcg-tifn-dm'
     groups: ['umcg-tifn']
-    sudoers: 'umcg-akurilshchikov,umcg-jfu'
+    sudoers: '%umcg-tifn-dms'
   - user: 'umcg-ukb-dm'
     groups: ['umcg-ukb']
     sudoers: '%umcg-ukb-dms'
   - user: 'umcg-ugli-dm'
     groups: ['umcg-ugli']
-    sudoers: 'umcg-pdeelen,umcg-mbenjamins,umcg-pneerincx'
+    sudoers: '%umcg-ugli-dms'
   - user: 'umcg-verbeek-dm'
     groups: ['umcg-verbeek']
     sudoers: '%umcg-verbeek'
   - user: 'umcg-weersma-dm'
     groups: ['umcg-weersma']
-    sudoers: 'umcg-avich,umcg-hushixian'
+    sudoers: '%umcg-weersma-dms'
   - user: 'umcg-wijmenga-dm'
     groups: ['umcg-wijmenga']
-    sudoers: 'umcg-jgelderloos,umcg-aclaringbould,umcg-rmodderman,umcg-hwestra,umcg-avich,umcg-obakker,umcg-ddevries'
+    sudoers: '%umcg-wijmenga-dms'
 #
 # Shared storage related variables
 #


### PR DESCRIPTION
After this update most groups will have a setup where:
 * Either members of a `groupname-dms` group for data managers can become the `groupname-dm` user of the corresponding group.
 * All members of the group can become the the `groupname-dm` user.

This allows us to manage who can sudo and who cannot by adding users to or removing users from groups in the account management system. And hence does not require a sys admin to redeploy the `sudoers` role for each and every update.

IDVault entries were already added/updated to work with the changes in this pull request.
