### PR TITLE
Updated Circle CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,17 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python:3
+      - image: cimg/python
     working_directory: ~/repo
     resource_class: small
     steps:
       - checkout
+      - run: python --version
+      - run: pip --version
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             pip install "ansible-lint[community,yamllint]"
             ansible-galaxy install -r galaxy-requirements.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python
+      - image: cimg/python:3.10
     working_directory: ~/repo
     resource_class: small
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     docker:
       - image: circleci/python:3
     working_directory: ~/repo
+    resource_class: small
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3
+      - image: cimg/python:3
     working_directory: ~/repo
     resource_class: small
     steps:


### PR DESCRIPTION
* Do not waste resources on Circle CI: downgraded to single core image as test code is single threaded and cannot use additional cores.
* Updated to new Circle CI "convenience image" for Python. (The previously used "legacy" image will be deprecated on 2021-12-31.)