### PR TITLE
[Inclomplete]: Changed to new lustre configuration syntax.

### DIFF
--- a/roles/lustre_client/templates/lustre.conf
+++ b/roles/lustre_client/templates/lustre.conf
@@ -1,1 +1,0 @@
-options lnet networks={{ lustre_client_networks }}


### PR DESCRIPTION
Datahandling 4 is now mounted on gs-vcompute01

This was done by installing the packages build by whamcloud by hand. These should be included in pulp We did not need to build any packages.  So perhaps we can omit the build dependencies.

The packages can be found here:
https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client/RPMS/x86_64/

The manual command used was:
yum --disablerepo=* reinstall lustre-client-2.12.8_6_g5457c37-1.el7.x86_64.rpm kmod-lustre-client-2.12.8_6_g5457c37-1.el7.x86_64.rpm

Mounting can be done like so. As you can se, the group mounts have not yet been changed,
172.23.57.213@tcp14:172.23.57.214@tcp14:/umcg /mnt/ lustre  defaults,_netdev,flock  0 0