### PR TITLE
Temporarily relocated EGA Fuse client mounts prm03 -> prm02

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -351,7 +351,7 @@ lfs_mounts: [
     machines: "{{ groups['compute_vm'] + groups['user_interface'] }}" },
 ]
 ega_fuse_client_mounts:
-  cineca: '/groups/umcg-cineca/prm03/ega-fuse-client'
-  solve_rd: '/groups/umcg-solve-rd/prm03/ega-fuse-client'
+  cineca: '/groups/umcg-cineca/prm02/ega-fuse-client'
+  solve_rd: '/groups/umcg-solve-rd/prm02/ega-fuse-client'
 ega_fuse_client_java_home: '/apps/software/AdoptOpenJDK/8u222b10-hotspot'
 ...


### PR DESCRIPTION
Because the issues with prm03 will take more time to resolve we temporarily relocate the EGA Fuse client mounts to prm02. (They do not work when prm03 is read-only.)