### PR TITLE
Updates for DNS entries for Nibbler.

### DIFF
--- a/group_vars/nibbler_cluster/ip_addresses.yml
+++ b/group_vars/nibbler_cluster/ip_addresses.yml
@@ -1,6 +1,6 @@
 ---
 ip_addresses:
-  nb-dt:
+  nb-transfer:
     addr: 10.10.1.28
     mask: /32
     vlan: internal_management

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -1,6 +1,6 @@
 ---
 slurm_cluster_name: 'nibbler'
-slurm_cluster_domain: ''  # Only add hpc.rug.nl domain when jumphost is registered in DNS.
+slurm_cluster_domain: 'hpc.rug.nl'
 stack_prefix: 'nb'
 slurm_version: '20.11.8-1.el7.umcg'
 repo_manager: 'pulp'
@@ -95,9 +95,6 @@ network_private_management_cidr: '10.10.1.0/24'
 network_private_management_gw: '10.10.1.1'
 network_private_storage_id: internal_storage
 network_private_storage_cidr: '10.10.2.0/24'
-public_ip_addresses:
-  tunnel: '195.169.22.136'
-  nb-dt: '195.169.22.166'
 availability_zone: nova
 local_volume_size_ds: 10000
 local_volume_size_repo: 20

--- a/roles/online_docs/templates/mkdocs/docs/dedicated-dt-server-overview.md
+++ b/roles/online_docs/templates/mkdocs/docs/dedicated-dt-server-overview.md
@@ -1,8 +1,9 @@
 #jinja2: trim_blocks:False
 # Data transfers - How to move data to / from the dedicated data transfer server
 
-Firstly and independent of technical options: make sure you are familiar with the _code of conduct_ / _terms and conditions_ / _license_ or whatever it is called and that you are allowed to upload/download a data set!
-When in doubt contact your supervisor / principal investigator and the group/institute that created the data set.
+Firstly and independent of technical options: make sure you are familiar with the _code of conduct_ / _terms and conditions_ / _license_ or whatever it is called
+and that you are allowed to upload / download a data set!
+When in doubt contact your supervisor / principal investigator and the group / institute that created the data set.
 
 The {{ slurm_cluster_name | capitalize }} HPC cluster features a dedicated data transfer server _{{ dt_server_address }}_,
 which can be used to exchange data with external collaborators,

--- a/static_inventories/nibbler_hosts.ini
+++ b/static_inventories/nibbler_hosts.ini
@@ -8,7 +8,7 @@ tunnel
 nb-repo
 
 [data_transfer]
-nb-dt
+nb-transfer
 
 [irods]
 irods-catalogus


### PR DESCRIPTION
* The _Nibbler_ jumphost and dedicated data transfer server now use DNS entries.
* This has already been deployed by re-running the `ssh_host_signer` and `online_docs roles`