### PR TITLE
Fix: swap for repo vms

### DIFF
--- a/roles/swap/tasks/disable_swap.yml
+++ b/roles/swap/tasks/disable_swap.yml
@@ -24,4 +24,7 @@
     path: "{{ swap_file_path }}"
     state: absent
   become: true
+
+- name: Flush handlers to disable swap.
+  ansible.builtin.meta: flush_handlers
 ...

--- a/roles/swap/tasks/enable_swap.yml
+++ b/roles/swap/tasks/enable_swap.yml
@@ -45,4 +45,7 @@
     name: vm.swappiness
     value: "{{ swap_swappiness | int }}"
   become: true
+
+- name: Flush handlers to enable swap.
+  ansible.builtin.meta: flush_handlers
 ...

--- a/single_group_playbooks/repo.yml
+++ b/single_group_playbooks/repo.yml
@@ -7,6 +7,7 @@
     - admin_users
     - ssh_host_signer
     - ssh_known_hosts
+    - swap
     - {role: geerlingguy.repo-epel, become: true}
     - logrotate
     - logins

--- a/single_role_playbooks/swap.yml
+++ b/single_role_playbooks/swap.yml
@@ -1,4 +1,6 @@
 ---
-- hosts: cluster
+- hosts:
+    - repo
+    - cluster
   roles:
     - swap

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -12,6 +12,7 @@ all:
       hosts:
         nb-repo:
           cloud_flavor: m1.small
+          swap_file_size: 2
     data_transfer:
       hosts:
         nb-transfer:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -13,6 +13,7 @@ all:
       hosts:
         wh-repo:
           cloud_flavor: m1.small
+          swap_file_size: 2
     docs:
       hosts:
         docs_on_merlin:


### PR DESCRIPTION
* Added swap role to `repo` _inventory group_.
* Adjusted `swap_file_size` for `wh-repo` and `nb-repo` as the default is too large.

Required to prevent the small `wh-repo` and `nb-repo` VMs from running out of memory when syncing _Pulp_ repos with their remotes.