### PR TITLE
Slurm: kill jobs that has invalid dependencies

### DIFF
--- a/roles/mariadb/handlers/main.yml
+++ b/roles/mariadb/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 #
 # Important: maintain correct handler order.
-# Handlers are executed in the order in which they are defined 
+# Handlers are executed in the order in which they are defined
 # and not in the order in which they are listed in a "notify: handler_name" statement!
 #
 # Restart before reload: an reload after a restart may be redundant but should not fail,
@@ -13,7 +13,7 @@
   ansible.builtin.systemd:
     name: 'mariadb.service'
     state: 'restarted'
-    daemon_reload: yes
+    daemon_reload: true
   become: true
   listen: restart_mariadb
 
@@ -21,8 +21,8 @@
   ansible.builtin.systemd:
     name: 'mariadb.service'
     state: 'started'
-    enabled: yes
-    daemon_reload: yes
+    enabled: true
+    daemon_reload: true
   become: true
   listen: start_mariadb
 ...

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -5,7 +5,7 @@
     name:
       - 'mariadb-server'
     state: 'latest'
-    update_cache: yes
+    update_cache: true
   notify:
     - 'restart_mariadb'
   become: true
@@ -72,7 +72,7 @@
     name:
       - 'MySQL-python'
     state: 'latest'
-    update_cache: yes
+    update_cache: true
   become: true
 
 - name: 'Set MariaDB/MySQL root user password.'
@@ -92,7 +92,8 @@
 # Without explicit flush the handlers will run after the slurm rol tasks,
 # which is too late resulting in Slurm unable to work with the Slurm Accounting DB.
 #
-- meta: flush_handlers
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: 'Give the MariaDB/MySQL master node some time to initialize the database cluster.'
   ansible.builtin.command: bash -c "sleep 60"

--- a/roles/slurm_management/templates/slurm.conf.22.05.2-1.el7.umcg
+++ b/roles/slurm_management/templates/slurm.conf.22.05.2-1.el7.umcg
@@ -18,6 +18,8 @@ JobSubmitPlugins=lua
 TmpFS=/local
 # Terminate job immediately when one of the processes is crashed or aborted.
 KillOnBadExit=1
+# Job with invalid dependency (by default) stay pending with DependencyNeverSatisfied. This option kills it and sets JOB_CANCELLED.
+DependencyParameters=kill_invalid_depend
 # Automatically requeue jobs after a node failure or preemption by a higher prio job.
 JobRequeue=1
 #
@@ -45,7 +47,7 @@ Waittime=15
 # Scheduling
 #
 SchedulerType=sched/backfill
-SchedulerParameters=kill_invalid_depend,bf_continue,bf_max_job_test=10000,bf_max_job_user=5000,default_queue_depth=1000,bf_window=10080,bf_resolution=300,bf_busy_nodes,preempt_reorder_count=100,preempt_youngest_first
+SchedulerParameters=bf_continue,bf_max_job_test=10000,bf_max_job_user=5000,default_queue_depth=1000,bf_window=10080,bf_resolution=300,bf_busy_nodes,preempt_reorder_count=100,preempt_youngest_first
 SelectType=select/cons_res
 SelectTypeParameters=CR_Core_Memory
 PriorityType=priority/multifactor


### PR DESCRIPTION
If submitted jobs fail, it dependent job stay in queue with status `DependencyNeverSatisfied`. Currently user has to either add additional `#SLURM` parameter that says that the jobs should be cleand OR user has to clean the jobs manually via `scancel`.
I checked the documentation of slurm configuration and found out that there is a setting called `DependencyParameters` that has option `kill_invalid_depend`, which does exactly this.

Other: fixed some other minor ansible-lint issues.