### PR TITLE
Only try to install the lustre client when a lustre mount is specified for inventory_hostname.

### DIFF
--- a/roles/lustre_client/tasks/main.yml
+++ b/roles/lustre_client/tasks/main.yml
@@ -7,5 +7,25 @@
 - name: 'Install Lustre client.'
   ansible.builtin.include_tasks:
     file: 'install.yml'
-  when: pfs_mounts | selectattr('type', 'equalto', 'lustre') | list | length >= 1
+  vars:
+    lustre_file_systems: "{{ pfs_mounts
+        | rejectattr('type', 'undefined')
+        | selectattr('type', 'equalto', 'lustre')
+        | map(attribute='pfs') }}"
+  when: inventory_hostname in lfs_mounts
+            | rejectattr('rw_machines', 'undefined')
+            | selectattr('pfs', 'in', lustre_file_systems)
+            | map(attribute='rw_machines')
+            | flatten | unique
+        or inventory_hostname in lfs_mounts
+            | rejectattr('ro_machines', 'undefined')
+            | selectattr('pfs', 'in', lustre_file_systems)
+            | map(attribute='ro_machines')
+            | flatten | unique
+        or inventory_hostname in pfs_mounts
+            | rejectattr('machines', 'undefined')
+            | rejectattr('type', 'undefined')
+            | selectattr('type', 'equalto', 'lustre')
+            | map(attribute='machines')
+            | flatten | unique
 ...


### PR DESCRIPTION
The previous `when` for installing the Lustre client would try to install that client on *all* machines of a _stack_ when `pfs_mounts` contained one or more Lustre file systems. Some machines of the _stack_ however may not need a Lustre mount and may not even have a network interface in a storage VLAN that can reach the Lustre server. This will then result in an error as the new `lustre_client` role will run a command that contacts the Lustre server to lookup certain configuration values.