### PR TITLE
Improved rsync handling

### DIFF
--- a/roles/cluster/meta/main.yml
+++ b/roles/cluster/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+    - { role: rsync }
+...

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -50,45 +50,6 @@
     - software
   become: true
 
-- name: Check if rsync >= 3.1.2 is installed on the managed hosts.
-  shell:
-    cmd: |
-      set -o pipefail
-      rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
-  args:
-    warn: no
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: rsync_version_managed_host
-
-- name: Abort when modern rsync >= 3.1.2 is missing on the managed hosts.
-  debug:
-    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version.stdout }}."
-  when:        'rsync_version_managed_host is failed or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))'
-  failed_when: 'rsync_version_managed_host is failed or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))'
-
-- name: Check if rsync >= 3.1.2 is installed on the control host.
-  shell:
-    cmd: |
-      set -o pipefail
-      rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
-  args:
-    warn: no
-  changed_when: false
-  failed_when: false
-  ignore_errors: true
-  check_mode: no
-  register: rsync_version_control_host
-  delegate_to: localhost
-
-- name: Abort when modern rsync >= 3.1.2 is missing on control host.
-  debug:
-    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version.stdout }}."
-  when:        'rsync_version_control_host is failed or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))'
-  failed_when: 'rsync_version_control_host is failed or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))'
-  delegate_to: localhost
-
 - name: Add custom config files to /etc/skel/.
   synchronize:
     src: "{{ playbook_dir }}/roles/cluster/files/skel/./{{ item.src }}"

--- a/roles/figlet_motd/meta/main.yml
+++ b/roles/figlet_motd/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+    - { role: rsync }
+...

--- a/roles/online_docs/meta/main.yml
+++ b/roles/online_docs/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+    - { role: rsync }
+...

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -2,26 +2,6 @@
 # Install webserver and deploy cluster specific documentation on that web server.
 #
 ---
-- name: 'Check if rsync >= 3.1.2 is installed on the control host.'
-  shell:
-    cmd: |
-      set -o pipefail
-      rsync --version  2>&1 | head -n 1 | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|' | tr -d '\n'
-  args:
-    warn: no
-  changed_when: false
-  failed_when: false
-  check_mode: no
-  register: 'rsync_version'
-  delegate_to: 'localhost'
-
-- name: 'Abort when modern rsync >= 3.1.2 is missing on control host.'
-  debug:
-    msg: "FATAL: Need rsync >= 3.1.2 on the control host, but detected {{ rsync_version.stdout }}."
-  when:         'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
-  failed_when: 'rsync_version is failed or (rsync_version.stdout is version_compare("3.1.2", operator="<"))'
-  delegate_to: 'localhost'
-
 - name: 'Check OS version of target host.'
   fail:
     msg: 'This role requires RedHat/CentOS version >= 7.x'

--- a/roles/rsync/tasks/main.yml
+++ b/roles/rsync/tasks/main.yml
@@ -1,0 +1,67 @@
+#
+# Install rsync on managed hosts and verify if rsync on both managed and control hosts meet minimum requirements.
+# This role must be applied before using the Ansible "synchronize" task in other roles.
+#
+# This role should not be confused with the rsyncd role,
+# which configures an rsync deamon on a managed host.
+#
+---
+- name: Install rsync.
+  yum:
+    state: 'latest'
+    update_cache: true
+    name: 'rsync'
+  become: true
+#
+# Check managed hosts.
+#
+- name: Check if rsync >= 3.1.2 is installed on the managed hosts.
+  shell:
+    cmd: |
+      set -o pipefail
+      (trap '' PIPE; rsync --version 2>/dev/null || echo 'missing') \
+          | head -n 1 | tr -d '\n' \
+          | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|'
+  args:
+    warn: no
+  changed_when: false
+  check_mode: no
+  register: rsync_version_managed_host
+
+- name: Abort when modern rsync >= 3.1.2 is missing on the managed hosts.
+  debug:
+    msg: "FATAL: Need rsync >= 3.1.2 on {{ inventory_hostname }}, but detected {{ rsync_version_managed_host.stdout }}."
+  when:        rsync_version_managed_host is failed
+               or rsync_version_managed_host.stdout == 'missing'
+               or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))
+  failed_when: rsync_version_managed_host is failed
+               or rsync_version_managed_host.stdout == 'missing'
+               or (rsync_version_managed_host.stdout is version_compare("3.1.2", operator="<"))
+#
+# Check control host.
+#
+- name: Check if rsync >= 3.1.2 is installed on the control host.
+  shell:
+    cmd: |
+      set -o pipefail
+      (trap '' PIPE; rsync --version 2>/dev/null || echo 'missing') \
+          | head -n 1 | tr -d '\n' \
+          | sed 's|^rsync *version *\([0-9\.]*\).*$|\1|'
+  args:
+    warn: no
+  changed_when: false
+  check_mode: no
+  register: rsync_version_control_host
+  delegate_to: localhost
+
+- name: Abort when modern rsync >= 3.1.2 is missing on control host.
+  debug:
+    msg: "FATAL: Need rsync >= 3.1.2 on control host, but detected {{ rsync_version_control_host.stdout }}."
+  when:        rsync_version_control_host is failed
+               or rsync_version_control_host.stdout == 'missing'
+               or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))
+  failed_when: rsync_version_control_host is failed
+               or rsync_version_control_host.stdout == 'missing'
+               or (rsync_version_control_host.stdout is version_compare("3.1.2", operator="<"))
+  delegate_to: localhost
+...

--- a/roles/rsyncd/tasks/main.yml
+++ b/roles/rsyncd/tasks/main.yml
@@ -5,6 +5,9 @@
 # * Hence there is no systemd managed rsyncd running constantly
 #   and therfore no handler to (re)start a daemon.
 #
+# This role should not be confused with the rsync role, 
+# which configures rsync on a managed host for use with the Ansible "synchronize" task.
+#
 ---
 - name: 'Install rsync.'
   yum:


### PR DESCRIPTION
* Fixed code that checks if working `rsync` version is present on both managed and control hosts:
   * Improved handling of exceptions when `rsync` is not found.  
* Moved code to check for working `rsync` version to separate role to reduce redundancy.
* Made all roles that use the ansible `synchronize` task (and hence which depend on rsync) depend on the new `rsync` role:
   * `cluster`
   * `figlet_motd`
   * `online_docs`