### PR TITLE
Fixes for Winged Helix

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -57,6 +57,8 @@ auth_groups:
     gid: 20013
   umcg-funad:
     gid: 20014
+  umcg-funus:
+    gid: 20015
 #
 # Default for a group of users that are only allowd to transfer data.
 # Is used by the sshd role and listed in

--- a/roles/sudoers/templates/92-ansible-managed
+++ b/roles/sudoers/templates/92-ansible-managed
@@ -6,4 +6,4 @@
 #
 # Allow specific users or group to become the {{ item.user }} user.
 #
-{% if functional_admin_group is defined and functional_admin_group | length %}%{{ functional_admin_group }},{% endif %}{{ item.sudoers }}    ALL=({{ item.user }})    NOPASSWD:ALL
+{% if functional_admin_group is defined and functional_admin_group | length %}%{{ functional_admin_group | regex_replace(' ', '\\ ') }},{% endif %}{{ item.sudoers }}    ALL=({{ item.user }})    NOPASSWD:ALL

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -71,7 +71,12 @@ all:
           ansible_host: uozkh1016.zkh.umcg.intra
           use_ldap: false
           functional_admin_group: 'MEDGEN-NFG GCC Analyse Team'
-          regular_groups:  # Overruled compared to rest of Winged Helix: do not create local functional_admin_group, which comes from UMCG AD.
+          #
+          # Overrule regular_groups compared to rest of Winged Helix:
+          # * Do not create local functional_admin_group, which comes from UMCG AD.
+          # * Do not create umcg-lab, which is not used on a chaperone.
+          #
+          regular_groups:
             - "{{ envsync_group }}"
             - "{{ functional_users_group }}"
             - 'umcg-atd'
@@ -80,7 +85,6 @@ all:
             - 'umcg-genomescan'
             - 'umcg-gsad'
             - 'umcg-gst'
-            - 'umcg-lab'
             - 'umcg-vipt'
     rsyslog:
       hosts:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -70,7 +70,18 @@ all:
         wh-chaperone:
           ansible_host: uozkh1016.zkh.umcg.intra
           use_ldap: false
-          functional_admin_group: 'MEDGEN-NFG\ GCC\ Analyse\ Team'
+          functional_admin_group: 'MEDGEN-NFG GCC Analyse Team'
+          regular_groups:  # Overruled compared to rest of Winged Helix: do not create local functional_admin_group, which comes from UMCG AD.
+            - "{{ envsync_group }}"
+            - "{{ functional_users_group }}"
+            - 'umcg-atd'
+            - 'umcg-gap'
+            - 'umcg-gd'
+            - 'umcg-genomescan'
+            - 'umcg-gsad'
+            - 'umcg-gst'
+            - 'umcg-lab'
+            - 'umcg-vipt'
     rsyslog:
       hosts:
         wh-repo:


### PR DESCRIPTION
* Improvement: Escape spaces in group names where necessary for a role (e.g. `sudoers`), but not in the _value_ itself.
* Bugfix: Added missing GID for `umcg-funus` group.
* Bugfix: Do not create the `functional_admin_group` locally on `wh-chaperone`, because it comes from the UMCG AD.
* Removed `umcg-lab` group from `wh-chaperone`, because it is not used.