### PR TITLE
Bugfix for fetching public keys from LDAP with sssd role.

### DIFF
--- a/roles/sssd/templates/get_public_keys_from_ldap.bash
+++ b/roles/sssd/templates/get_public_keys_from_ldap.bash
@@ -120,12 +120,12 @@ function getPublicKeysFromLDAP() {
       while read -r _public_key; do
         test -z "${_public_key:-}" && continue
         filterKeys "${_public_key}"
-      done < <(printf '%s\n' "${_user_ssh_public_key_value}")
+      done < <(printf '%s\n' "${_user_ssh_public_key_value}" && echo)
     elif [[ "${_separator}" == '::' ]]; then
       while read -r _public_key; do
         test -z "${_public_key:-}" && continue
         filterKeys "${_public_key}"
-      done < <(printf '%s\n' "${_user_ssh_public_key_value}" | "${base64}" -di)
+      done < <(printf '%s\n' "${_user_ssh_public_key_value}" | "${base64}" -di && echo)
     else
       echo "ERROR: Got an unsupported key value separator ${_separator} for LDAP attribute: ${_user_ssh_public_key_value:-}." 1>&2
       continue


### PR DESCRIPTION
Fixed issue where sssd would not get the last public key when it was missing a newline character.