### PR TITLE
yum_local: relocate directory and fix triggers

### DIFF
--- a/roles/yum_local/defaults/main.yml
+++ b/roles/yum_local/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 local_yum_repository: "false"
-lyr_dir_path: "/var/local/repo/"
+lyr_dir_path: "/usr/local/repo/"
 ...

--- a/roles/yum_local/tasks/main.yml
+++ b/roles/yum_local/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Create a local yum repository
   ansible.builtin.include: lyr.yml
-  when: local_yum_repository == true
+  when: local_yum_repository | bool is true
 
 - name: Remove a local yum repository
   ansible.builtin.include: lyr_remove.yml
-  when: local_yum_repository == false
+  when: local_yum_repository | bool is false
 ...

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -11,7 +11,7 @@
     - swap
     - {role: spacewalk_client, when: repo_manager == 'spacewalk'}
     - {role: pulp_client, when: repo_manager == 'pulp'}
-    - {role: yum_local, when: local_yum_repository == 'true' }
+    - {role: yum_local, when: local_yum_repository is defined}
     - static_hostname_lookup
     - logrotate
     - remove


### PR DESCRIPTION
- changed repo folder from /var/local/repo to /usr/local/repo as (based on linux's filesystem hierarchy standard) it fits better there
- fixed main task triggering to be executed when truly needed:
  - inside the playbook and
  - when running single_group/cluster_part1 playbook