### PR TITLE
Create prm, tmp and rsc mounts for umcg-sysops group

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -123,6 +123,7 @@ regular_groups:
   - 'umcg-pub'
   - 'umcg-radicon'
   - 'umcg-solve-rd'
+  - 'umcg-sysops'
   - 'umcg-tifn'
   - 'umcg-ukb'
   - 'umcg-ugli'
@@ -235,6 +236,9 @@ regular_users:
   - user: 'umcg-solve-rd-dm'
     groups: ['umcg-solve-rd']
     sudoers: '%umcg-solve-rd-dms'
+  - user: 'umcg-sysops-dm'
+    groups: ['umcg-sysops']
+    sudoers: '%umcg-sysops'
   - user: 'umcg-tifn-dm'
     groups: ['umcg-tifn']
     sudoers: '%umcg-tifn-dms'
@@ -290,7 +294,7 @@ lfs_mounts: [
         'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
         'umcg-griac', 'umcg-gsad', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
         'umcg-llnext', 'umcg-micompany', 'umcg-mmbimg', 'umcg-msb', 'umcg-oncogenetics',
-        'umcg-pub', 'umcg-radicon', 'umcg-solve-rd', 'umcg-tifn', 'umcg-ukb', 'umcg-ugli',
+        'umcg-pub', 'umcg-radicon', 'umcg-solve-rd', 'umcg-sysops', 'umcg-tifn', 'umcg-ukb', 'umcg-ugli',
         'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
       ]},
   { lfs: 'prm01',
@@ -306,13 +310,13 @@ lfs_mounts: [
         'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
         'umcg-griac', 'umcg-gsad', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
         'umcg-llnext', 'umcg-micompany', 'umcg-mmbimg', 'umcg-msb', 'umcg-oncogenetics',
-        'umcg-pub', 'umcg-radicon', 'umcg-solve-rd', 'umcg-tifn', 'umcg-ukb', 'umcg-ugli',
+        'umcg-pub', 'umcg-radicon', 'umcg-solve-rd', 'umcg-sysops', 'umcg-tifn', 'umcg-ukb', 'umcg-ugli',
         'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
       ]},
   { lfs: 'rsc01',
     pfs: 'umcgst03',
     groups: [
-        'umcg-atd', 'umcg-solve-rd'
+        'umcg-atd', 'umcg-solve-rd', 'umcg-sysops'
       ]},
   { lfs: 'env01',
     pfs: 'umcgst10',

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -96,6 +96,7 @@ regular_groups:
   - 'umcg-endocrinology'
   - 'umcg-gcc'
   - 'umcg-lifelines'
+  - 'umcg-sysops'
 regular_users:
   - user: 'umcg-atd-ateambot'
     groups: ['umcg-atd']
@@ -112,6 +113,9 @@ regular_users:
   - user: 'umcg-lifelines-dm'
     groups: ['umcg-lifelines']
     sudoers: '%umcg-lifelines-dms'
+  - user: 'umcg-sysops-dm'
+    groups: ['umcg-sysops']
+    sudoers: '%umcg-sysops'
 #
 # Shared storage related variables
 #
@@ -129,13 +133,13 @@ lfs_mounts: [
     machines: "{{ groups['cluster'] }}" },
   { lfs: 'tmp08',
     pfs: 'umcgst11',
-    groups: ['umcg-atd', 'umcg-endocrinology', 'umcg-gcc', 'umcg-lifelines'] },
+    groups: ['umcg-atd', 'umcg-endocrinology', 'umcg-gcc', 'umcg-lifelines', 'umcg-sysops'] },
   { lfs: 'rsc08',
     pfs: 'umcgst11',
-    groups: ['umcg-atd', 'umcg-lifelines'] },
+    groups: ['umcg-atd', 'umcg-lifelines', 'umcg-sysops'] },
   { lfs: 'prm08',
     pfs: 'umcgst11',
-    groups: ['umcg-atd', 'umcg-gcc', 'umcg-lifelines', 'umcg-solve-rd'] },
+    groups: ['umcg-atd', 'umcg-gcc', 'umcg-lifelines', 'umcg-solve-rd', 'umcg-sysops'] },
   { lfs: 'env08',
     pfs: 'umcgst11',
     machines: "{{ groups['compute_vm'] + groups['user_interface'] }}" },


### PR DESCRIPTION
Allow sysops to test cluster functionality without requiring access to data from other groups.