### PR TITLE
Added the upgrade of pip, the installation of wheel and the installation of ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ source openstacksdk.venv/bin/activate
 #
 # Install OpenStack SDK (once) and other python packages.
 #
+pip3 install --upgrade pip
+pip3 install wheel
 pip3 install openstacksdk
 pip3 install ruamel.yaml
+pip3 install ansible
 ```
 
 #### 1. First import the required roles and collections for the playbooks:


### PR DESCRIPTION
The upgrade of pip and the installation of wheel prevent issues with the installation of the later packages.
The installation of ansible was missing from the documentation, but is required to actually run the playbooks.