### PR TITLE
Improved Java for EGA Fuse client

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -362,5 +362,5 @@ lfs_mounts: [
 ega_fuse_client_mounts:
   cineca: '/groups/umcg-cineca/prm02/ega-fuse-client'
   solve_rd: '/groups/umcg-solve-rd/prm02/ega-fuse-client'
-ega_fuse_client_java_home: '/apps/software/AdoptOpenJDK/8u222b10-hotspot'
+ega_fuse_client_java_home: '/etc/alternatives/jre_11_openjdk'
 ...

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -162,7 +162,7 @@ lfs_mounts: [
 ega_fuse_client_mounts:
   cineca: '/groups/umcg-cineca/prm08/ega-fuse-client'
   solve_rd: '/groups/umcg-solve-rd/prm08/ega-fuse-client'
-ega_fuse_client_java_home: '/apps/software/AdoptOpenJDK/8u222b10-hotspot'
+ega_fuse_client_java_home: '/etc/alternatives/jre_11_openjdk'
 iptables_allow_icmp_inbound:
   - 'umcg_net1'
   - 'umcg_net2'

--- a/roles/ega_fuse_client/tasks/main.yml
+++ b/roles/ega_fuse_client/tasks/main.yml
@@ -6,6 +6,7 @@
       - fuse
       - fuse-libs
       - ega-fuse-client
+      - java-11-openjdk
   become: true
   notify: restart_ega-fuse-client
 


### PR DESCRIPTION
Fix: use normal Java dependency from Linux distro/OS as opposed to hacky one from /apps, which may not be there yet. Was previously already implemented for Hyperchicken and Fender. Now also enabled for Talos and Gearshift now that they also get their repos from a local Pulp server.