### PR TITLE
Fixed some dependencies

### DIFF
--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -97,17 +97,6 @@
   changed_when: ('nss_ldap is disabled' in authconfig_test.stdout) or ('pam_ldap is disabled' in authconfig_test.stdout)
   notify: authconfig_enable_ldap
 
-- name: Redeploy sshd config.
-  ansible.builtin.template:
-    src: "{{ playbook_dir }}/roles/sshd/templates/sshd_config"
-    dest: /etc/ssh/sshd_config
-    validate: '/usr/sbin/sshd -T -f %s'
-    owner: root
-    group: root
-    mode: '0644'
-  notify: restart_sshd
-  become: true
-
 - name: Flush handlers.
   ansible.builtin.meta: flush_handlers
 ...

--- a/roles/sssd/tasks/main.yml
+++ b/roles/sssd/tasks/main.yml
@@ -59,12 +59,17 @@
     - /usr/libexec/openssh/ssh-ldap-wrapper.bash
   become: true
 
+- name: Get a list of currently existing services.
+  service_facts:  # Results in "services" variable.
+
 - name: Disable conflicting services.
   ansible.builtin.systemd:
     name: nslcd
     state: stopped
     enabled: false
     daemon_reload: true
+  register: nslcd_status
+  when: "'nslcd.service' in services"
   become: true
 
 - name: Deploy nsswitch.conf
@@ -129,17 +134,6 @@
   register: authconfig_test
   changed_when: ('nss_sss is disabled' in authconfig_test.stdout) or ('pam_sss is disabled' in authconfig_test.stdout)
   notify: authconfig_enable_sssd
-
-- name: Redeploy sshd config.
-  ansible.builtin.template:
-    src: "{{ playbook_dir }}/roles/sshd/templates/sshd_config"
-    dest: /etc/ssh/sshd_config
-    validate: '/usr/sbin/sshd -T -f %s'
-    owner: root
-    group: root
-    mode: '0644'
-  notify: restart_sshd
-  become: true
 
 - name: Flush handlers.
   ansible.builtin.meta: flush_handlers

--- a/roles/sssd/tasks/main.yml
+++ b/roles/sssd/tasks/main.yml
@@ -60,7 +60,7 @@
   become: true
 
 - name: Get a list of currently existing services.
-  service_facts:  # Results in "services" variable.
+  ansible.builtin.service_facts:  # Results in "services" variable.
 
 - name: Disable conflicting services.
   ansible.builtin.systemd:

--- a/single_role_playbooks/ldap.yml
+++ b/single_role_playbooks/ldap.yml
@@ -1,8 +1,9 @@
 ---
-- name: Install ldap role.
+- name: Install ldap client role.
   hosts:
     - jumphost
     - cluster
   roles:
      - ldap
+     - sshd  # Always re-run sshd role after potentially changing the logic to fetch public keys.
 ...

--- a/single_role_playbooks/sssd.yml
+++ b/single_role_playbooks/sssd.yml
@@ -6,4 +6,5 @@
     - data_transfer
   roles:
      - sssd
+     - sshd  # Always re-run sshd role after potentially changing the logic to fetch public keys.
 ...


### PR DESCRIPTION
* ```sssd``` role: Do not fail on disabling ```nslcd.service``` task when ```nslcd``` does not exist on a machine.
* Always (re-)run ```sshd``` role after potentially changing the logic to fetch public keys.
  * Included ```sshd``` role in ```single_role_playbooks/ldap.yml``` and ```single_role_playbooks/sssd.yml```
  * Removed code to only redeploy ```sshd.conf``` in ```roles/ldap/tasks/main.yml``` and ```roles/sssd/tasks/main.yml``` as that will fail when the ```sshd``` role is not included in a play -> resulting in missing defaults/vars for the sshd role and used in that ```sshd.conf```file.