### PR TITLE
Fix/synchronize

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,6 @@ E.g. ```19.01.1``` is the first release in January 2019.
 
 We follow the [Python PEP8 naming conventions](https://www.python.org/dev/peps/pep-0008/#naming-conventions) for variable names, function names, etc.
 
-#### Ansible & environment patches
-
-Various parts of the Ansible playbook use rsync to copy data to the target host.
-Unfortunately the Ansible rsync wrapper module contains a few bugs.
-These bugs must be patched on the control host:
-
- - [Bugfix for bug #17492 "Do not prepend PWD when path is in form user@server:path or server:path"](https://github.com/ansible-collections/ansible.posix/pull/118)
- - [Bugfix for bug #24365 "Do not disable SSH connection sharing"](https://github.com/ansible/ansible/pull/41332)
- - Both bugs are in a file named ```synchronize.py```, but one is a _module_ and the other is an _action_ with the same name.
- - On macOS with Ansible installed using HomeBrew you will find these files in:  
-   For Ansible <= 2.9.x:  
-   ```
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible/modules/files/synchronize.py
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible/modules/files/synchronize.py
-   ```
-   For Ansible >= 2.10.x:  
-   ```
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible_collections/ansible/posix/plugins/action/synchronize.py
-   /usr/local/Cellar/ansible/${ansible_version}/libexec/lib/python*/site-packages/ansible_collections/ansible/posix/plugins/modules/synchronize.py
-   ```
-
 ## Clusters
 
 This repo currently contains code and configs for the following clusters:

--- a/galaxy-requirements.yml
+++ b/galaxy-requirements.yml
@@ -10,4 +10,6 @@ roles:
 collections:
   - name: openstack.cloud
     version: '>=1.2.1'
+  - name: ansible.posix
+    version: '>=1.2.0'
 ...

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -51,12 +51,13 @@
   become: true
 
 - name: Add custom config files to /etc/skel/.
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ playbook_dir }}/roles/cluster/files/skel/./{{ item.src }}"
     dest: '/etc/skel/'
     owner: 'no'
     group: 'no'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
       #                   for file systems like NFS mounts that cannot handle setting dir times properly.

--- a/roles/figlet_motd/tasks/main.yml
+++ b/roles/figlet_motd/tasks/main.yml
@@ -7,12 +7,13 @@
   become: true
 
 - name: 'Install custom figlet fonts.'
-  synchronize:
+  ansible.posix.synchronize:
     src: "files/{{ item }}"
     dest: "/usr/share/figlet/{{ item }}"
     owner: false
     group: false
     use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       - '--chmod=Fu=rw,Fgo=r'
       - '--perms'

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -123,12 +123,13 @@
   become: true
 
 - name: 'Create static files for index in document root.'
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ playbook_dir }}/roles/online_docs/files/index//./{{ item.src }}"
     dest: "/var/www/html/"
     owner: 'no'
     group: 'no'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
       #                   for file systems like NFS mounts that cannot handle setting dir times properly.
@@ -167,12 +168,13 @@
   become: true
 
 - name: 'Create static files for MarkDown.'
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ playbook_dir }}/roles/online_docs/files/mkdocs/docs/./{{ item.src }}"
     dest: "/srv/mkdocs/{{ slurm_cluster_name }}/docs/"
     owner: 'no'
     group: 'no'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     rsync_opts:
       # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"
       #                   for file systems like NFS mounts that cannot handle setting dir times properly.
@@ -204,12 +206,13 @@
   become: true
 
 - name: 'Create skeleton for AppleScript apps.'
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ playbook_dir }}/roles/online_docs/files/attachments/{{ item.src }}/./"
     dest: "/srv/mkdocs/{{ slurm_cluster_name }}/tmp/{{ item.dest }}"
     owner: 'no'
     group: 'no'
-    use_ssh_args: 'yes'
+    use_ssh_args: true
+    ssh_connection_multiplexing: true
     recursive: 'yes'
     rsync_opts:
       - '--relative'

--- a/roles/rsync/tasks/main.yml
+++ b/roles/rsync/tasks/main.yml
@@ -1,6 +1,6 @@
 #
 # Install rsync on managed hosts and verify if rsync on both managed and control hosts meet minimum requirements.
-# This role must be applied before using the Ansible "synchronize" task in other roles.
+# This role must be applied before using the Ansible "ansible.posix.synchronize" task in other roles.
 #
 # This role should not be confused with the rsyncd role,
 # which configures an rsync deamon on a managed host.

--- a/roles/rsyncd/tasks/main.yml
+++ b/roles/rsyncd/tasks/main.yml
@@ -6,7 +6,7 @@
 #   and therfore no handler to (re)start a daemon.
 #
 # This role should not be confused with the rsync role, 
-# which configures rsync on a managed host for use with the Ansible "synchronize" task.
+# which configures rsync on a managed host for use with the Ansible "ansible.posix.synchronize" task.
 #
 ---
 - name: 'Install rsync.'


### PR DESCRIPTION
Updated `synchronize` task to `ansible.posix.synchronize`, which includes two bug fixes we now no longer need to patch after each Ansible update.

