### PR TITLE
Added info for new tl-repo and gs-repo machines for Pulp.

### DIFF
--- a/group_vars/gearshift_cluster/ip_addresses.yml
+++ b/group_vars/gearshift_cluster/ip_addresses.yml
@@ -12,6 +12,12 @@ ip_addresses:
     vlan: vlan983
     fqdn:
     desc: Sys Admin Interface
+  gs-repo:
+    addr: 172.23.40.98
+    mask: /32
+    vlan: vlan983
+    fqdn:
+    desc: Repository Management
   gs-vcompute10:
     addr: 172.23.40.90
     mask: /32

--- a/group_vars/nibbler_cluster/ip_addresses.yml
+++ b/group_vars/nibbler_cluster/ip_addresses.yml
@@ -5,6 +5,7 @@ ip_addresses:
     mask: /32
     vlan: internal_management
     fqdn:
+    desc: Data Transfer
   irods-test:
     addr: 10.10.1.182
     mask: /32
@@ -20,6 +21,7 @@ ip_addresses:
     mask: /32
     vlan: internal_management
     fqdn:
+    desc: Repository Management
   nb-sai:
     addr: 10.10.1.106
     mask: /32

--- a/group_vars/talos_cluster/ip_addresses.yml
+++ b/group_vars/talos_cluster/ip_addresses.yml
@@ -1,5 +1,11 @@
 ---
 ip_addresses:
+  tl-repo:
+    addr: 172.23.40.99
+    mask: /32
+    vlan: vlan983
+    fqdn:
+    desc: Repository Management
   tl-dai:
     addr: 172.23.40.94
     mask: /32

--- a/group_vars/template/ip_addresses.yml.j2
+++ b/group_vars/template/ip_addresses.yml.j2
@@ -9,6 +9,10 @@ ip_addresses:
     fqdn:
     {% if server_info.name in groups['jumphost']%}
     desc: Jumphost
+    {% elif server_info.name in groups['repo']%}
+    desc: Repository Management
+    {% elif server_info.name in groups['data_transfer']%}
+    desc: Data Transfer
     {% elif server_info.name in groups['sys_admin_interface']%}
     desc: Sys Admin Interface
     {% elif server_info.name in groups['deploy_admin_interface']%}

--- a/static_inventories/gearshift_hosts.ini
+++ b/static_inventories/gearshift_hosts.ini
@@ -1,6 +1,9 @@
 [jumphost]
 airlock
 
+[repo]
+gs-repo
+
 [docs]
 docs
 
@@ -26,6 +29,7 @@ compute_vm
 administration
 
 [gearshift_cluster:children]
-cluster
 jumphost
+repo
+cluster
 docs

--- a/static_inventories/talos_hosts.ini
+++ b/static_inventories/talos_hosts.ini
@@ -1,6 +1,9 @@
 [jumphost]
 reception
 
+[repo]
+tl-repo
+
 [docs]
 docs
 
@@ -27,5 +30,6 @@ administration
 
 [talos_cluster:children]
 jumphost
+repo
 cluster
 docs


### PR DESCRIPTION
* Added info for new `tl-repo` and `gs-repo` machines for Pulp.
* Added missing `desc` keys to several `ip_addresses.yml` files as well as to the template in `group_vars/template/ip_addresses.yml.j21`