### PR TITLE
Changed a list of packages into variable that can be defined per cluster/server

### DIFF
--- a/roles/cluster/defaults/main.yml
+++ b/roles/cluster/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+cluster_common_packages:
+  - bash-completion
+  - bc
+  - bcc-tools
+  - bind-utils
+  - bzip2
+  - cargo
+  - curl
+  - dos2unix
+  - figlet
+  - git
+  - git-core
+  - gnutls
+  - irods-icommands
+  - libsodium
+  - lsof
+  - nano
+  - ncdu
+  - ncurses-static
+  - net-tools
+  - openssl
+  - qt5-qtbase
+  - qt5-qtxmlpatterns
+  - readline-static
+  - rsync
+  - screen
+  - singularity-runtime
+  - singularity
+  - strace
+  - tcl-devel
+  - telnet
+  - tmux
+  - tree
+  - unzip
+  - urw-base35-fonts
+  - vim
+  - wget
+
+...

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -9,43 +9,7 @@
   ansible.builtin.yum:
     state: latest
     update_cache: true
-    name:
-      - bash-completion
-      - bc
-      - bcc-tools
-      - bind-utils
-      - bzip2
-      - cargo
-      - curl
-      - dos2unix
-      - figlet
-      - git
-      - git-core
-      - gnutls
-      - irods-icommands
-      - libsodium
-      - lsof
-      - nano
-      - ncdu
-      - ncurses-static
-      - net-tools
-      - openssl
-      - qt5-qtbase
-      - qt5-qtxmlpatterns
-      - readline-static
-      - rsync
-      - screen
-      - singularity-runtime
-      - singularity
-      - strace
-      - tcl-devel
-      - telnet
-      - tmux
-      - tree
-      - unzip
-      - urw-base35-fonts
-      - vim
-      - wget
+    name: '{{ cluster_common_packages }}'
   tags:
     - software
   become: true


### PR DESCRIPTION
For example `Betabarrel` might not need `irods-icommand` package (at least not now). It expects to install it, but fails as we didn't add `irods` repository to `Betabarrel`.

This commit converts static list of packages to a variable that can be easily overwritten for individual cluster or just a server (inside `group_vars` or `static_inventory`).