### PR TITLE
Hostnames change: cluster playbook - when hostnames are defined, the …

### DIFF
--- a/group_vars/irods.yml
+++ b/group_vars/irods.yml
@@ -1,10 +1,11 @@
 ---
-firewall_allowed_tcp_ports:
+irods_icat_fqdn: "umcg-icat01.hpc.rug.nl"   # fqdn of iCAT server
+firewall_allowed_tcp_ports:                 # list of open ports on iCAT server
   - "22"    # SSH.
   - "1247"  # irods
   - "20000:20199"  # irods
 irods_ssl_certificate_chain_file: "localhost_and_chain_umcg-icat01.crt"
 irods_ssl_certificate_key_file: "localhost-umcg01.key"
 irods_ssl_dh_params_file: "dhparams.pem"
-irods_zone: 'nlumcg'
+irods_zone: 'nlumcg'                        # default main iRODS zone name
 ...

--- a/group_vars/nibbler_cluster/ip_addresses.yml
+++ b/group_vars/nibbler_cluster/ip_addresses.yml
@@ -10,12 +10,12 @@ ip_addresses:
     addr: 10.10.1.182
     mask: /32
     vlan: internal_management
-    fqdn: umcg-icat01.hpc.rug.nl
+    fqdn:
   irods-catalogus:
     addr: 10.10.1.121
     mask: /32
     vlan: internal_management
-    fqdn: umcg-icat01.hpc.rug.nl
+    fqdn:
   nb-repo:
     addr: 10.10.1.56
     mask: /32

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Set hostname to inventory_hostname
-  hostname:
-    name: "{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}"
-  become: true
-
 - name: Set selinux in permissive mode
   selinux:
     policy: targeted

--- a/roles/irods/vars/main.yml
+++ b/roles/irods/vars/main.yml
@@ -1,8 +1,9 @@
 #Default iRODS setup info
-server_type: 'icat'                                         #iRODS Server Type
-irods_service_account: 'irods'                              #serviceaccount
-irods_admin_account: 'rods'                                 #rods admin account
-irods_vault: ''                                             #iRODS resource vault path
-irods_db_server: '127.0.0.1'                                #iRODS Database Server
-irods_db_name: 'ICAT'                                       #iRODS Database Name
-irods_db_user: 'irods'                                     #iRODS Database Username
+server_type: 'icat'                       #iRODS Server Type
+irods_icat_fqdn: ''                       #fqdn of the iCAT server
+irods_service_account: 'irods'            #serviceaccount
+irods_admin_account: 'rods'               #rods admin account
+irods_vault: ''                           #iRODS resource vault path
+irods_db_server: '127.0.0.1'              #iRODS Database Server
+irods_db_name: 'ICAT'                     #iRODS Database Name
+irods_db_user: 'irods'                    #iRODS Database Username

--- a/roles/ssh_host_signer/tasks/main.yml
+++ b/roles/ssh_host_signer/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 - name: 'Set hostname to inventory_hostname.'
   hostname:
-    name: "{% if groups['irods'] is defined and inventory_hostname in groups['irods'] and irods_icat_fqdn is defined and irods_icat_fqdn|length %}{{ irods_icat_fqdn }}{% else %}{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}{% endif %}"
+    name: "{%- if groups['irods'] is defined and inventory_hostname in groups['irods'] and
+            irods_icat_fqdn is defined and irods_icat_fqdn|length -%}{{ irods_icat_fqdn }}
+          {%- else -%}{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}{%- endif -%}"
   become: true
 
 - name: 'Find SSH host keys.'

--- a/roles/ssh_host_signer/tasks/main.yml
+++ b/roles/ssh_host_signer/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Set hostname to inventory_hostname.'
   hostname:
-    name: "{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}"
+    name: "{% if groups['irods'] is defined and inventory_hostname in groups['irods'] and irods_icat_fqdn is defined and irods_icat_fqdn|length %}{{ irods_icat_fqdn }}{% else %}{{ inventory_hostname | regex_replace('^' + ai_jumphost + '\\+','') }}{% endif %}"
   become: true
 
 - name: 'Find SSH host keys.'


### PR DESCRIPTION
…irods should have fqdn

The issue:
we need the hostname to be a short name of the machine. The FQDN is not used within the virtual network and most of the machines don't have set one. The iRODS machines on the other hand need to have hostname exactly the same as their FQDN. The playbooks need to work for with regular clusters and with the iRODS server. At the same time, it was pointed out that the task is done twice, and should be in the `ssh_host_signer` only.

Fix was tested on the `irods-test` (iRODS type of server) and `hc-vcompute01` (non-iRODS type of server). Test was:
1. first I changed the hostname on machine
2. comment everything in the  `single_group_playbooks/cluster_part1.yml` except ssh_host_signer and rerun the playbook

- [x] it worked on both machines 