### PR TITLE
Disable PID files for all Slurm daemons.

### DIFF
--- a/roles/slurm_client/tasks/main.yml
+++ b/roles/slurm_client/tasks/main.yml
@@ -59,11 +59,12 @@
     - 'restart_slurmd'
   become: true
 
-- name: 'Patch slurm daemon systemd service files to use custom sub dir for PID files.'
+# See: https://bugs.schedmd.com/show_bug.cgi?id=8388
+- name: 'Patch slurm daemon systemd service files to disable PID files.'
   lineinfile:
     path: "/usr/lib/systemd/system/{{ item }}.service"
-    regexp: '^PIDFile='
-    line: "PIDFile=/var/run/slurm/{{ item }}.pid"
+    regexp: '^#?PIDFile='
+    line: "#PIDFile=/var/run/slurm/{{ item }}.pid"
     owner: root
     group: root
     mode: '0644'

--- a/roles/slurm_management/tasks/main.yml
+++ b/roles/slurm_management/tasks/main.yml
@@ -99,11 +99,12 @@
     - 'restart_slurmctld'
   become: true
 
-- name: 'Patch slurm daemon systemd service files to use custom sub dir for PID files.'
+# See: https://bugs.schedmd.com/show_bug.cgi?id=8388
+- name: 'Patch slurm daemon systemd service files to disable PID files.'
   lineinfile:
     path: "/usr/lib/systemd/system/{{ item }}.service"
-    regexp: '^PIDFile='
-    line: "PIDFile=/var/run/slurm/{{ item }}.pid"
+    regexp: '^#?PIDFile='
+    line: "#PIDFile=/var/run/slurm/{{ item }}.pid"
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
Let systemd automagically detect the PID of any running Slurm daemons as that is more robust. Sometimes the PID files are not written (yet) or get lost resulting in failures when trying to (re)start Slurm daemons.