### PR TITLE
Upgraded Slurm 20.11.8-1.el7.umcg -> 22.05.2-1.el7.umcg for various clusters

### DIFF
--- a/group_vars/marvin_cluster/vars.yml
+++ b/group_vars/marvin_cluster/vars.yml
@@ -3,7 +3,7 @@ slurm_cluster_name: 'marvin'
 stack_domain: ''
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'mv'
-slurm_version: '20.11.8-1.el7.umcg'
+slurm_version: '22.05.2-1.el7.umcg'
 slurm_partitions:
   - name: regular  # Must be in sync with group listed in Ansible inventory.
     default: yes

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -3,7 +3,7 @@ slurm_cluster_name: 'nibbler'
 stack_domain: 'hpc.rug.nl'
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'nb'
-slurm_version: '20.11.8-1.el7.umcg'
+slurm_version: '22.05.2-1.el7.umcg'
 slurm_partitions:
   - name: regular  # Must be in sync with group listed in Ansible inventory.
     default: yes

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -3,7 +3,7 @@ slurm_cluster_name: 'talos'
 stack_domain: 'hpc.rug.nl'
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'tl'
-slurm_version: '20.11.8-1.el7.umcg'
+slurm_version: '22.05.2-1.el7.umcg'
 slurm_allow_jobs_to_span_nodes: true
 slurm_partitions:
   - name: regular  # Must be in sync with group listed in Ansible inventory.

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -3,7 +3,7 @@ slurm_cluster_name: 'wingedhelix'
 stack_domain: 'hpc.rug.nl'
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'wh'
-slurm_version: '20.11.8-1.el7.umcg'
+slurm_version: '22.05.2-1.el7.umcg'
 slurm_partitions:
   - name: regular  # Must be in sync with group listed in Ansible inventory.
     default: yes

--- a/roles/slurm_management/tasks/main.yml
+++ b/roles/slurm_management/tasks/main.yml
@@ -83,6 +83,15 @@
     - 'restart_slurmctld'
   become: true
 
+- name: 'Delete deprecated/unused Slurm packages.'
+  ansible.builtin.yum:
+    state: 'removed'
+    name:
+      - 'slurm-libpmi'
+      - 'slurm-openlava'
+      - 'slurm-torque'
+  become: true
+
 - name: 'Install Slurm management deamons with yum.'
   ansible.builtin.yum:
     state: 'installed'


### PR DESCRIPTION
* For Nibbler, Talos, Winged Helix and Marvin.
* Also added task to `slurm_management` role to delete unused Slurm RPMs.