### PR TITLE
Changed Ansible "default" to OpenSSH default SSH ControlPath

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,7 +18,7 @@ inventory_plugins = inventory_plugins
 
 [ssh_connection]
 pipelining = True
-ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o PreferredAuthentications=publickey,keyboard-interactive
+ssh_args = -C -o ControlPath='~/.ssh/tmp/%C' -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o PreferredAuthentications=publickey,keyboard-interactive
 
 [inventory]
 enable_plugins = yaml_with_jumphost


### PR DESCRIPTION
For proper re-use of sockets for SSH connection multiplexing.