### PR TITLE
Fix/ldap

### DIFF
--- a/deploy-os_servers.yml
+++ b/deploy-os_servers.yml
@@ -138,6 +138,16 @@
         remote_ip_prefix: 0.0.0.0/0
         wait: true
         timeout: "{{ openstack_api_timeout }}"
+    - name: "Add rule to {{ slurm_cluster_name }}_jumphosts security group: allow LDAPS inbound on port {{ ldaps_port }}."
+      openstack.cloud.security_group_rule:
+        security_group: "{{ slurm_cluster_name }}_jumphosts"
+        direction: ingress
+        protocol: tcp
+        port_range_min: "{{ ldaps_port }}"
+        port_range_max: "{{ ldaps_port }}"
+        remote_ip_prefix: 0.0.0.0/0  # ToDo restrict to {{ ldap_uri }}
+        wait: true
+        timeout: "{{ openstack_api_timeout }}"
     - name: "Add rule to {{ slurm_cluster_name }}_jumphosts security group: allow ICMP inbound."
       openstack.cloud.security_group_rule:
         security_group: "{{ slurm_cluster_name }}_jumphosts"
@@ -169,6 +179,16 @@
         remote_group: "{{ slurm_cluster_name }}_jumphosts"
         wait: true
         timeout: "{{ openstack_api_timeout }}"
+    - name: "Add rule to {{ slurm_cluster_name }}_cluster security group: allow LDAPS inbound on port {{ ldaps_port }}."
+      openstack.cloud.security_group_rule:
+        security_group: "{{ slurm_cluster_name }}_cluster"
+        direction: ingress
+        protocol: tcp
+        port_range_min: "{{ ldaps_port }}"
+        port_range_max: "{{ ldaps_port }}"
+        remote_ip_prefix: 0.0.0.0/0  # ToDo restrict to {{ ldap_uri }}
+        wait: true
+        timeout: "{{ openstack_api_timeout }}"
     - name: "Add rule to {{ slurm_cluster_name }}_cluster security group: allow ICMP inbound from {{ slurm_cluster_name }}_jumphosts security group."
       openstack.cloud.security_group_rule:
         security_group: "{{ slurm_cluster_name }}_cluster"
@@ -184,7 +204,7 @@
         security_group: "{{ slurm_cluster_name }}_cluster"
         direction: ingress
         protocol: tcp
-        port_range_min: -1  # Pport range min -1 and max -1 means the same as min 1 and max 65535,
+        port_range_min: -1  # Port range min -1 and max -1 means the same as min 1 and max 65535,
         port_range_max: -1  # but the latter is not idempotent due to a known bug.
         remote_group: "{{ slurm_cluster_name }}_cluster"
         wait: true
@@ -194,7 +214,7 @@
         security_group: "{{ slurm_cluster_name }}_cluster"
         direction: ingress
         protocol: udp
-        port_range_min: -1  # Pport range min -1 and max -1 means the same as min 1 and max 65535,
+        port_range_min: -1  # Port range min -1 and max -1 means the same as min 1 and max 65535,
         port_range_max: -1  # but the latter is not idempotent due to a known bug.
         remote_group: "{{ slurm_cluster_name }}_cluster"
         wait: true

--- a/roles/ldap/files/ssh_ldap_wrapper.py
+++ b/roles/ldap/files/ssh_ldap_wrapper.py
@@ -182,7 +182,7 @@ class UserKeys(object):
     @property
     def ldap_keys(self):
         """
-        Retreive the keys from the standard ldap wrapper.
+        Retrieve the keys from the standard ldap wrapper.
 
         Returns:
             str: The keys of a user.

--- a/roles/ldap/templates/ldap.conf
+++ b/roles/ldap/templates/ldap.conf
@@ -2,7 +2,7 @@
 #
 # OpenLDAP client configuration.
 # Do NOT confuse this file with /etc/ldap.conf.
-# See ldap.conf(5) for details.
+# See ssh-ldap.conf(5) for details.
 #
 
 uri {{ ldap_uri }}

--- a/roles/shared_storage/templates/ldapcache.bash
+++ b/roles/shared_storage/templates/ldapcache.bash
@@ -700,13 +700,13 @@ done
 #
 log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "Retrieving data from LDAP..."
 log4Bash 'TRACE' "${LINENO}" "${FUNCNAME:-main}" '0' "ldap_group_quota_fields to retrieve = ${ldap_group_quota_fields}."
-mixed_stdouterr=$(ldapsearch -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
+mixed_stdouterr=$(ldapsearch -LLL -o ldif-wrap=no -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
 					"(ObjectClass=GroupofNames)" ${ldap_group_quota_fields} 2>&1 >"${groups_ldif}") \
 					|| log4Bash 'FATAL' ${LINENO} "${FUNCNAME:-main}" $? "ldapsearch failed."
 
 ldap_user_quota_fields='cn rugpersonUMCGQuotaHome rugpersonUMCGQuotaHomeSoft loginExpirationTime loginDisabled'
 log4Bash 'TRACE' "${LINENO}" "${FUNCNAME:-main}" '0' "ldap_user_quota_fields to retrieve = ${ldap_user_quota_fields}."
-mixed_stdouterr=$(ldapsearch -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
+mixed_stdouterr=$(ldapsearch -LLL -o ldif-wrap=no -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
 					"(ObjectClass=person)" ${ldap_user_quota_fields} 2>&1 > "${users_ldif}") \
 					|| log4Bash 'FATAL' ${LINENO} "${FUNCNAME:-main}" $? "ldapsearch failed."
 log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "ldapsearch results were saved to ${groups_ldif} and ${users_ldif}."
@@ -764,11 +764,11 @@ if [ ! -z "${backup_dir:-}" ]; then
 	#
 	BACKUP_TS=`date "+%Y-%m-%d-T%H%M"`
 	log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "Retrieving data from LDAP for backup..."
-	mixed_stdouterr=$(ldapsearch -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
+	mixed_stdouterr=$(ldapsearch -o ldif-wrap=no -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
 					"(ObjectClass=GroupofNames)" 2>&1 >"${backup_dir}/groups-${BACKUP_TS}.ldif") \
 						|| log4Bash 'FATAL' ${LINENO} "${FUNCNAME:-main}" $? "ldapsearch failed."
 	
-	mixed_stdouterr=$(ldapsearch -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
+	mixed_stdouterr=$(ldapsearch -o ldif-wrap=no -LLL -D "${LDAP_USER}" -w "${LDAP_PASS}" -b "${LDAP_SEARCH_BASE}" \
 					"(ObjectClass=person)" 2>&1 > "${backup_dir}/users-${BACKUP_TS}.ldif") \
 						|| log4Bash 'FATAL' ${LINENO} "${FUNCNAME:-main}" $? "ldapsearch failed."
 	log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME:-main}" '0' "ldapsearch results for backup were saved to ${groups_ldif} and ${users_ldif}."

--- a/roles/subgroup_directories/tasks/create_subgroup_directories.yml
+++ b/roles/subgroup_directories/tasks/create_subgroup_directories.yml
@@ -2,7 +2,7 @@
 - block:
     - name: "Get list of {{ group }} subgroups with version number from the LDAP."
       shell: |
-        ldapsearch -LLL -D '{{ ldap_binddn }}' -w '{{ bindpw }}' -b '{{ ldap_base }}' -H '{{ ldap_uri }}' \
+        ldapsearch -LLL -o ldif-wrap=no -D '{{ ldap_binddn }}' -w '{{ bindpw }}' -b '{{ ldap_base }}' -H '{{ ldap_uri }}' \
             "(ObjectClass=GroupofNames)" dn \
           | tr "=," "\n" \
           | grep "^{{ group }}-.*-v[0-9][0-9]*$" \
@@ -14,7 +14,7 @@
 - block:
     - name: "Get list of {{ group }} subgroups without version number and excluding *-dms groups from the LDAP."
       shell: |
-        ldapsearch -LLL -D '{{ ldap_binddn }}' -w '{{ bindpw }}' -b '{{ ldap_base }}' -H '{{ ldap_uri }}' \
+        ldapsearch -LLL -o ldif-wrap=no -D '{{ ldap_binddn }}' -w '{{ bindpw }}' -b '{{ ldap_base }}' -H '{{ ldap_uri }}' \
             "(ObjectClass=GroupofNames)" dn \
           | tr "=," "\n" \
           | grep "^{{ group }}-.*$" \


### PR DESCRIPTION
* Added `-o ldif-wrap=no` option to `ldapsearch` commands to prevent line wrapping and make it easier to parse the query results.
* Fixed typos in comments.
* Added security rule to allow inbound LDAPS traffic.
