### PR TITLE
Chaperone aliases and attempt at making CircleCI jobs with ansible-lint more robust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             else
                 export ANSIBLE_ROLES_PATH="${HOME}/.ansible/roles/"
             fi
-            if ansible-lint -p --nocolor *.yml > lint_results 2>&1; then
+            if ansible-lint -p --nocolor --offline *.yml > lint_results 2>&1; then
               lint_errors=0
             else
               cat lint_results

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -88,7 +88,7 @@ all:
     chaperone:
       hosts:
         bb-chaperone:
-          ansible_host: bb-chaperone.umcg.nl
+          ansible_host: bb-chaperone.umcg.nl  # upzkh1055
           use_ldap: false
           functional_admin_group: 'MEDGEN-NFG GCC Analyse Team'
           #

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -88,7 +88,7 @@ all:
     chaperone:
       hosts:
         cf-chaperone:
-          ansible_host: cf-chaperone.umcg.nl
+          ansible_host: cf-chaperone.umcg.nl  # upzkh1056
           use_ldap: false
           functional_admin_group: 'MEDGEN-NFG GCC Analyse Team'
           #

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -102,7 +102,7 @@ all:
       hosts:
         wh-chaperone:
           #ansible_host: uozkh1016.zkh.umcg.intra
-          ansible_host: wh-chaperone.umcg.nl
+          ansible_host: wh-chaperone.umcg.nl  # upzkh1054.
           use_ldap: false
           functional_admin_group: 'MEDGEN-NFG GCC Analyse Team'
           #


### PR DESCRIPTION
* [Added chaperone aliases in a comment in static_inventories.](https://github.com/rug-cit-hpc/league-of-robots/commit/ff4540d1e78fc98cb6f80e9ac05de6f67f4ca168)
* [Switched ansible-lint to offline mode in CircleCI config to prevent redundantly resolving dependencies with "ansible-galaxy install -r requirements.yml" with a high chance of failing, because of silly timeouts.](https://github.com/rug-cit-hpc/league-of-robots/commit/813a4d913123753735df1846b01e6c60e9eea3dd)