### PR TITLE
Nibbler: redeploy vcomputes after OS issues

### DIFF
--- a/group_vars/nibbler_cluster/ip_addresses.yml
+++ b/group_vars/nibbler_cluster/ip_addresses.yml
@@ -48,31 +48,31 @@ ip_addresses:
       fqdn: 'nb-transfer.hpc.rug.nl'
   nb-vcompute01:
     nb_internal_management:
-      address: 10.10.1.199
+      address: 10.10.1.172
       netmask: /32
     nb_internal_storage:
-      address: 10.10.2.215
+      address: 10.10.2.190
       netmask: /32
   nb-vcompute02:
     nb_internal_management:
-      address: 10.10.1.140
+      address: 10.10.1.246
       netmask: /32
     nb_internal_storage:
-      address: 10.10.2.38
+      address: 10.10.2.152
       netmask: /32
   nb-vcompute03:
     nb_internal_management:
-      address: 10.10.1.108
+      address: 10.10.1.32
       netmask: /32
     nb_internal_storage:
-      address: 10.10.2.55
+      address: 10.10.2.220
       netmask: /32
   nb-vcompute04:
     nb_internal_management:
-      address: 10.10.1.missing
+      address: 10.10.1.197
       netmask: /32
     nb_internal_storage:
-      address: 10.10.2.missing
+      address: 10.10.2.129
       netmask: /32
   nibbler:
     nb_internal_management:


### PR DESCRIPTION
Nibblers vcompute[01-04] have been recreated because openstack had issues. Here are the new IP's.