### PR TITLE
Betabarrel slurm fix

### DIFF
--- a/roles/mariadb/handlers/main.yml
+++ b/roles/mariadb/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 #
 # Important: maintain correct handler order.
-# Handlers are executed in the order in which they are defined 
+# Handlers are executed in the order in which they are defined
 # and not in the order in which they are listed in a "notify: handler_name" statement!
 #
 # Restart before reload: an reload after a restart may be redundant but should not fail,
@@ -13,7 +13,7 @@
   ansible.builtin.systemd:
     name: 'mariadb.service'
     state: 'restarted'
-    daemon_reload: yes
+    daemon_reload: true
   become: true
   listen: restart_mariadb
 
@@ -21,8 +21,8 @@
   ansible.builtin.systemd:
     name: 'mariadb.service'
     state: 'started'
-    enabled: yes
-    daemon_reload: yes
+    enabled: true
+    daemon_reload: true
   become: true
   listen: start_mariadb
 ...

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -5,7 +5,7 @@
     name:
       - 'mariadb-server'
     state: 'latest'
-    update_cache: yes
+    update_cache: true
   notify:
     - 'restart_mariadb'
   become: true
@@ -72,7 +72,7 @@
     name:
       - 'MySQL-python'
     state: 'latest'
-    update_cache: yes
+    update_cache: true
   become: true
 
 - name: 'Set MariaDB/MySQL root user password.'
@@ -92,7 +92,8 @@
 # Without explicit flush the handlers will run after the slurm rol tasks,
 # which is too late resulting in Slurm unable to work with the Slurm Accounting DB.
 #
-- meta: flush_handlers
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: 'Give the MariaDB/MySQL master node some time to initialize the database cluster.'
   ansible.builtin.command: bash -c "sleep 60"

--- a/roles/slurm_client/tasks/main.yml
+++ b/roles/slurm_client/tasks/main.yml
@@ -147,9 +147,19 @@
     group: 'root'
     mode: '0755'
   with_items:
-    - 'slurm.prolog'
     - 'slurm.epilog'
     - 'slurm.taskprolog'
+  become: true
+
+- name: 'Deploy slurm.conf.'
+  ansible.builtin.template:
+    src: "roles/slurm_management/templates/slurm.prolog"
+    dest: '/etc/slurm/slurm.prolog'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  notify:
+    - 'restart_slurmd'
   become: true
 
 - name: 'Deploy slurm.conf.'

--- a/single_group_playbooks/cluster_part2.yml
+++ b/single_group_playbooks/cluster_part2.yml
@@ -15,7 +15,7 @@
         - use_sssd | default(false) | bool
     - sshd
     - regular_users
-    - lustre_client
+#    - lustre_client
     - nfs_client
     - shared_storage
     - backup_local

--- a/single_group_playbooks/cluster_part2.yml
+++ b/single_group_playbooks/cluster_part2.yml
@@ -15,7 +15,7 @@
         - use_sssd | default(false) | bool
     - sshd
     - regular_users
-#    - lustre_client
+    - lustre_client
     - nfs_client
     - shared_storage
     - backup_local


### PR DESCRIPTION
- Converted a `slurm.prolog` file into template and moved it to `templates`. Added wrapper around the if/then part where it expect `/local` to be mounted from another filesystem than root partition - this is not the case in our one-node-cluster Betabarrel, Copperfist and Forkhead systems.
- Minor fixes due to the `ansible-lint` issues :heavy_check_mark: 
- Test deployed on true clustered system - Hyperchicken :heavy_check_mark: 