### PR TITLE
Refactored subgroup_directories role to remove redundant tasks and improve speed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ pip3 install ruamel.yaml
 # E.g. with HomeBrew on macOS, with yum or dnf on Linux, etc.
 #
 pip3 install ansible
+#
+# Optional: install Mitogen with pip.
+# Mitogen provides an optional strategy plugin that makes playbooks a lot (up to 7 times!) faster.
+# See https://mitogen.networkgenomics.com/ansible_detailed.html
+#
+pip3 install mitogen
 ```
 
 #### 1. First import the required roles and collections for the playbooks:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,13 @@ retry_files_enabled = False
 stdout_callback = community.general.yaml
 timeout = 30
 inventory_plugins = inventory_plugins
+
+#
+# Do not define strategy_plugins path here as we cannot dynamically determine Python major.minor version numbers.
+# We define ANSIBLE_STRATEGY_PLUGINS in lor-init instead:
+#	export ANSIBLE_STRATEGY_PLUGINS=$(ls -d *.venv/lib/python*/site-packages/ansible_mitogen/plugins/strategy | sort -V | tail -1)
+#
+
 #
 # Do not use a hard-code vault_password_file file here:
 # we have multiple .vault_pass.txt.${stack_name} files with specific passwords for each stack.

--- a/lor-init
+++ b/lor-init
@@ -73,8 +73,21 @@ function lor-config() {
 	export AI_PROXY="${_jumphost}"
 	export ANSIBLE_INVENTORY="static_inventories/${_stack_name}.yml"
 	export ANSIBLE_VAULT_IDENTITY_LIST="all@.vault/vault_pass.txt.all, ${_stack_name}@.vault/vault_pass.txt.${_stack_name}"
-	printf '%s\n' "Current working directory is $(pwd)"
-	printf '%s\n' "Using AI_PROXY:                    ${AI_PROXY}"
-	printf '%s\n' "Using ANSIBLE_INVENTORY:           ${ANSIBLE_INVENTORY}"
-	printf '%s\n' "Using ANSIBLE_VAULT_IDENTITY_LIST: ${ANSIBLE_VAULT_IDENTITY_LIST}"
+	printf 'INFO: Current working directory is:      %s\n' "$(pwd)"
+	printf 'INFO: Using AI_PROXY:                    %s\n' "${AI_PROXY}"
+	printf 'INFO: Using ANSIBLE_INVENTORY:           %s\n' "${ANSIBLE_INVENTORY}"
+	printf 'INFO: Using ANSIBLE_VAULT_IDENTITY_LIST: %s\n' "${ANSIBLE_VAULT_IDENTITY_LIST}"
+	#
+	# Enable ansible_mitogen strategy plugin for improved speed of plays when available.
+	#
+	_ansible_mitogen_search_path='.*/lib/python.*/site-packages/ansible_mitogen/plugins/strategy'
+	if find . -regex "${_ansible_mitogen_search_path}" 1>/dev/null; then
+		export ANSIBLE_STRATEGY_PLUGINS=$(find . -regex "${_ansible_mitogen_search_path}" | sort -V | tail -1)
+		export ANSIBLE_STRATEGY='mitogen_linear'
+		printf 'INFO: Found Mitogen strategy plugin in:  %s\n' "${ANSIBLE_STRATEGY_PLUGINS}"
+		printf 'INFO: Using Ansible strategy:            %s.\n' "${ANSIBLE_STRATEGY}"
+	else
+		printf 'WARNING: Could not find Mitogen strategy plugin in %s\n' "${_ansible_mitogen_search_path}"
+		printf 'INFO: Mitogen strategy plugin is:        %s.\n' 'disabled (default)'
+	fi
 }

--- a/roles/subgroup_directories/tasks/create_subgroup_directories.yml
+++ b/roles/subgroup_directories/tasks/create_subgroup_directories.yml
@@ -1,81 +1,57 @@
 ---
-- block:
-    - name: "Get list of {{ group }} subgroups with version number."
-      ansible.builtin.shell: |
-        getent group \
-          | grep -o "^{{ group }}-[^:]*-v[0-9][0-9]*" \
-          || true
-      changed_when: false
-      register: versioned_subgroups
-    - ansible.builtin.set_fact:  # noqa unnamed-task
-        versioned_subgroups_list: "{% if versioned_subgroups.stdout | length %}{{ versioned_subgroups.stdout.split('\n') | list }}{% endif %}"
-
-- block:
-    - name: "Get list of {{ group }} subgroups without version number and excluding *-dms, *owners & primary groups."
-      ansible.builtin.shell: |
-        for group in $(getent group | grep -o "^{{ group }}-[^:]*" | grep -v -- "-v[0-9][0-9]*$\|-dms$\|-owners$"); do \
-          if ! getent passwd "${group}" >/dev/null 2>&1; then \
-            echo "${group}"; \
-          fi; \
-        done
-      changed_when: false
-      register: unversioned_subgroups
-    - ansible.builtin.set_fact:  # noqa unnamed-task
-        unversioned_subgroups_list: "{% if unversioned_subgroups.stdout | length %}{{ unversioned_subgroups.stdout.split('\n') | list }}{% endif %}"
-
 - name: "Create directory structure for releases with version number on {{ lfs }}."
   block:
-    - name: "Create /groups/{{ group }}/{{ lfs }}/releases/ directory."
+    - name: "Create /groups/{{ main_group }}/{{ lfs }}/releases/ directory."
       ansible.builtin.file:
-        path: "/groups/{{ group }}/{{ lfs }}/releases/"
-        owner: "{{ group }}-dm"
-        group: "{{ group }}"
+        path: "/groups/{{ main_group }}/{{ lfs }}/releases/"
+        owner: "{{ main_group }}-dm"
+        group: "{{ main_group }}"
         mode: '2750'
         state: 'directory'
-    - name: "Create /groups/{{ group }}/{{ lfs }}/releases/${dataset} directory."
+    - name: "Create /groups/{{ main_group }}/{{ lfs }}/releases/${dataset} directory."
       ansible.builtin.file:
-        path: "/groups/{{ group }}/{{ lfs }}/releases/{{ item | regex_replace('^' + group + '-(.*)-(v[0-9][0-9]*)$', '\\1') }}"
-        owner: "{{ group }}-dm"
-        group: "{{ group }}"
+        path: "/groups/{{ main_group }}/{{ lfs }}/releases/{{ item }}"
+        owner: "{{ main_group }}-dm"
+        group: "{{ main_group }}"
         mode: "{{ mode_dataset }}"
         state: 'directory'
-      with_items: "{{ versioned_subgroups_list }}"
-    - name: "Create /groups/{{ group }}/{{ lfs }}/releases/${dataset}/${version} directory."
+      with_items: "{{ versioned_sub_groups | map('regex_replace', '^' + main_group + '-(.*)-(v[0-9][0-9]*)$', '\\1') | unique }}"
+    - name: "Create /groups/{{ main_group }}/{{ lfs }}/releases/${dataset}/${version} directory."
       ansible.builtin.file:
-        path: "/groups/{{ group }}/{{ lfs }}/releases/\
-               {{ item | regex_replace('^' + group + '-(.*)-(v[0-9][0-9]*)$', '\\1') }}/\
-               {{ item | regex_replace('^' + group + '-(.*)-(v[0-9][0-9]*)$', '\\2') }}"
-        owner: "{{ group }}-dm"
-        group: "{% if item | length %}{{ item }}{% else %}{{ group }}{% endif %}"
+        path: "/groups/{{ main_group }}/{{ lfs }}/releases/\
+               {{ item | regex_replace('^' + main_group + '-(.*)-(v[0-9][0-9]*)$', '\\1') }}/\
+               {{ item | regex_replace('^' + main_group + '-(.*)-(v[0-9][0-9]*)$', '\\2') }}"
+        owner: "{{ main_group }}-dm"
+        group: "{% if item | length %}{{ item }}{% else %}{{ main_group }}{% endif %}"
         mode: "{{ mode_version }}"
         state: 'directory'
-      with_items: "{{ versioned_subgroups_list }}"
+      with_items: "{{ versioned_sub_groups }}"
       # Continue if this specific subgroup failed and try to create other subgroup folders.
       ignore_errors: true  # noqa ignore-errors
-  when: versioned_subgroups_list | length > 0
+  when: versioned_sub_groups | length > 0
   become: true
-  become_user: "{{ group }}-dm"
+  become_user: "{{ main_group }}-dm"
 
 - name: "Create directory structure for projects on {{ lfs }}."
   block:
-    - name: "Create /groups/{{ group }}/{{ lfs }}/projects directory."
+    - name: "Create /groups/{{ main_group }}/{{ lfs }}/projects directory."
       ansible.builtin.file:
-        path: "/groups/{{ group }}/{{ lfs }}/projects/"
-        owner: "{{ group }}-dm"
-        group: "{{ group }}"
+        path: "/groups/{{ main_group }}/{{ lfs }}/projects/"
+        owner: "{{ main_group }}-dm"
+        group: "{{ main_group }}"
         mode: '2750'
         state: 'directory'
-    - name: "Create /groups/{{ group }}/{{ lfs }}/projects/${project} directory."
+    - name: "Create /groups/{{ main_group }}/{{ lfs }}/projects/${project} directory."
       ansible.builtin.file:
-        path: "/groups/{{ group }}/{{ lfs }}/projects/{{ item | regex_replace('^' + group + '-(.*)$', '\\1') }}"
-        owner: "{{ group }}-dm"
-        group: "{% if item | length %}{{ item }}{% else %}{{ group }}{% endif %}"
+        path: "/groups/{{ main_group }}/{{ lfs }}/projects/{{ item | regex_replace('^' + main_group + '-(.*)$', '\\1') }}"
+        owner: "{{ main_group }}-dm"
+        group: "{% if item | length %}{{ item }}{% else %}{{ main_group }}{% endif %}"
         mode: "{{ mode_project }}"
         state: 'directory'
-      with_items: "{{ unversioned_subgroups_list }}"
+      with_items: "{{ unversioned_sub_groups }}"
       # Continue if this specific subgroup failed and try to create other subgroup folders.
       ignore_errors: true  # noqa ignore-errors
-  when: unversioned_subgroups_list | length > 0
+  when: unversioned_sub_groups | length > 0
   become: true
-  become_user: "{{ group }}-dm"
+  become_user: "{{ main_group }}-dm"
 ...

--- a/roles/subgroup_directories/tasks/main.yml
+++ b/roles/subgroup_directories/tasks/main.yml
@@ -39,8 +39,14 @@
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
     main_group: "{{ lfs_item.1.name }}"
-    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
-    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results
+                              | selectattr('main_group', 'equalto', lfs_item.1.name)
+                              | map(attribute='stdout_lines')
+                              | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results
+                                | selectattr('main_group', 'equalto', lfs_item.1.name)
+                                | map(attribute='stdout_lines')
+                                | flatten }}"
     mode_project: '2750'
     mode_version: '2750'
     mode_dataset: '2750'
@@ -59,8 +65,14 @@
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
     main_group: "{{ lfs_item.1.name }}"
-    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
-    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results
+                              | selectattr('main_group', 'equalto', lfs_item.1.name)
+                              | map(attribute='stdout_lines')
+                              | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results
+                                | selectattr('main_group', 'equalto', lfs_item.1.name)
+                                | map(attribute='stdout_lines')
+                                | flatten }}"
     mode_project: '2750'
     mode_version: '2750'
     mode_dataset: '2750'
@@ -79,8 +91,14 @@
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
     main_group: "{{ lfs_item.1.name }}"
-    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
-    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results
+                              | selectattr('main_group', 'equalto', lfs_item.1.name)
+                              | map(attribute='stdout_lines')
+                              | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results
+                                | selectattr('main_group', 'equalto', lfs_item.1.name)
+                                | map(attribute='stdout_lines')
+                                | flatten }}"
     mode_project: '2770'
     mode_version: '2770'
     mode_dataset: '2750'

--- a/roles/subgroup_directories/tasks/main.yml
+++ b/roles/subgroup_directories/tasks/main.yml
@@ -1,10 +1,46 @@
 ---
+- name: "Get list of all subgroups with version number."
+  ansible.builtin.shell: |
+    getent group \
+      | grep -o "^{{ main_group }}-[^:]*-v[0-9][0-9]*" \
+      || true
+  vars:
+    main_groups: "{{ lfs_mounts | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+                                | map(attribute='groups') | list | flatten
+                                | map(attribute='name') | list | unique }}"
+  with_items: "{{ main_groups }}"
+  loop_control:
+    loop_var: main_group
+  changed_when: false
+  register: getent_versioned_subgroups
+  when: inventory_hostname in groups['user_interface']
+
+- name: "Get list of all subgroups without version number and excluding *-dms, *owners & primary groups."
+  ansible.builtin.shell: |
+    for group in $(getent group | grep -o "^{{ main_group }}-[^:]*" | grep -v -- "-v[0-9][0-9]*$\|-dms$\|-owners$"); do \
+      if ! getent passwd "${group}" >/dev/null 2>&1; then \
+        echo "${group}"; \
+      fi; \
+    done
+  vars:
+    main_groups: "{{ lfs_mounts | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+                                | map(attribute='groups') | list | flatten
+                                | map(attribute='name') | list | unique }}"
+  with_items: "{{ main_groups }}"
+  loop_control:
+    loop_var: main_group
+  changed_when: false
+  register: getent_unversioned_subgroups
+  when: inventory_hostname in groups['user_interface']
+
 - name: 'Loop over "prm" file systems.'
   include_tasks:
     file: create_subgroup_directories.yml
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
-    group: "{{ lfs_item.1.name }}"
+    main_group: "{{ lfs_item.1.name }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
     mode_project: '2750'
     mode_version: '2750'
     mode_dataset: '2750'
@@ -13,14 +49,18 @@
     - 'groups'
   loop_control:
     loop_var: lfs_item
-  when: inventory_hostname in groups['user_interface']
+  when:
+    - inventory_hostname in groups['user_interface']
+    - (versioned_sub_groups | length > 0) or (unversioned_sub_groups | length > 0)
 
 - name: 'Loop over "rsc" file systems.'
   include_tasks:
     file: create_subgroup_directories.yml
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
-    group: "{{ lfs_item.1.name }}"
+    main_group: "{{ lfs_item.1.name }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
     mode_project: '2750'
     mode_version: '2750'
     mode_dataset: '2750'
@@ -29,14 +69,18 @@
     - 'groups'
   loop_control:
     loop_var: lfs_item
-  when: inventory_hostname in groups['user_interface']
+  when:
+    - inventory_hostname in groups['user_interface']
+    - (versioned_sub_groups | length > 0) or (unversioned_sub_groups | length > 0)
 
 - name: 'Loop over "tmp" file systems.'
   include_tasks:
     file: create_subgroup_directories.yml
   vars:
     lfs: "{{ lfs_item.0.lfs }}"
-    group: "{{ lfs_item.1.name }}"
+    main_group: "{{ lfs_item.1.name }}"
+    versioned_sub_groups: "{{ getent_versioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
+    unversioned_sub_groups: "{{ getent_unversioned_subgroups.results | selectattr('main_group', 'equalto', lfs_item.1.name) | map(attribute='stdout_lines') | flatten }}"
     mode_project: '2770'
     mode_version: '2770'
     mode_dataset: '2750'
@@ -45,5 +89,7 @@
     - 'groups'
   loop_control:
     loop_var: lfs_item
-  when: inventory_hostname in groups['user_interface']
+  when:
+    - inventory_hostname in groups['user_interface']
+    - (versioned_sub_groups | length > 0) or (unversioned_sub_groups | length > 0)
 ...

--- a/roles/subgroup_directories/tasks/main.yml
+++ b/roles/subgroup_directories/tasks/main.yml
@@ -1,9 +1,10 @@
 ---
 - name: "Get list of all subgroups with version number."
   ansible.builtin.shell: |
+    set -o pipefail
+    set -e
     getent group \
-      | grep -o "^{{ main_group }}-[^:]*-v[0-9][0-9]*" \
-      || true
+      | { grep -o "^{{ main_group }}-[^:]*-v[0-9][0-9]*" || test "${?}" = 1; }
   vars:
     main_groups: "{{ lfs_mounts | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
                                 | map(attribute='groups') | list | flatten
@@ -17,7 +18,12 @@
 
 - name: "Get list of all subgroups without version number and excluding *-dms, *owners & primary groups."
   ansible.builtin.shell: |
-    for group in $(getent group | grep -o "^{{ main_group }}-[^:]*" | grep -v -- "-v[0-9][0-9]*$\|-dms$\|-owners$"); do \
+    set -o pipefail
+    set -e
+    for group in $(getent group \
+          | { grep -o "^{{ main_group }}-[^:]*" || test "${?}" = 1; }\
+          | { grep -v -- "-v[0-9][0-9]*$\|-dms$\|-owners$" || test "${?}" = 1; }\
+        ); do \
       if ! getent passwd "${group}" >/dev/null 2>&1; then \
         echo "${group}"; \
       fi; \


### PR DESCRIPTION
Improved speed:
 * Refactored ```subgroup_directories``` role:
    * Removed redundant tasks.
    * Added ```set -o pipefail``` for ```ansible.builtin.shell``` tasks and make sure ```grep``` does not make the ansible task failed when the exit status is 1 (no results found).
 * Added support for Mitogen strategy plugin for Ansible
    * Updated ```lor-init```: detects whether Mitogen is installed and ```lor-config``` will enable it automatically when installed.
    * Updated ```README.md``` with instructions to install Mitogen.
    * Tested for ```ansible-playbook single_role_playbooks/subgroup_directories.yml``` on _Gearshift_:
    * Without Mitogen installed and with redundant tasks:
       ```
       PLAY RECAP
       ****************************************************************************************************
       gearshift: ok=1046   changed=1   unreachable=0   failed=0   skipped=845   rescued=0   ignored=0
       422.13s user 215.45s system 32% cpu 32:54.14 total
       ```
    * With Mitogen installed and without redundant tasks:
       ```
       PLAY RECAP
       ***************************************************************************************************
       gearshift: ok=139    changed=0   unreachable=0   failed=0   skipped=80   rescued=0   ignored=0
       6.41s user 15.71s system 67% cpu 2:16.36 total
       ```