### PR TITLE
Updated CircleCI config for new ansible-linter 5.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install ansible-lint
+            pip install "ansible-lint[community,yamllint]"
       - run:
           name: run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install "ansible-lint[community,yamllint]"
+            ansible-galaxy install -r galaxy-requirements.yml
       - run:
           name: run tests
           command: |


### PR DESCRIPTION
ansible-linter 5.x requires explicit config for which ansible version to install: use latest ansible with community collections and optional yamllint support.