### PR TITLE
Feature/extra groups on nibbler

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -30,7 +30,7 @@ public_keys_of_local_admins: "{{ local_admin_users | map('extract', auth_users) 
 #
 # Local group specs.
 # Note:
-#  *  all local groups are listed here.
+#  * All local groups are listed here.
 #  * In ../[name]_cluster/vars.yml we list which groups are created locally on which cluster.
 #  * Never ever change nor recycle a GID value here unless you are in for a surprise...
 #
@@ -47,6 +47,8 @@ auth_groups:
     gid: 20004
   umcg-atd:
     gid: 20005
+  funad:
+    gid: 20006
 #
 # Default for a group of users that are only allowd to transfer data.
 # Is used by the sshd role and listed in

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -77,15 +77,17 @@ local_admin_users:
   - 'wim'
 envsync_user: 'envsync'
 envsync_group: 'depad'
+functional_admin_group: 'funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'users'
-  - 'depad'
   - 'solve-rd'
   - 'umcg-atd'
 regular_users:
-  - user: 'envsync'
-    groups: ['depad']
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'solve-rd-dm'
     groups: ['solve-rd']
     sudoers: '%solve-rd'
@@ -96,21 +98,21 @@ regular_users:
     groups: ['solve-rd']
     sudoers: '%solve-rd'
   - user: 'gvdvries'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'mbijlsma'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'mswertz'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'pneerincx'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'rkanninga'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'ljohansson'
-    groups: ['users', 'depad','umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'ddanis'
     groups: ['users', 'solve-rd']
   - user: 'dhendriksen'
-    groups: ['users', 'solve-rd', 'depad']
+    groups: ['users', "{{ envsync_group }}", 'solve-rd']
   - user: 'ksablauskas'
     groups: ['users', 'solve-rd']
   - user: 'wsteyaert'
@@ -132,7 +134,7 @@ regular_users:
   - user: 'cthomas'
     groups: ['users', 'solve-rd']
   - user: 'mbenjamins'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'lmatalonga'
     groups: ['users', 'solve-rd']
   - user: 'gbullich'
@@ -140,9 +142,9 @@ regular_users:
   - user: 'ebenetti'
     groups: ['users', 'solve-rd']
   - user: 'kdelange'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'scimerman'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'sli'
     groups: ['users', 'solve-rd']
   - user: 'rschuele'
@@ -188,7 +190,7 @@ regular_users:
   - user: 'byaldiz'
     groups: ['users', 'solve-rd']
   - user: 'bcharbon'
-    groups: ['users', 'depad', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'solve-rd']
   - user: 'amaver'
     groups: ['users', 'solve-rd']
   - user: 'cgilissen'

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -63,7 +63,6 @@ ldap_group_quota_hard_limit_template: 'ruggroupumcgquotaLFS'
 filter_passwd: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'
 filter_shadow: '(|(rugpersonentitlementvalue=scz)(rugpersonentitlementvalue=umcg))'
 pam_authz_search: '(|(&(objectClass=posixGroup)(cn=co_bbmri_g-GRP_Gearshift)(memberUid=$username))(&(cn=$username)(rugpersonentitlementvalue=umcg)))'
-data_transfer_only_group: umcg-sftp-only
 nameservers: [
   '172.23.40.244', # Order is important: local DNS for Isilon storage first!
   '8.8.4.4',       # Google DNS.
@@ -86,11 +85,15 @@ local_admin_users:
   - 'marlies'
   - 'robin'
   - 'wim'
+data_transfer_only_group: umcg-sftp-only
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ data_transfer_only_group }}"
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'umcg-aad'
   - 'umcg-as'
   - 'umcg-atd'
@@ -100,7 +103,6 @@ regular_groups:
   - 'umcg-cineca'
   - 'umcg-dag3'
   - 'umcg-datateam'
-  - 'umcg-depad'
   - 'umcg-ejp-rd'
   - 'umcg-endocrinology'
   - 'umcg-franke-scrna'
@@ -134,6 +136,8 @@ regular_groups:
   - 'umcg-weersma'
   - 'umcg-wijmenga'
 regular_users:
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'umcg-aad-dm'
     groups: ['umcg-aad']
     sudoers: '%umcg-aad'

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -77,15 +77,17 @@ local_admin_users:
   - 'wim'
 envsync_user: 'envsync'
 envsync_group: 'depad'
+functional_admin_group: 'funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'users'
-  - 'depad'
   - 'solve-rd'
   - 'umcg-atd'
 regular_users:
-  - user: 'envsync'
-    groups: ['depad']
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'solve-rd-dm'
     groups: ['solve-rd']
     sudoers: '%solve-rd'
@@ -93,17 +95,17 @@ regular_users:
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'
   - user: 'gvdvries'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'mbijlsma'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'mswertz'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'pneerincx'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'rkanninga'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
   - user: 'scimerman'
-    groups: ['users', 'depad', 'umcg-atd', 'solve-rd']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'solve-rd']
 #
 # Shared storage related variables
 #

--- a/group_vars/marvin_cluster/vars.yml
+++ b/group_vars/marvin_cluster/vars.yml
@@ -64,8 +64,6 @@ nameservers: [
 local_admin_groups:
   - 'admin'
   - 'docker'
-  - 'umcg-atd'
-  - 'depad'
 local_admin_users:
   - 'egon'
   - 'gerben'
@@ -75,47 +73,43 @@ local_admin_users:
   - 'morris'
   - 'pieter'
   - 'wim'
-  - 'umcg-atd-dm'
-  - 'envsync'
 envsync_user: 'envsync'
 envsync_group: 'depad'
+functional_admin_group: 'funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'users'
-  - 'depad'
   - 'erknet'
   - 'euro-nmd'
   - 'ern-liver'
   - 'umcg-atd'
 regular_users:
-  - user: 'envsync'
-    groups: ['depad']
-
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'erknet-dm'
     groups: ['erknet']
     sudoers: '%erknet'
-
   - user: 'euro-nmd-dm'
     groups: ['euro-nmd']
     sudoers: '%euro-nmd'
-
   - user: 'ern-liver-dm'
     groups: ['ern-liver']
     sudoers: '%ern-liver'
-
   - user: 'umcg-atd-dm'
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'
   - user: 'gvdvries'
-    groups: ['users', 'depad', 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
   - user: 'mbijlsma'
-    groups: ['users', 'depad', 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
   - user: 'mswertz'
-    groups: ['users', 'depad', 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
   - user: 'pneerincx'
-    groups: ['users', 'depad', 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
   - user: 'rkanninga'
-    groups: ['users', 'depad', 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
+    groups: ['users', "{{ envsync_group }}", 'umcg-atd', 'erknet', 'euro-nmd','ern-liver']
   - user: 'umcg-atd-dm'
     groups: ['users', 'umcg-atd']
     sudoers: 'pieter,gerben'

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -59,7 +59,6 @@ ldap_binddn: 'cn=clusteradminumcg,o=asds'
 ldap_group_object_class: 'groupofnames'
 ldap_group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
 ldap_group_quota_hard_limit_template: 'ruggroupumcgquotaLFS'
-data_transfer_only_group: umcg-sftp-only
 cloud_image: CentOS 7
 cloud_user: centos
 flavor_jumphost: m1.small
@@ -106,36 +105,224 @@ local_admin_users:
   - 'robin'
   - 'sandi'
   - 'wim'
+data_transfer_only_group: 'umcg-sftp-only'
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
 hpc_env_prefix: '/apps'
 regular_groups:
-  - 'umcg-atd'
-  - 'umcg-depad'
-  - 'umcg-gcc'
-  - 'umcg-lifelines'
   - "{{ data_transfer_only_group }}"
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
+  - 'umcg-aad'
+  - 'umcg-as'
+  - 'umcg-atd'
+  - 'umcg-biogen'
+  - 'umcg-bionic-mdd-gwama'
+  - 'umcg-bios'
+  - 'umcg-cineca'
+  - 'umcg-dag3'
+  - 'umcg-datateam'
+  - 'umcg-ejp-rd'
+  - 'umcg-endocrinology'
+  - 'umcg-franke-scrna'
+  - 'umcg-gaf'
+  - 'umcg-gap'
+  - 'umcg-gastrocol'
+  - 'umcg-gcc'
+  - 'umcg-gdio'
+  - 'umcg-gonl'
+  - 'umcg-griac'
+  - 'umcg-gsad'
+  - 'umcg-hematology'
+  - 'umcg-impact'
+  - 'umcg-lifelines'
+  - 'umcg-lld'
+  - 'umcg-llnext'
+  - 'umcg-micompany'
+  - 'umcg-mmbimg'
+  - 'umcg-msb'
+  - 'umcg-oncogenetics'
+  - 'umcg-pmb'
+  - 'umcg-pub'
+  - 'umcg-radicon'
+  - 'umcg-rehabilitation'
+  - 'umcg-solve-rd'
+  - 'umcg-sysops'
+  - 'umcg-tifn'
+  - 'umcg-ukb'
+  - 'umcg-ugli'
+  - 'umcg-verbeek'
+  - 'umcg-weersma'
+  - 'umcg-wijmenga'
 regular_users:
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
+  - user: 'umcg-aad-dm'
+    groups: ['umcg-aad']
+    sudoers: '%umcg-aad'
+  - user: 'umcg-capicebot'
+    groups: ['umcg-as']
+    sudoers: '%umcg-as'
+  - user: 'umcg-as-dm'
+    groups: ['umcg-as']
+    sudoers: '%umcg-as'
   - user: 'umcg-atd-ateambot'
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'
   - user: 'umcg-atd-dm'
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'
+  - user: 'umcg-biogen-dm'
+    groups: ['umcg-biogen']
+    sudoers: '%umcg-biogen-dms'
+  - user: 'umcg-bionic-mdd-gwama-dm'
+    groups: ['umcg-bionic-mdd-gwama']
+    sudoers: '%umcg-bionic-mdd-gwama-dms'
+  - user: 'umcg-bios-dm'
+    groups: ['umcg-bios']
+    sudoers: '%umcg-bios'
+  - user: 'umcg-cineca-dm'
+    groups: ['umcg-cineca']
+    sudoers: '%umcg-cineca-dms'
+  - user: 'umcg-dag3-dm'
+    groups: ['umcg-dag3']
+    sudoers: '%umcg-dag3-dms'
+  - user: 'umcg-datateam-dm'
+    groups: ['umcg-datateam']
+    sudoers: '%umcg-datateam'
+  - user: 'umcg-ejp-rd-dm'
+    groups: ['umcg-ejp-rd']
+    sudoers: '%umcg-ejp-rd-dms'
+  - user: 'umcg-endocrinology-dm'
+    groups: ['umcg-endocrinology']
+    sudoers: '%umcg-endocrinology-dms'
+  - user: 'umcg-franke-scrna-dm'
+    groups: ['umcg-franke-scrna']
+    sudoers: '%umcg-franke-scrna-dms'
+  - user: 'umcg-gaf-ateambot'
+    groups: ['umcg-gaf']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gaf-dm'
+    groups: ['umcg-gaf']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gap-ateambot'
+    groups: ['umcg-gap']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gap-dm'
+    groups: ['umcg-gap']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-gastrocol-dm'
+    groups: ['umcg-gastrocol']
+    sudoers: '%umcg-gastrocol-dms'
   - user: 'umcg-gcc-dm'
     groups: ['umcg-gcc']
     sudoers: '%umcg-gcc'
+  - user: 'umcg-gdio-dm'
+    groups: ['umcg-gdio']
+    sudoers: '%umcg-gdio-dms'
+  - user: 'umcg-gonl-dm'
+    groups: ['umcg-gonl']
+    sudoers: '%umcg-gonl-dms'
+  - user: 'umcg-griac-dm'
+    groups: ['umcg-griac']
+    sudoers: '%umcg-griac-dms'
+  - user: 'umcg-gsad-dm'
+    groups: ['umcg-gsad']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-hematology-dm'
+    groups: ['umcg-hematology']
+    sudoers: '%umcg-hematology-dms'
+  - user: 'umcg-impact-dm'
+    groups: ['umcg-impact']
+    sudoers: '%umcg-impact'
   - user: 'umcg-lifelines-dm'
     groups: ['umcg-lifelines']
     sudoers: '%umcg-lifelines-dms'
+  - user: 'umcg-lld-dm'
+    groups: ['umcg-lld']
+    sudoers: '%umcg-lld-dms'
+  - user: 'umcg-llnext-dm'
+    groups: ['umcg-llnext']
+    sudoers: '%umcg-llnext-dms'
+  - user: 'umcg-micompany-dm'
+    groups: ['umcg-micompany']
+    sudoers: '%umcg-micompany-dms'
+  - user: 'umcg-mmbimg-dm'
+    groups: ['umcg-mmbimg']
+    sudoers: '%umcg-mmbimg-dms'
+  - user: 'umcg-msb-dm'
+    groups: ['umcg-msb']
+    sudoers: '%umcg-msb'
+  - user: 'umcg-oncogenetics-dm'
+    groups: ['umcg-oncogenetics']
+    sudoers: '%umcg-oncogenetics'
+  - user: 'umcg-pmb-dm'
+    groups: ['umcg-pmb']
+    sudoers: '%umcg-pmb-dms'
+  - user: 'umcg-pub-dm'
+    groups: ['umcg-pub']
+    sudoers: '%umcg-pub-dms'
+  - user: 'umcg-radicon-dm'
+    groups: ['umcg-radicon']
+    sudoers: 'umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga'
+  - user: 'umcg-rehabilitation-dm'
+    groups: ['umcg-rehabilitation']
+    sudoers: '%umcg-rehabilitation-dms'
+  - user: 'umcg-solve-rd-dm'
+    groups: ['umcg-solve-rd']
+    sudoers: '%umcg-solve-rd-dms'
+  - user: 'umcg-sysops-dm'
+    groups: ['umcg-sysops']
+    sudoers: '%umcg-sysops'
+  - user: 'umcg-tifn-dm'
+    groups: ['umcg-tifn']
+    sudoers: '%umcg-tifn-dms'
+  - user: 'umcg-ukb-dm'
+    groups: ['umcg-ukb']
+    sudoers: '%umcg-ukb-dms'
+  - user: 'umcg-ugli-dm'
+    groups: ['umcg-ugli']
+    sudoers: '%umcg-ugli-dms'
+  - user: 'umcg-verbeek-dm'
+    groups: ['umcg-verbeek']
+    sudoers: '%umcg-verbeek'
+  - user: 'umcg-weersma-dm'
+    groups: ['umcg-weersma']
+    sudoers: '%umcg-weersma-dms'
+  - user: 'umcg-wijmenga-dm'
+    groups: ['umcg-wijmenga']
+    sudoers: '%umcg-wijmenga-dms'
+#
+# Local storage variables.
+#
+volume_group_folders: [
+  { mount_point: '/groups',
+    machines: "{{ groups['data_transfer'] }}",
+    mode: '2750',
+    groups: [
+        "{{ data_transfer_only_group }}"
+      ]},
+  { mount_point: '/groups',
+    machines: "{{ groups['data_transfer'] }}",
+    mode: '2770',
+    groups: [
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama',
+        'umcg-bios', 'umcg-cineca', 'umcg-dag3', 'umcg-datateam', 'umcg-ejp-rd', 'umcg-endocrinology', 'umcg-franke-scrna',
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
+        'umcg-griac', 'umcg-gsad', 'umcg-hematology', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
+        'umcg-llnext', 'umcg-micompany', 'umcg-mmbimg', 'umcg-msb', 'umcg-oncogenetics',
+        'umcg-pmb', 'umcg-pub', 'umcg-radicon', 'umcg-rehabilitation', 'umcg-solve-rd', 'umcg-sysops', 'umcg-tifn', 'umcg-ukb',
+        'umcg-ugli', 'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
+      ]},
+]
 #
 # Shared storage related variables
 #
 lustre_client_networks: 'tcp11(vlan???.lustre),tcp12(vlan???.lustre)'
 pfs_mounts: [
   { pfs: 'umcgst01',
-    source: '172.23.57.201@tcp11:172.23.57.202@tcp11:/dh1',
+    #source: '172.23.57.201@tcp11:172.23.57.202@tcp11:/dh1',
     type: 'lustre',
     rw_options: 'defaults,_netdev,flock',
     ro_options: 'defaults,_netdev,ro' },
@@ -146,10 +333,26 @@ lfs_mounts: [
     machines: "{{ groups['cluster'] }}" },
   { lfs: 'tmp02',
     pfs: 'xyz',
-    groups: ['umcg-atd', 'umcg-gcc', 'umcg-lifelines'] },
+    groups: [
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama',
+        'umcg-bios', 'umcg-cineca', 'umcg-dag3', 'umcg-datateam', 'umcg-ejp-rd', 'umcg-endocrinology', 'umcg-franke-scrna',
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
+        'umcg-griac', 'umcg-gsad', 'umcg-hematology', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
+        'umcg-llnext', 'umcg-micompany', 'umcg-mmbimg', 'umcg-msb', 'umcg-oncogenetics',
+        'umcg-pmb', 'umcg-pub', 'umcg-radicon', 'umcg-rehabilitation', 'umcg-solve-rd', 'umcg-sysops', 'umcg-tifn', 'umcg-ukb',
+        'umcg-ugli', 'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
+      ]},
   { lfs: 'prm02',
     pfs: 'umcgst01',
-    groups: ['umcg-atd', 'umcg-gcc', 'umcg-lifelines'] },
+    groups: [
+        'umcg-aad', 'umcg-as', 'umcg-atd', 'umcg-biogen', 'umcg-bionic-mdd-gwama',
+        'umcg-bios', 'umcg-cineca', 'umcg-dag3', 'umcg-datateam', 'umcg-ejp-rd', 'umcg-endocrinology', 'umcg-franke-scrna',
+        'umcg-gaf', 'umcg-gap', 'umcg-gastrocol', 'umcg-gcc', 'umcg-gdio', 'umcg-gonl',
+        'umcg-griac', 'umcg-gsad', 'umcg-hematology', 'umcg-impact', 'umcg-lifelines', 'umcg-lld',
+        'umcg-llnext', 'umcg-micompany', 'umcg-mmbimg', 'umcg-msb', 'umcg-oncogenetics',
+        'umcg-pmb', 'umcg-pub', 'umcg-radicon', 'umcg-rehabilitation', 'umcg-solve-rd', 'umcg-sysops', 'umcg-tifn', 'umcg-ukb',
+        'umcg-ugli', 'umcg-verbeek', 'umcg-weersma', 'umcg-wijmenga'
+      ]},
   { lfs: 'env02',
     pfs: 'xyz',
     machines: "{{ groups['compute_vm'] + groups['user_interface'] }}" },

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -61,7 +61,6 @@ ldap_binddn: 'cn=clusteradminumcg,o=asds'
 ldap_group_object_class: 'groupofnames'
 ldap_group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
 ldap_group_quota_hard_limit_template: 'ruggroupumcgquotaLFS'
-data_transfer_only_group: umcg-sftp-only
 nameservers: [
   '/gcc-storage001.stor.hpc.local/172.23.40.244',  # Local DNS lookups for shared storage.
   '8.8.4.4',  # Google DNS.
@@ -85,18 +84,23 @@ local_admin_users:
   - 'robin'
   - 'sandi'
   - 'wim'
+data_transfer_only_group: 'umcg-sftp-only'
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ data_transfer_only_group }}"
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'umcg-atd'
-  - 'umcg-depad'
   - 'umcg-endocrinology'
   - 'umcg-gcc'
   - 'umcg-lifelines'
   - 'umcg-sysops'
 regular_users:
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'umcg-atd-ateambot'
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -43,7 +43,6 @@ ldap_binddn: 'cn=clusteradminGD,o=asds'
 ldap_group_object_class: 'groupofnames'
 ldap_group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
 ldap_group_quota_hard_limit_template: 'ruggroupumcgquotaLFS'
-data_transfer_only_group: umcg-sftp-only
 cloud_image: CentOS 7
 cloud_user: centos
 flavor_jumphost: m1.small
@@ -86,13 +85,15 @@ local_admin_users:
   - 'robin'
   - 'sandi'
   - 'wim'
+data_transfer_only_group: 'umcg-sftp-only'
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
 hpc_env_prefix: '/apps'
 regular_groups:
+  - "{{ envsync_group }}"
+  - "{{ functional_admin_group }}"
   - 'umcg-atd'
-  - 'umcg-depad'
   - 'umcg-gcc'
   - 'umcg-gap'
   - 'umcg-gd'
@@ -101,6 +102,8 @@ regular_groups:
   - 'umcg-gst'
   - 'umcg-vipt'
 regular_users:
+  - user: "{{ envsync_user }}"
+    groups: ["{{ envsync_group }}"]
   - user: 'umcg-atd-ateambot'
     groups: ['umcg-atd']
     sudoers: '%umcg-atd'

--- a/roles/mount_volume/tasks/create_group_folders.yml
+++ b/roles/mount_volume/tasks/create_group_folders.yml
@@ -1,25 +1,13 @@
 ---
-- name: 'Create folder for each group.'
+- name: Create group folders in {{ mount_point }} with mode {{ mode }}.
   file:
-    path: "/groups/{{ group }}"
+    path: "/groups/{{ folder }}"
     owner: 'root'
-    group: "{{ group }}"
-    mode: '2750'
+    group: "{{ folder }}"
+    mode: "{{ mode }}"
     state: 'directory'
-  loop: "{{ regular_groups }}"
+  loop: "{{ folders }}"
   loop_control:
-    loop_var: group
-  become: true
-
-- name: 'Create folder for each group.'
-  file:
-    path: "/groups/{{ group }}"
-    owner: 'root'
-    group: "{{ group }}"
-    mode: "{% if data_transfer_only_group is defined and data_transfer_only_group == group %}2750{% else %}2770{% endif %}"
-    state: 'directory'
-  loop: "{{ regular_groups }}"
-  loop_control:
-    loop_var: group
+    loop_var: folder
   become: true
 ...

--- a/roles/mount_volume/tasks/main.yml
+++ b/roles/mount_volume/tasks/main.yml
@@ -57,10 +57,16 @@
   become: true
   loop: "{{ mount_point_status.results }}"
 
-- name: 'Create group folders on volume.'
+- name: 'Create group folders on volumes.'
   include_tasks:
     file: create_group_folders.yml
+  vars:
+    mount_point: "{{ item.1.mount_point }}"
+    folders: "{{ item.1.groups | list }}"
+    mode: "{{ item.1.mode }}"
   when:
-    - item.mount_point == '/groups'
-  loop: "{{ volumes }}"
+    - volume_group_folders is defined
+    - item.0.mount_point == item.1.mount_point
+    - inventory_hostname in item.1.machines
+  loop: "{{ volumes | product(volume_group_folders) | list }}"
 ...


### PR DESCRIPTION
* _Nibbler_ group vars: commented `source` (dh1 lustre) for `pfs` 'umcgst01' to prevent mounting it already, which would be prematurely. This file is not ready yet for use with Nibbler.
* Bugfix: removed non-admin groups and users from list of admin groups and users on Marvin.
* Bugfix: Replaced several hard coded group and user names with variables where possible for several clusters.
* Bugfix: Added missing groups and users on Nibbler.
* Bugfix: Added missing gid for funad group in `group_vars/all/vars.yml`.
* Bugfix: Improved creation of group folders on local volumes. Use dedicated variable to indicate which group folders should be created on which local volumes on which machines as opposed to simply using the list of all regular groups, which would create the required folders, but may also create unnecessary/unwanted folders in other places.


