### PR TITLE
Fixed config files for LDAP client

### DIFF
--- a/roles/ldap/templates/nslcd.conf
+++ b/roles/ldap/templates/nslcd.conf
@@ -1,6 +1,10 @@
 uid nslcd
 gid ldap
+{% if 'ldap://' in ldap_uri %}
+ssl off
+{% else %}
 ssl on
+{% endif %}
 tls_cacertfile /etc/pki/tls/certs/ca-bundle.crt
 uri {{ ldap_uri }}
 base {{ ldap_base }}

--- a/roles/ldap/templates/ssh-ldap.conf
+++ b/roles/ldap/templates/ssh-ldap.conf
@@ -7,7 +7,11 @@
 
 uri {{ ldap_uri }}
 base {{ ldap_base }}
+{% if 'ldap://' in ldap_uri %}
+ssl no
+{% else %}
 ssl yes
+{% endif %}
 tls_cacertfile /etc/pki/tls/certs/ca-bundle.crt
 binddn {{ ldap_binddn }}
 bindpw {{ bindpw }}


### PR DESCRIPTION
Do not enforce SSL when URI contains `ldap://` as opposed to `ldaps://`.