### PR TITLE
Fix permissions for "releases" and "projects" folder when a group uses sub groups.

### DIFF
--- a/roles/subgroup_directories/tasks/create_subgroup_directories.yml
+++ b/roles/subgroup_directories/tasks/create_subgroup_directories.yml
@@ -30,7 +30,7 @@
         path: "/groups/{{ group }}/{{ lfs }}/releases/"
         owner: "{{ group }}-dm"
         group: "{{ group }}"
-        mode: "{{ mode_dataset }}"
+        mode: '2750'
         state: 'directory'
     - name: "Create /groups/{{ group }}/{{ lfs }}/releases/${dataset} directory."
       ansible.builtin.file:
@@ -63,7 +63,7 @@
         path: "/groups/{{ group }}/{{ lfs }}/projects/"
         owner: "{{ group }}-dm"
         group: "{{ group }}"
-        mode: "{{ mode_project }}"
+        mode: '2750'
         state: 'directory'
     - name: "Create /groups/{{ group }}/{{ lfs }}/projects/${project} directory."
       ansible.builtin.file:


### PR DESCRIPTION
Enforce write permission in the `releases` and `projects` folder only for the functional data manager accounts.