### PR TITLE
Workaround for Ansible control hosts that do not have Python installed in /usr/bin/python.

### DIFF
--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/docs_library.yml
+++ b/static_inventories/docs_library.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/fender_cluster.yml
+++ b/static_inventories/fender_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         corridor:

--- a/static_inventories/forkhead_cluster.yml
+++ b/static_inventories/forkhead_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/gearshift_cluster.yml
+++ b/static_inventories/gearshift_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         airlock:

--- a/static_inventories/hyperchicken_cluster.yml
+++ b/static_inventories/hyperchicken_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         portal:

--- a/static_inventories/jenkins_server.yml
+++ b/static_inventories/jenkins_server.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jenkins:
       hosts:
         jenkins:

--- a/static_inventories/marvin_cluster.yml
+++ b/static_inventories/marvin_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         dockingport:

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         tunnel:

--- a/static_inventories/talos_cluster.yml
+++ b/static_inventories/talos_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         reception:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -4,6 +4,7 @@ all:
     openstack_api:
       hosts:
         localhost:
+          ansible_python_interpreter: /usr/bin/env python
     jumphost:
       hosts:
         porch:


### PR DESCRIPTION
Ansible will fail if it cannot find Python in ```/usr/bin/python``` when using ```connection: local```. Recent versions of macOS removed _Python 2_ from ```/usr/bin/python``` and only have a ```/usr/bin/python3```. The workaround is to
* Create a symlink .../python3 -> .../python somewhere in a location that is listed in your ```$PATH```
* Make sure Ansible will look for ```/usr/bin/env python``` instead of ```/usr/bin/python```, which is arranged in this PR.