### PR TITLE
Switched prm03 from group to project quota.

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -469,9 +469,8 @@ lfs_mounts:
     rw_machines: "{{ groups['user_interface'] }}"
   - lfs: prm03
     pfs: umcgst02
-    quota_type: 'group'
-    #quota_type: 'project'
-    #quota_pid_increment: 200000  # Value added to GID to create unique PID for a group on the PFS hosting this LFS.
+    quota_type: 'project'
+    quota_pid_increment: 200000  # Value added to GID to create unique PID for a group on the PFS hosting this LFS.
     groups:
       - name: umcg-aad
       - name: umcg-as


### PR DESCRIPTION
Robin enabled project quota on `DH4`, so we can now switch the `prm03` folders from group to project quota.