### PR TITLE
Removed ACCRUE_ALWAYS PriorityFlag for Slurm scheduler.

### DIFF
--- a/roles/slurm_management/templates/slurm.conf
+++ b/roles/slurm_management/templates/slurm.conf
@@ -79,7 +79,7 @@ PriorityWeightJobSize=0
 PriorityWeightPartition=0
 PriorityWeightQOS=1000000
 PriorityMaxAge=14-0
-PriorityFlags=ACCRUE_ALWAYS,FAIR_TREE,MAX_TRES
+PriorityFlags=FAIR_TREE,MAX_TRES
 PreemptType=preempt/qos
 PreemptMode=REQUEUE
 #


### PR DESCRIPTION
This means jobs that were submitted, but are not eligible for scheduling due to an unsatisfied dependency, will not accumulate "wait time" for the `Age` job priority factor. In other words, only jobs that can start immediately and are waiting for resources to become available will accrue "wait time" resulting in a higher weight for the `Age` factor of their priority. With `ACCRUE_ALWAYS` enabled workflow management systems like NextFlow that use "just in time" job submission would be penalized compared to others that just submit all jobs (including ones with dependencies on other jobs) for an entire workflow at once.