### PR TITLE
Various small bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ pip3 install 'openstacksdk<0.99'
 pip3 install ruamel.yaml
 pip3 install netaddr
 #
+# On macOS only to prevent this error:
+# crypt.crypt not supported on Mac OS X/Darwin, install passlib python module.
+#
+pip3 install passlib
+#
 # Optional: install Ansible with pip.
 # You may skip this step if you already installed Ansible by other means.
 # E.g. with HomeBrew on macOS, with yum or dnf on Linux, etc.

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -20,7 +20,7 @@
     dest: '/etc/skel/'
     owner: 'no'
     group: 'no'
-    use_ssh_args: true
+    #use_ssh_args: true  # Temporarily disabled as it is broken in Mitogen 0.3.3. Fix is already merged and will be in next Mitogen version.
     ssh_connection_multiplexing: true
     rsync_opts:
       # --omit-dir-times  Is required to prevent "sync error: some files/attrs were not transferred"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -30,7 +30,7 @@
 
 - name: Update docker service to reload every time after iptables service
   ansible.builtin.blockinfile:
-    path: /etc/systemd/system/multi-user.target.wants/docker.service
+    path: /usr/lib/systemd/system/docker.service
     insertafter: '\[Unit\]'
     block: |
       After=iptables.service

--- a/roles/figlet_motd/tasks/main.yml
+++ b/roles/figlet_motd/tasks/main.yml
@@ -12,7 +12,7 @@
     dest: "/usr/share/figlet/{{ item }}"
     owner: false
     group: false
-    use_ssh_args: true
+    #use_ssh_args: true  # Temporarily disabled as it is broken in Mitogen 0.3.3. Fix is already merged and will be in next Mitogen version.
     ssh_connection_multiplexing: true
     rsync_opts:
       - '--chmod=Fu=rw,Fgo=r'


### PR DESCRIPTION
* Updated `README.md` for Python dependency issue on macOS.
* Disabled `use_ssh_args` for `synchronize` tasks due to incompatibility issue with latest _mitogen_ release.
* Patch original `docker.service` file for _systemd_ as opposed to the symlink, which is only present when the service is enabled.