### PR TITLE
Added functional_users_group on Winged Helix.

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -99,10 +99,12 @@ data_transfer_only_group: 'umcg-sftp-only'
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
+functional_users_group: 'umcg-funus'  # For all functional accounts. Used in /etc/security/access.conf.
 hpc_env_prefix: '/apps'
 regular_groups:
   - "{{ envsync_group }}"
   - "{{ functional_admin_group }}"
+  - "{{ functional_users_group }}"
   - 'umcg-atd'
   - 'umcg-gap'
   - 'umcg-gd'
@@ -113,45 +115,45 @@ regular_groups:
   - 'umcg-vipt'
 regular_users:
   - user: "{{ envsync_user }}"
-    groups: ["{{ envsync_group }}"]
+    groups: ["{{ envsync_group }}", "{{ functional_users_group }}"]
   - user: 'umcg-atd-ateambot'
-    groups: ['umcg-atd']
+    groups: ['umcg-atd', "{{ functional_users_group }}"]
     sudoers: '%umcg-atd'
   - user: 'umcg-atd-dm'
-    groups: ['umcg-atd']
+    groups: ['umcg-atd', "{{ functional_users_group }}"]
     sudoers: '%umcg-atd'
   - user: 'umcg-gap-ateambot'
-    groups: ['umcg-gap']
+    groups: ['umcg-gap', "{{ functional_users_group }}"]
     sudoers: '%umcg-gap'
   - user: 'umcg-gap-dm'
-    groups: ['umcg-gap']
+    groups: ['umcg-gap', "{{ functional_users_group }}"]
     sudoers: '%umcg-gap'
   - user: 'umcg-gd-ateambot'
-    groups: ['umcg-gd']
+    groups: ['umcg-gd', "{{ functional_users_group }}"]
     sudoers: '%umcg-gd'
   - user: 'umcg-gd-dm'
-    groups: ['umcg-gd']
+    groups: ['umcg-gd', "{{ functional_users_group }}"]
     sudoers: '%umcg-gd'
   - user: 'umcg-genomescan-ateambot'
-    groups: ['umcg-genomescan']
+    groups: ['umcg-genomescan', "{{ functional_users_group }}"]
     sudoers: '%umcg-genomescan'
   - user: 'umcg-genomescan-dm'
-    groups: ['umcg-genomescan']
+    groups: ['umcg-genomescan', "{{ functional_users_group }}"]
     sudoers: '%umcg-genomescan'
   - user: 'umcg-gsad-ateambot'
-    groups: ['umcg-gsad']
+    groups: ['umcg-gsad', "{{ functional_users_group }}"]
     sudoers: '%umcg-gsad'
   - user: 'umcg-gsad-dm'
-    groups: ['umcg-gsad']
+    groups: ['umcg-gsad', "{{ functional_users_group }}"]
     sudoers: '%umcg-gsad'
   - user: 'umcg-gst-ateambot'
-    groups: ['umcg-gst']
+    groups: ['umcg-gst', "{{ functional_users_group }}"]
     sudoers: '%umcg-gst'
   - user: 'umcg-gst-dm'
-    groups: ['umcg-gst']
+    groups: ['umcg-gst', "{{ functional_users_group }}"]
     sudoers: '%umcg-gst'
   - user: 'umcg-vipt-dm'
-    groups: ['umcg-vipt']
+    groups: ['umcg-vipt', "{{ functional_users_group }}"]
     sudoers: '%umcg-vipt'
 #
 # Shared storage related variables


### PR DESCRIPTION
Added functional_users_group on Winged Helix. This group can be included in `/etc/security/access.conf` by _MIT_ on the new `wh-chaperone`.