### PR TITLE
Bugfix for chrooted rsync

### DIFF
--- a/roles/rsyncd/templates/rsyncd_data_transfer_only_group.conf
+++ b/roles/rsyncd/templates/rsyncd_data_transfer_only_group.conf
@@ -27,7 +27,7 @@ incoming chmod = Du=rwx,Dg=rsx,Fu=rw,Fg=r,o-rwx
 outgoing chmod = o-rwx
 
 [home]
-	path = /groups/{{ data_transfer_only_group }}/%RSYNC_USER_NAME%/
+	path = /groups/{{ data_transfer_only_group }}/%USER%/
 	read only = false
 	munge symlinks = no
 

--- a/roles/sshd/templates/sshd_config
+++ b/roles/sshd/templates/sshd_config
@@ -155,9 +155,11 @@ Match Group {{ data_transfer_only_group }} LocalPort 22
 Match Group *,!admin,!{{ data_transfer_only_group }} LocalPort 443
     AllowAgentForwarding no
     AllowTcpForwarding no
+    PermitTTY no
     ForceCommand /bin/rsync --server --daemon --config=/etc/rsyncd_all_groups.conf .
 Match Group {{ data_transfer_only_group }} LocalPort 443
     AllowAgentForwarding no
     AllowTcpForwarding no
+    PermitTTY no
     ForceCommand /bin/rsync --server --daemon --config=/etc/rsyncd_data_transfer_only_group.conf .
 {% endif %}


### PR DESCRIPTION
* `roles/rsyncd/templates/rsyncd_data_transfer_only_group.conf`: replaced `%RSYNC_USER_NAME%` variable, which remains empty in our setup, with `%USER%` variable, which does work.