### PR TITLE
The import from test.test_sax fails after following the instructions.

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -55,7 +55,6 @@ except ImportError:
 import os
 import re
 import sys
-from test.test_sax import start
 if sys.version_info >= (3,2,0):
     from configparser import ConfigParser
 elif sys.version_info >= (3,0,0):


### PR DESCRIPTION
The import from test.test_sax fails after following the instructions. Since the start function is not used it can be removed.