### PR TITLE
Betabarrel added missing configuration

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -105,58 +105,75 @@ data_transfer_only_group: 'umcg-sftp-only'
 envsync_user: 'umcg-envsync'
 envsync_group: 'umcg-depad'
 functional_admin_group: 'umcg-funad'
+functional_users_group: 'umcg-funus'  # For all functional accounts. Used in /etc/security/access.conf.
 hpc_env_prefix: '/apps'
 regular_groups:
   - "{{ envsync_group }}"
   - "{{ functional_admin_group }}"
+  - "{{ functional_users_group }}"
   - 'umcg-atd'
   - 'umcg-gap'
   - 'umcg-gd'
   - 'umcg-genomescan'
   - 'umcg-gsad'
   - 'umcg-gst'
+  - 'umcg-lab'
+  - 'umcg-labgnkbh'
+  - 'umcg-patho'
   - 'umcg-vipt'
 regular_users:
   - user: "{{ envsync_user }}"
-    groups: ["{{ envsync_group }}"]
+    groups: ["{{ envsync_group }}", "{{ functional_users_group }}"]
   - user: 'umcg-atd-ateambot'
-    groups: ['umcg-atd']
+    groups: ['umcg-atd', 'umcg-gsad', "{{ functional_users_group }}"]
     sudoers: '%umcg-atd'
   - user: 'umcg-atd-dm'
-    groups: ['umcg-atd']
+    groups: ['umcg-atd', "{{ functional_users_group }}"]
     sudoers: '%umcg-atd'
   - user: 'umcg-gap-ateambot'
-    groups: ['umcg-gap']
+    groups: ['umcg-gap', "{{ functional_users_group }}"]
     sudoers: '%umcg-gap'
   - user: 'umcg-gap-dm'
-    groups: ['umcg-gap']
+    groups: ['umcg-gap', "{{ functional_users_group }}"]
     sudoers: '%umcg-gap'
   - user: 'umcg-gd-ateambot'
-    groups: ['umcg-gd']
+    groups: ['umcg-gd', 'umcg-gap', "{{ functional_users_group }}"]
     sudoers: '%umcg-gd'
   - user: 'umcg-gd-dm'
-    groups: ['umcg-gd']
+    groups: ['umcg-gd', "{{ functional_users_group }}"]
     sudoers: '%umcg-gd'
   - user: 'umcg-genomescan-ateambot'
-    groups: ['umcg-genomescan']
+    groups: ['umcg-genomescan', "{{ functional_users_group }}"]
     sudoers: '%umcg-genomescan'
   - user: 'umcg-genomescan-dm'
-    groups: ['umcg-genomescan']
+    groups: ['umcg-genomescan', "{{ functional_users_group }}"]
     sudoers: '%umcg-genomescan'
   - user: 'umcg-gsad-ateambot'
-    groups: ['umcg-gsad']
+    groups: ['umcg-gsad', "{{ functional_users_group }}"]
     sudoers: '%umcg-gsad'
   - user: 'umcg-gsad-dm'
-    groups: ['umcg-gsad']
+    groups: ['umcg-gsad', "{{ functional_users_group }}"]
     sudoers: '%umcg-gsad'
   - user: 'umcg-gst-ateambot'
-    groups: ['umcg-gst']
+    groups: ['umcg-gst', "{{ functional_users_group }}"]
     sudoers: '%umcg-gst'
   - user: 'umcg-gst-dm'
-    groups: ['umcg-gst']
+    groups: ['umcg-gst', "{{ functional_users_group }}"]
     sudoers: '%umcg-gst'
+  - user: 'umcg-labgnkbh-ateambot'
+    groups: ['umcg-labgnkbh', "{{ functional_users_group }}"]
+    sudoers: '%umcg-labgnkbh'
+  - user: 'umcg-labgnkbh-dm'
+    groups: ['umcg-labgnkbh', "{{ functional_users_group }}"]
+    sudoers: '%umcg-labgnkbh'
+  - user: 'umcg-patho-ateambot'
+    groups: ['umcg-patho', "{{ functional_users_group }}"]
+    sudoers: '%umcg-patho'
+  - user: 'umcg-patho-dm'
+    groups: ['umcg-patho', "{{ functional_users_group }}"]
+    sudoers: '%umcg-patho'
   - user: 'umcg-vipt-dm'
-    groups: ['umcg-vipt']
+    groups: ['umcg-vipt', "{{ functional_users_group }}"]
     sudoers: '%umcg-vipt'
 #
 # Shared storage related variables
@@ -200,73 +217,97 @@ lfs_mounts:
       - name: umcg-genomescan
       - name: umcg-gsad
       - name: umcg-gst
+      - name: umcg-lab
+        mode: '2750'
       - name: umcg-vipt
     rw_machines: "{{ groups['user_interface'] + groups['compute_vm'] }}"
   - lfs: prm05
     pfs: 'medgen_zincfinger$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
       - name: umcg-gsad
-      - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: dat05
     pfs: 'medgen_zincfinger$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
-      - name: umcg-genomescan
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
+      #- name: umcg-genomescan  Do not use production groups while still in development phase.
       - name: umcg-gsad
       - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: prm06
     pfs: 'medgen_leucinezipper$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
       - name: umcg-gsad
-      - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: dat06
     pfs: 'medgen_leucinezipper$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
-      - name: umcg-genomescan
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
+      #- name: umcg-genomescan  Do not use production groups while still in development phase.
       - name: umcg-gsad
       - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: prm07
     pfs: 'medgen_wingedhelix$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
       - name: umcg-gsad
-      - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: dat07
     pfs: 'medgen_wingedhelix$'
     groups:
       - name: umcg-atd
-      - name: umcg-gap
-      - name: umcg-gd
-      - name: umcg-genomescan
+      #- name: umcg-gap         Do not use production groups while still in development phase.
+      #- name: umcg-gd          Do not use production groups while still in development phase.
+      #- name: umcg-genomescan  Do not use production groups while still in development phase.
       - name: umcg-gsad
       - name: umcg-gst
-      - name: umcg-vipt
+      #- name: umcg-vipt        Do not use production groups while still in development phase.
     rw_machines: "{{ groups['chaperone'] }}"
   - lfs: env05
     pfs: local_raid
     ro_machines: "{{ groups['compute_vm'] + groups['user_interface'] }}"
     rw_machines: "{{ groups['deploy_admin_interface'] }}"
+smb_server_users:
+  - name: sbsuser
+    uid: 501
+    groups:
+      - name: umcg-lab
+        gid: 55100194
+  - name: illumina
+    uid: 502
+    groups:
+      - name: umcg-gap
+        gid: 55100225
+smb_server_interfaces: 192.168.1.0/24  # in addition to 127.0.0.1, which must always be present.
+smb_server_shares:
+  - name: ngs
+    comment: Share for sequencers
+    path: /mnt/umcgst12/groups/umcg-lab/tmp07/sequencers
+    users: sbsuser
+    file_mode: 0640
+    dir_mode: 0750
+  - name: array
+    comment: Share for array scanners
+    path: /mnt/umcgst12/groups/umcg-gap/tmp07/rawdata/array/IDAT/
+    users: illumina
+    file_mode: 0660
+    dir_mode: 0770
 ...

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -306,7 +306,7 @@ smb_server_shares:
     dir_mode: 0750
   - name: array
     comment: Share for array scanners
-    path: /mnt/umcgst12/groups/umcg-gap/tmp07/rawdata/array/IDAT/
+    path: /mnt/local_raid/groups/umcg-gap/tmp05/rawdata/array/IDAT/
     users: illumina
     file_mode: 0660
     dir_mode: 0770

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -300,7 +300,7 @@ smb_server_interfaces: 192.168.1.0/24  # in addition to 127.0.0.1, which must al
 smb_server_shares:
   - name: ngs
     comment: Share for sequencers
-    path: /mnt/umcgst12/groups/umcg-lab/tmp07/sequencers
+    path: /mnt/local_raid/groups/umcg-lab/tmp05/sequencers
     users: sbsuser
     file_mode: 0640
     dir_mode: 0750


### PR DESCRIPTION
I have checked what was missing from the BB configuration (in comparison to the WH) as the `vars.yml` were copied few weeks ago, and since then there were some changes in the list of users (and so ansible-pipelines were crashing due to missing users).
Please note that some groups in WH were removed while other just commented out. Please look at the group `umcg-gst`.
Perhaps there is a good reason for that?