### PR TITLE
Rsyslog

### DIFF
--- a/roles/rsyslog_client/tasks/main.yml
+++ b/roles/rsyslog_client/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Deploy configuration for managed remote rsyslog servers
   ansible.builtin.template:
     src: templates/rsyslog_managed.conf
-    dest: /etc/rsyslog.d/rsyslog_managed.conf
+    dest: /etc/rsyslog.d/managed.conf
     force: true
     mode: 0644
   become: true
@@ -37,7 +37,7 @@
 - name: Deploy configuration for unmanaged remote rsyslog servers
   ansible.builtin.template:
     src: templates/rsyslog_unmanaged.conf
-    dest: /etc/rsyslog.d/rsyslog_unmanaged.conf
+    dest: /etc/rsyslog.d/unmanaged.conf
     force: true
     mode: 0644
   become: true

--- a/roles/rsyslog_client/tasks/main.yml
+++ b/roles/rsyslog_client/tasks/main.yml
@@ -24,7 +24,7 @@
   when: inventory_hostname not in groups['rsyslog']
   notify: client_restart_rsyslog
 
-- name: Deploy rsyslog_managed.conf template on the client
+- name: Deploy configuration for managed remote rsyslog servers
   ansible.builtin.template:
     src: templates/rsyslog_managed.conf
     dest: /etc/rsyslog.d/rsyslog_managed.conf
@@ -34,7 +34,7 @@
   when: inventory_hostname not in groups['rsyslog']
   notify: client_restart_rsyslog
 
-- name: Deploy rsyslog_unmanaged.conf template on the client
+- name: Deploy configuration for unmanaged remote rsyslog servers
   ansible.builtin.template:
     src: templates/rsyslog_unmanaged.conf
     dest: /etc/rsyslog.d/rsyslog_unmanaged.conf

--- a/roles/rsyslog_client/tasks/main.yml
+++ b/roles/rsyslog_client/tasks/main.yml
@@ -24,6 +24,26 @@
   when: inventory_hostname not in groups['rsyslog']
   notify: client_restart_rsyslog
 
+- name: Deploy rsyslog_managed.conf template on the client
+  ansible.builtin.template:
+    src: templates/rsyslog_managed.conf
+    dest: /etc/rsyslog.d/rsyslog_managed.conf
+    force: true
+    mode: 0644
+  become: true
+  when: inventory_hostname not in groups['rsyslog']
+  notify: client_restart_rsyslog
+
+- name: Deploy rsyslog_unmanaged.conf template on the client
+  ansible.builtin.template:
+    src: templates/rsyslog_unmanaged.conf
+    dest: /etc/rsyslog.d/rsyslog_unmanaged.conf
+    force: true
+    mode: 0644
+  become: true
+  when: inventory_hostname not in groups['rsyslog']
+  notify: client_restart_rsyslog
+
 - name: Start and enable rsyslog service if they are not
   ansible.builtin.systemd:
     name: rsyslog.service

--- a/roles/rsyslog_client/templates/rsyslog.conf
+++ b/roles/rsyslog_client/templates/rsyslog.conf
@@ -63,34 +63,3 @@ uucp,news.crit                                          /var/log/spooler
 
 # Save boot messages also to boot.log
 local7.*                                                /var/log/boot.log
-
-$DefaultNetstreamDriver gtls
-
-# certificate files, first for rsyslog servers withing the cluster
-{% if groups['rsyslog'] is defined and ( groups['rsyslog']|length>0 ) %}
-$DefaultNetstreamDriverCAFile {{ rsyslog_remote_path_cert_dir }}/{{ rsyslog_ca_cert_file }}
-$DefaultNetstreamDriverCertFile {{ rsyslog_remote_path_cert_dir }}/{{ inventory_hostname }}.pem
-$DefaultNetstreamDriverKeyFile {{ rsyslog_remote_path_key_dir }}/{{ inventory_hostname }}.key
-
-$ActionSendStreamDriverMode 1 # run driver in TLS-only mode
-$ActionSendStreamDriverAuthMode x509/certvalid
-
-{% for server in groups['rsyslog'] %}
-$ActionQueueType LinkedList
-$ActionQueueFileName Forward1
-$ActionResumeRetryCount -1
-$ActionQueueSaveOnShutdown on
-*.* @@{{ server }}:{{ hostvars[server].rsyslog_port | default('514') }}
-{% endfor %}
-{% endif %}
-
-# certificate files, then for extra rsyslog servers defined in group vars
-{% if rsyslog_external_servers is defined %}
-{% for server in rsyslog_external_servers %}
-$ActionQueueType LinkedList
-$ActionQueueFileName Forward1
-$ActionResumeRetryCount -1
-$ActionQueueSaveOnShutdown on
-*.* @@{{ server.hostname }}:{{ server.port | default('514')}}
-{% endfor %}
-{% endif %}

--- a/roles/rsyslog_client/templates/rsyslog_managed.conf
+++ b/roles/rsyslog_client/templates/rsyslog_managed.conf
@@ -1,0 +1,20 @@
+$DefaultNetstreamDriver gtls
+
+# certificate files, first for rsyslog servers withing the cluster
+{% if groups['rsyslog'] is defined and ( groups['rsyslog']|length>0 ) %}
+$DefaultNetstreamDriverCAFile {{ rsyslog_remote_path_cert_dir }}/{{ rsyslog_ca_cert_file }}
+$DefaultNetstreamDriverCertFile {{ rsyslog_remote_path_cert_dir }}/{{ inventory_hostname }}.pem
+$DefaultNetstreamDriverKeyFile {{ rsyslog_remote_path_key_dir }}/{{ inventory_hostname }}.key
+
+$ActionSendStreamDriverMode 1 # run driver in TLS-only mode
+$ActionSendStreamDriverAuthMode x509/certvalid
+
+{% for server in groups['rsyslog'] %}
+$ActionQueueType LinkedList
+$ActionQueueFileName Forward{{ server }}
+$ActionResumeRetryCount -1
+$ActionQueueSaveOnShutdown on
+*.* @@{{ server }}:{{ hostvars[server].rsyslog_port | default('514') }}
+
+{% endfor %}
+{% endif %}

--- a/roles/rsyslog_client/templates/rsyslog_unmanaged.conf
+++ b/roles/rsyslog_client/templates/rsyslog_unmanaged.conf
@@ -1,0 +1,10 @@
+# certificate files, then for extra rsyslog servers defined in group vars
+{% if rsyslog_external_servers is defined %}
+{% for server in rsyslog_external_servers %}
+$ActionQueueType LinkedList
+$ActionQueueFileName Forward1{{ server }}
+$ActionResumeRetryCount -1
+$ActionQueueSaveOnShutdown on
+*.* @@{{ server.hostname }}:{{ server.port | default('514')}}
+{% endfor %}
+{% endif %}

--- a/roles/rsyslog_server/tasks/rsyslog.yml
+++ b/roles/rsyslog_server/tasks/rsyslog.yml
@@ -97,10 +97,11 @@
   become: true
   notify: restart-rsyslog.service
 
-- name: Open tcp port {{ rsyslog_port | default('514') }}
+- name: Open incoming rsyslog tcp port
   ansible.posix.firewalld:
-    port: "{{ rsyslog_port | default('514') }}/tcp"
+    port: "{{ hostvars[inventory_hostname].rsyslog_port|default('514',true) }}/tcp"
     permanent: true
+    immediate: true
     state: enabled
   become: true
 

--- a/roles/rsyslog_server/templates/rsyslog.conf
+++ b/roles/rsyslog_server/templates/rsyslog.conf
@@ -40,12 +40,12 @@ $IMJournalStateFile imjournal.state
 
 #### RULES ####
 
-template(name="DynMessages" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-messages")
-template(name="DynSecure" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-secure")
-template(name="DynMaillog" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-maillog")
-template(name="DynCron" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-cron")
-template(name="DynSpooler" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-spooler")
-template(name="DynBootLog" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-boot.log")
+template(name="DynMessages" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/messages-%$DAY%")
+template(name="DynSecure" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/secure-%$DAY%")
+template(name="DynMaillog" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/maillog-%$DAY%")
+template(name="DynCron" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/cron-%$DAY%")
+template(name="DynSpooler" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/spooler-%$DAY%")
+template(name="DynBootLog" type="string" string="/var/log/remote/%HOSTNAME%/%$YEAR%-%$MONTH%/boot.log-%$DAY%")
 
 ruleset(name="remote_rule"){
     if prifilt("authpriv.*") then {

--- a/roles/rsyslog_server/templates/rsyslog.conf
+++ b/roles/rsyslog_server/templates/rsyslog.conf
@@ -37,7 +37,33 @@ $OmitLocalLogging on
 $IMJournalStateFile imjournal.state
 
 
+
 #### RULES ####
+
+template(name="DynMessages" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-messages")
+template(name="DynSecure" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-secure")
+template(name="DynMaillog" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-maillog")
+template(name="DynCron" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-cron")
+template(name="DynSpooler" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-spooler")
+template(name="DynBootLog" type="string" string="/var/log/remote/%$YEAR%-%$MONTH%-%$DAY%/%HOSTNAME%-boot.log")
+
+ruleset(name="remote_rule"){
+    if prifilt("authpriv.*") then {
+       action(type="omfile"  dynaFile="DynMessages" dirCreateMode="0755" )
+    } else if prifilt("authpriv.*") then {
+       action(type="omfile"  dynaFile="DynSecure" dirCreateMode="0755" )
+    } else if prifilt("mail.*") then {
+       action(type="omfile"  dynaFile="DynMaillog" dirCreateMode="0755" )
+    } else if prifilt("cron.*") then {
+       action(type="omfile"  dynaFile="DynCron" dirCreateMode="0755" )
+    } else if prifilt("uucp,news.crit") then {
+       action(type="omfile"  dynaFile="DynSpooler" dirCreateMode="0755" )
+    } else if prifilt("local7.*") then {
+       action(type="omfile"  dynaFile="DynBootLog" dirCreateMode="0755" )
+    } else {
+       action(type="omfile"  dynaFile="DynMessages" dirCreateMode="0755" )
+    }
+}
 
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
@@ -65,6 +91,10 @@ uucp,news.crit                                          /var/log/spooler
 # Save boot messages also to boot.log
 local7.*                                                /var/log/boot.log
 
+
+
+#### INCOMING SERVER SETTINGS #### 
+
 # make gtls driver the default
 $DefaultNetstreamDriver gtls
 
@@ -78,5 +108,4 @@ $ModLoad imtcp # load TCP listener
 $InputTCPServerStreamDriverMode 1 # run driver in TLS-only mode
 $InputTCPServerStreamDriverAuthMode x509/certvalid
 # start up listening on port defined by rsyslog_port variable or 514 by default
-$InputTCPServerRun {{ hostvars[inventory_hostname].rsyslog_port|default('514',true) }}
-
+input(type="imtcp" port="{{ hostvars[inventory_hostname].rsyslog_port|default('514',true) }}" ruleset="remote_rule")


### PR DESCRIPTION
The rsyslog configuration file is now defined in `/etc/rsyslog.conf` which also defines to look into `/etc/rsyslog.d/` for `*.conf` files. The playbook adds there
- `/etc/rsyslog.d/managed.conf` which hold all the configuration for the managed remote rsyslog servers
- `/etc/rsyslog.d/unmanaged.conf` with all the configuration of unmanaged remote rsyslog servers

All the logs (from the server and all the clients) were until now saved in the same file, f.e. inside
- `/var/log/messages`, `/var/log/secure` ...
Now they are saved inside file structure

`/var/log/remote/%hostname%/%year%-%month%/message-%day%`

where `message-%day%` contains all the log messages that are also in the client's `/var/log/messages`