### PR TITLE
Betabarrel: updated slurm to new version

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -3,7 +3,7 @@ slurm_cluster_name: 'betabarrel'
 stack_domain: ''  # Only add hpc.rug.nl domain when jumphost is registered in DNS.
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'bb'
-slurm_version: '20.11.8-1.el7.umcg'
+slurm_version: '22.05.2-1.el7.umcg'
 slurm_partitions:
   - name: regular  # Must be in sync with group listed in Ansible inventory.
     default: yes


### PR DESCRIPTION
Like forkhead: updated slurm version for Betabarrel and it also uses new slurm template that supports slurm-in-a-box configuration.
Already deployed and working on Betabarrel.