### PR TITLE
WH: geerlingguy.security fix sshd_config 2FA

### DIFF
--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -8,6 +8,7 @@ all:
       hosts:
         porch:
           cloud_flavor: m1.small
+          security_ssh_challenge_response_auth: 'yes' # geerlingguy.security fix sshd_config 2FA
     repo:
       hosts:
         wh-repo:


### PR DESCRIPTION
The playbook was failing, as default values of geerlingguy.security were conflicting with settings for 2FA.
The `security_ssh_challenge_response_auth` is by default set to `no`, while for the `Porch` we need it to be `yes`.