### PR TITLE
Fix for error AuthorizedKeysCommand signal 13

### DIFF
--- a/roles/sssd/templates/get_public_keys_from_ldap.bash
+++ b/roles/sssd/templates/get_public_keys_from_ldap.bash
@@ -166,8 +166,6 @@ fi
 #
 # Return filtered public keys.
 #
-for authorized_key in "${authorized_keys[@]}"; do
-  printf '%s\n' "${authorized_key}"
-done
+( printf '%s\n' "${authorized_keys[@]}" ) || exit 0
 
 {% endraw %}


### PR DESCRIPTION
As discussed before, the sshd exits when finds the key already matches, while the bash script still is in the process printing out all of the keys. When this happened, the sshd kills the pipe, and so bash script gets an `error signal 13`. Sshd then still checks the return value, and since it is `> 0` it stops the login. This issue occurred to only some users (probably somehow connected with the ssh client version), but for those it was approximately quarter sessions failed.
The proposed solution wraps the script's last part, where only the key printing is happening. It catches any problematic output and exits gracefully.

Deployed on Hyperchicken :heavy_check_mark: 