### PR TITLE
Fix/mkdocs

### DIFF
--- a/roles/online_docs/defaults/main.yml
+++ b/roles/online_docs/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+external_hrefs:
+  spacewalk: 'https://spacewalkproject.github.io/'
+  pulp: 'https://pulpproject.org/'
+...

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -2,39 +2,6 @@
 # Install webserver and deploy cluster specific documentation on that web server.
 #
 ---
-- name: "Find all ip_addresses.yml files in {{ playbook_dir }}/group_vars/*."
-  find:
-    paths: "{{ playbook_dir }}/group_vars/"
-    recurse: true
-    patterns: 'ip_addresses.yml'
-  register: ip_addresses_files
-  delegate_to: localhost
-
-- name: 'Include variables from all ip_addresses.yml files.'
-  include_vars:
-    file: "{{ item }}"
-    #name: "networking_lookup.{{ item | dirname | basename }}"
-    name: "networking_lookup"
-  with_items: "{{ ip_addresses_files.files | map (attribute='path') | list }}"
-  register: networking_lookups
-  delegate_to: localhost
-
-- name: Debug1
-  debug:
-    msg: "{{ networking_lookups.results }}"
-
-- name: Combine configs into one dict
-  set_fact:
-    #networking_lookups: "{{ dict(networking_lookups.results | json_query('[].[item, ansible_facts.networking_lookup]')) }}"
-    networking_lookups: "{{ networking_lookups.results | json_query('[].[ansible_facts.networking_lookup.ip_addresses][][][][]') }}"
-  delegate_to: localhost
-
-- name: Debug2
-  debug:
-    msg: "{{ networking_lookups.[groups['docs'] | first | regex_replace('^' + ai_jumphost + '\\+','')].fqdn }}"
-
-
-
 - name: 'Check OS version of target host.'
   fail:
     msg: 'This role requires RedHat/CentOS version >= 7.x'
@@ -92,6 +59,28 @@
   failed_when: false
   check_mode: false
   register: 'lmod_version'
+
+- name: "Find all ip_addresses.yml files in {{ playbook_dir }}/group_vars/*."
+  find:
+    paths: "{{ playbook_dir }}/group_vars/"
+    recurse: true
+    patterns: 'ip_addresses.yml'
+  register: ip_addresses_files
+  delegate_to: localhost
+
+- name: 'Include variables from all ip_addresses.yml files.'
+  include_vars:
+    file: "{{ item }}"
+    #name: "networking_lookup.{{ item | dirname | basename }}"
+    name: "networking_lookup"
+  with_items: "{{ ip_addresses_files.files | map (attribute='path') | list }}"
+  register: networking_lookups
+  delegate_to: localhost
+
+- name: 'Combine network info from ip_addresses.yml files into one dict.'
+  set_fact:
+    networking_lookups: "{{ networking_lookups.results | json_query('[].ansible_facts.networking_lookup.ip_addresses') | combine() }}"
+  delegate_to: localhost
 
 - name: 'Set selinux in permissive mode.'
   selinux:

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -2,6 +2,39 @@
 # Install webserver and deploy cluster specific documentation on that web server.
 #
 ---
+- name: "Find all ip_addresses.yml files in {{ playbook_dir }}/group_vars/*."
+  find:
+    paths: "{{ playbook_dir }}/group_vars/"
+    recurse: true
+    patterns: 'ip_addresses.yml'
+  register: ip_addresses_files
+  delegate_to: localhost
+
+- name: 'Include variables from all ip_addresses.yml files.'
+  include_vars:
+    file: "{{ item }}"
+    #name: "networking_lookup.{{ item | dirname | basename }}"
+    name: "networking_lookup"
+  with_items: "{{ ip_addresses_files.files | map (attribute='path') | list }}"
+  register: networking_lookups
+  delegate_to: localhost
+
+- name: Debug1
+  debug:
+    msg: "{{ networking_lookups.results }}"
+
+- name: Combine configs into one dict
+  set_fact:
+    #networking_lookups: "{{ dict(networking_lookups.results | json_query('[].[item, ansible_facts.networking_lookup]')) }}"
+    networking_lookups: "{{ networking_lookups.results | json_query('[].[ansible_facts.networking_lookup.ip_addresses][][][][]') }}"
+  delegate_to: localhost
+
+- name: Debug2
+  debug:
+    msg: "{{ networking_lookups.[groups['docs'] | first | regex_replace('^' + ai_jumphost + '\\+','')].fqdn }}"
+
+
+
 - name: 'Check OS version of target host.'
   fail:
     msg: 'This role requires RedHat/CentOS version >= 7.x'

--- a/roles/online_docs/tasks/main.yml
+++ b/roles/online_docs/tasks/main.yml
@@ -71,7 +71,6 @@
 - name: 'Include variables from all ip_addresses.yml files.'
   include_vars:
     file: "{{ item }}"
-    #name: "networking_lookup.{{ item | dirname | basename }}"
     name: "networking_lookup"
   with_items: "{{ ip_addresses_files.files | map (attribute='path') | list }}"
   register: networking_lookups

--- a/roles/online_docs/templates/mkdocs/docs/cluster.md
+++ b/roles/online_docs/templates/mkdocs/docs/cluster.md
@@ -10,7 +10,7 @@ The jobs are submitted to a workload manager, which distributes them efficiently
 
 The key features of the {{ slurm_cluster_name | capitalize }} cluster include:
 
- * Linux OS: [CentOS](https://www.centos.org/) 7.x with [Spacewalk](https://spacewalkproject.github.io/) for package distribution/management.
+ * Linux OS: [CentOS](https://www.centos.org/) 7.x with [{{ repo_manager | capitalize }}]({{ external_hrefs[repo_manager] }}) for package distribution/management.
  * Completely virtualised on an [OpenStack](https://www.openstack.org/) cloud
  * Deployment of HPC cluster with [Ansible playbooks](https://docs.ansible.com/ansible/latest/index.html) under version control in a Git repo: [league-of-robots](https://github.com/rug-cit-hpc/league-of-robots)
  * Job scheduling: [Slurm Workload Manager](https://slurm.schedmd.com/)

--- a/roles/online_docs/templates/mkdocs/docs/specifications.md
+++ b/roles/online_docs/templates/mkdocs/docs/specifications.md
@@ -5,7 +5,7 @@
 
 Key ingredients of the High Performance Computing (HPC) environment of the {{ slurm_cluster_name | capitalize }} cluster
 
- * Linux OS: [CentOS](https://www.centos.org/) {{ hostvars[groups['user_interface'][0]]['ansible_distribution_version'] }} with [Spacewalk](https://spacewalkproject.github.io/) for package distribution/management.
+ * Linux OS: [CentOS](https://www.centos.org/) {{ hostvars[groups['user_interface'][0]]['ansible_distribution_version'] }} with [{{ repo_manager | capitalize }}]({{ external_hrefs[repo_manager] }}) for package distribution/management.
  * Job scheduling: [Slurm Workload Manager](https://slurm.schedmd.com/) {{ slurm_version.stdout }}
  * Module system: [Lmod](https://github.com/TACC/Lmod) {{ lmod_version.stdout }}
  * Deployment of (Bioinformatics) software: [EasyBuild](https://github.com/easybuilders/easybuild)

--- a/roles/online_docs/templates/mkdocs/mkdocs.yml
+++ b/roles/online_docs/templates/mkdocs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: "{{ slurm_cluster_name | capitalize }} HPC cluster"
-site_url: "http://{{ ip_addresses[groups['docs'] | first | regex_replace('^' + ai_jumphost + '\\+','')].fqdn }}/{{ slurm_cluster_name }}/"
+site_url: "http://{{ networking_lookups[groups['docs'] | first | regex_replace('^' + ai_jumphost + '\\+','')].fqdn }}/{{ slurm_cluster_name }}/"
 use_directory_urls: true
 theme:
   name: readthedocs

--- a/roles/online_docs/templates/mkdocs/mkdocs.yml
+++ b/roles/online_docs/templates/mkdocs/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: "{{ slurm_cluster_name | capitalize }} HPC cluster"
+site_url: "http://{{ ip_addresses[groups['docs'] | first | regex_replace('^' + ai_jumphost + '\\+','')].fqdn }}/{{ slurm_cluster_name }}/"
+use_directory_urls: true
 theme:
   name: readthedocs
   highlightjs: false


### PR DESCRIPTION
* Bugfix for broken URLs in the online documentation due to update with backward incompatible changes in `mkdocs`
* Report repo manager used for a cluster based on a variable as opposed to using hardcoded Spacewalk.