### PR TITLE
Feature: case insensitive slurm accounts

### DIFF
--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -30,20 +30,20 @@ additional_etc_hosts:
       - calculon-management
       - calculon-storage
 vcompute_hostnames: "{{ stack_prefix }}-vcompute[01-03]"
-vcompute_sockets: 4
+vcompute_sockets: 8
 vcompute_cores_per_socket: 1
-vcompute_real_memory: 3790
+vcompute_real_memory: 15884
 vcompute_max_cpus_per_node: "{{ vcompute_sockets * vcompute_cores_per_socket - 2 }}"
 vcompute_max_mem_per_node: "{{ vcompute_real_memory - vcompute_sockets * vcompute_cores_per_socket * 512 }}"
-vcompute_local_disk: 270000
+vcompute_local_disk: 975
 vcompute_features: 'tmp02'
 vcompute_ethernet_interfaces:
   - 'eth0'
   - 'eth1'
 ui_hostnames: "{{ slurm_cluster_name }}"
-ui_sockets: 4
+ui_sockets: 8
 ui_cores_per_socket: 1
-ui_real_memory: 3790
+ui_real_memory: 15884
 ui_local_disk: 0
 ui_features: 'prm02,tmp02'
 ui_ethernet_interfaces:

--- a/roles/slurm_management/files/slurm.taskprolog
+++ b/roles/slurm_management/files/slurm.taskprolog
@@ -13,7 +13,7 @@ set -u
 
 #
 # Make sure we have a tmp dir in /local on compute nodes.
-# When this failed the job should not continue as SLURM will default to /tmp,
+# When this fails, the job should not continue as SLURM will default to /tmp,
 # which is not suitable for heavy random IO nor large data sets.
 # Hammering /tmp may effectively result in the node going down.
 # When the prolog fails the node will be set to state=DRAIN instead.

--- a/roles/slurm_management/templates/slurm.conf
+++ b/roles/slurm_management/templates/slurm.conf
@@ -131,8 +131,8 @@ HealthCheckInterval=300
 # Partitions
 #
 EnforcePartLimits=YES
-PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and true %}{{ groups['compute_vm']|list|length }}{% else %}1{% endif %} MaxTime=7-00:00:01
-PartitionName=regular Default=YES MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and true %}{{ groups['compute_vm']|list|length }}{% else %}1{% endif %} Nodes={{ vcompute_hostnames }} MaxCPUsPerNode={{ vcompute_max_cpus_per_node }} MaxMemPerNode={{ vcompute_max_mem_per_node }} TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long
+PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['compute_vm']|list|length }}{% else %}1{% endif %} MaxTime=7-00:00:01
+PartitionName=regular Default=YES MaxNodes={% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['compute_vm']|list|length }}{% else %}1{% endif %} Nodes={{ vcompute_hostnames }} MaxCPUsPerNode={{ vcompute_max_cpus_per_node }} MaxMemPerNode={{ vcompute_max_mem_per_node }} TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long
 PartitionName=ds      Default=No  MaxNodes=1 Nodes={{ ui_hostnames }} MaxCPUsPerNode=1 MaxMemPerNode=1024 TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long
 #
 # COMPUTE NODES

--- a/roles/slurm_management/templates/slurmdbd.conf
+++ b/roles/slurm_management/templates/slurmdbd.conf
@@ -25,3 +25,4 @@ StoragePass={{ slurm_storage_pass }}
 StorageType=accounting_storage/mysql
 StorageUser={{ slurm_storage_user }}
 StorageLoc={{ slurm_database_name }}
+Parameters=PreserveCaseUser


### PR DESCRIPTION
Feature: Make Slurm accounts case insensitive in preparation for account names based on email addresses from _**SURF SRAM**_, which may contain uppercase characters.

Some additional bugfixes, which were required to test the feature above on _Nibbler_:
* Fixed wrong values for resources of _Nibbler_ compute nodes.
* Fixed typo in comment in `slurm.taskprolog`.
* Fixed bug in jinja expression to check for `slurm_allow_jobs_to_span_nodes` in `slurm.conf`.