### PR TITLE
Updates for new lobby jumphost

### DIFF
--- a/deploy-os_servers.yml
+++ b/deploy-os_servers.yml
@@ -69,6 +69,8 @@
         dns_nameservers: "{{ nameservers }}"
         wait: true
         timeout: "{{ openstack_api_timeout }}"
+      tags:
+        - never
     - name: "Create {{ network_id_private_storage }} network."
       openstack.cloud.network:
         name: "{{ network_id_private_storage }}"

--- a/group_vars/calculon_cluster/vars.yml
+++ b/group_vars/calculon_cluster/vars.yml
@@ -49,7 +49,7 @@ network_id_public_external: vlan16
 network_id_private_management: internal_management
 network_id_private_storage: internal_storage
 public_ip_addresses:
-  lobby: ''
+  lobby: '195.169.22.135'
 availability_zone: nova
 local_volume_size_vcompute: 1
 local_volume_size_management: 1


### PR DESCRIPTION
* Temporarily added tag to skip task suffering from know bug. Can be removed again once the bug is fixed.
* Added floating IP of new lobby jumphost to group_vars for Calculon.
