### PR TITLE
Fixed issue with variable values not getting picked up from the static inventory due to precedence.

### DIFF
--- a/group_vars/irods.yml
+++ b/group_vars/irods.yml
@@ -12,9 +12,11 @@ iptables_allow_https_inbound:
   - ANY  # For DAVRODS.
 iptables_allow_irods:
   - ANY
-iptables_allow_postgres_outbound:
+iptables_allow_postgresql_outbound:
   - ANY
-
+ssh_host_signer_hostnames: "{{ ansible_fqdn }},{{ ansible_hostname }},{{ inventory_hostname }}\
+  {% for host in groups['jumphost'] %},{{ host }}+{{ ansible_hostname }}{% endfor %}\
+  {% for host in groups['jumphost'] %},{{ host }}+{{ inventory_hostname }}{% endfor %}"
 ir_version: '-4.2.11*'                  # if defined (empty): version will be installed (must start with '-' and end with '*')
 ir_server_type: 'icat'                  # iRODS Server Type
 ir_client_server_policy: 'CS_NEG_REQUIRE'  # communicating using SSL (CS_NEG_REQUIRE) or without (CS_NEG_REFUSE

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -37,6 +37,9 @@ all:
           # ir_local_stage_res_fol: '/tmp/irods/{{ ir_local_stage_res }}'
           # ir_local_perm_res: 'demoRescPerm'                # Permanent resource, where it will keep data indefinitely
           # ir_local_perm_res_fol: '/tmp/irods/{{ ir_local_perm_res }}'
+          iptables_allow_ssh_outbound: []
+          iptables_allow_irods:
+            - "{{ all.ip_addresses['surfsara']['umcg-resc1'] }}"
         irods-test:
           fqdn: umcg-icat01.hpc.rug.nl
           ir_client_server_policy: 'CS_NEG_REFUSE'         # communicating using (default) SSL (CS_NEG_REQUIRE) or without (CS_NEG_REFUSE
@@ -55,13 +58,7 @@ all:
       vars:
         cloud_flavor: m1.large
         local_volume_size_extra: 20
-        ssh_host_signer_hostnames: "{{ ansible_fqdn }},{{ ansible_hostname }},{{ inventory_hostname }}\
-          {% for host in groups['jumphost'] %},{{ host }}+{{ ansible_hostname }}{% endfor %}\
-          {% for host in groups['jumphost'] %},{{ host }}+{{ inventory_hostname }}{% endfor %}"
         davrods_icat_ip: "{{ ip_addresses[inventory_hostname][network_private_management_id]['address'] }}"
-        iptables_allow_ssh_outbound: []
-        iptables_allow_irods:
-          - "{{ all.ip_addresses['surfsara']['umcg-resc1'] }}"
     docs:
       hosts:
         docs_on_merlin:


### PR DESCRIPTION
Fixes variable precedence for variables used by `ssh_host_signer` and `iptables` roles on `irods` machines.