### PR TITLE
Small improvements

### DIFF
--- a/roles/lustre_client/tasks/install.yml
+++ b/roles/lustre_client/tasks/install.yml
@@ -166,7 +166,7 @@
     backup: true
     insertafter: '\[Install\]'
     regexp: '^#?WantedBy='
-    line: 'WantedBy=multi-user.target remote-fs.target'
+    line: 'WantedBy=multi-user.target remote-fs-pre.target'
     owner: root
     group: root
     mode: '0644'

--- a/single_group_playbooks/pre_deploy_checks.yml
+++ b/single_group_playbooks/pre_deploy_checks.yml
@@ -29,12 +29,15 @@
       connection: local
     - name: 'Download dependencies from Ansible Galaxy on the Ansible control host.'
       ansible.builtin.command:
-        cmd: ansible-galaxy install -r requirements.yml
+        cmd: ansible-galaxy install -r requirements.yml --timeout 120
       run_once: true  # noqa run-once
       delegate_to: localhost
       connection: local
-      changed_when: "'installed successfully' in resolved_dependencies.stdout"
       register: resolved_dependencies
+      changed_when: "'installed successfully' in resolved_dependencies.stdout"
+      retries: 3
+      delay: 10
+      until: resolved_dependencies is not failed
     - name: "Find all ip_addresses.yml files in {{ playbook_dir }}/group_vars/*."
       ansible.builtin.find:
         paths: "{{ playbook_dir }}/group_vars/"

--- a/single_role_playbooks/openstack_computing.yml
+++ b/single_role_playbooks/openstack_computing.yml
@@ -8,7 +8,7 @@
     # Disable Ansible's interpretor detection logic,
     # which would fail to use the interpretor from an activated virtual environment.
     #
-    - ansible_python_interpreter: python
+    ansible_python_interpreter: python
   roles:
     - openstack_computing
 ...

--- a/single_role_playbooks/openstack_networking.yml
+++ b/single_role_playbooks/openstack_networking.yml
@@ -8,7 +8,7 @@
     # Disable Ansible's interpretor detection logic,
     # which would fail to use the interpretor from an activated virtual environment.
     #
-    - ansible_python_interpreter: python
+    ansible_python_interpreter: python
   roles:
     - openstack_networking
 ...


### PR DESCRIPTION
* Fixed vars list -> dict in `openstack* single_role_playbooks`
* Implemented timeout & retry for fetching Ansible dependencies from `requirements.yml` in `single_group_playbooks/pre_deploy_checks.yml`.
* `lustre_client` role: Fixed (re)boot order dependency.