### PR TITLE
Improved configuration of functional accounts on chaperone machines.

### DIFF
--- a/roles/envsync/tasks/main.yml
+++ b/roles/envsync/tasks/main.yml
@@ -80,7 +80,7 @@
     create: false
   become: true
 
-- name: 'Deploy script to verify and if necessary fix prmissions of the environment managed by the envsync account.'
+- name: 'Deploy script to verify and if necessary fix permissions of the environment managed by the envsync account.'
   ansible.builtin.template:
     src: 'templates/hpc-environment-permissions.bash'
     dest: '/root/hpc-environment-permissions.bash'

--- a/roles/envsync/tasks/main.yml
+++ b/roles/envsync/tasks/main.yml
@@ -86,7 +86,7 @@
     dest: '/root/hpc-environment-permissions.bash'
     owner: 'root'
     group: 'root'
-    mode: '0644'
+    mode: '0750'
   become: true
 
 - name: 'Create cron job to execute script to verify and if necessary fix prmissions of the environment managed by the envsync account.'
@@ -96,7 +96,8 @@
     hour: '04'
     minute: '04'
     user: 'root'
-    job: '/bin/bash /root/hpc-environment-permissions.bash'
+    job: |
+         /bin/bash -c '/root/hpc-environment-permissions.bash | /bin/logger'
     cron_file: 'hpc-environment-permissions'
   become: true
 
@@ -108,7 +109,7 @@
     minute: '05'
     user: "{{ envsync_user }}"
     job: |
-         /usr/bin/sg '{{ envsync_group }}' -c '/bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; hpc-environment-sync.bash -a"'
+         /usr/bin/sg '{{ envsync_group }}' -c '/bin/bash -c "export SOURCE_HPC_ENV="True"; . ~/.bashrc; hpc-environment-sync.bash -a | /bin/logger"'
     cron_file: 'hpc-environment-sync'
   become: true
 ...

--- a/roles/online_docs/templates/attachments/ssh-client-config.bash
+++ b/roles/online_docs/templates/attachments/ssh-client-config.bash
@@ -239,7 +239,7 @@ function manageConfig() {
 	#
 	log4Bash 'DEBUG' "${LINENO}" "${FUNCNAME[0]:-main}" '0' "Appending the public key of the Certificate Authority (CA) to ${HOME}/.ssh/known_hosts ..."
 	printf '%s\n' \
-		"@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key+'.pub') }} for {{ slurm_cluster_name }}" \
+		"@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key + '.pub') }} for {{ slurm_cluster_name }}" \
 		> "${HOME}/.ssh/known_hosts.new"
 	if [[ -e "${HOME}/.ssh/known_hosts" ]]; then
 		#

--- a/roles/online_docs/templates/mkdocs/docs/logins-linux-config.md
+++ b/roles/online_docs/templates/mkdocs/docs/logins-linux-config.md
@@ -30,7 +30,7 @@ Open a terminal and copy paste the following commands:
 # Create new known_hosts file and append the UMCG HPC CA's public key.
 #
 printf '%s\n' \
-            "@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key+'.pub') }} for {{ slurm_cluster_name }}" \
+            "@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key + '.pub') }} for {{ slurm_cluster_name }}" \
     > "${HOME}/.ssh/known_hosts.new"
 if [[ -e "${HOME}/.ssh/known_hosts" ]]; then
     #

--- a/roles/regular_users/defaults/main.yml
+++ b/roles/regular_users/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+known_hosts_hostnames: "\
+  {% for jumphost in groups['jumphost'] | default([]) %}\
+    {{ jumphost }}*,\
+    {% for network_id in ip_addresses[jumphost] %}\
+      {% if ip_addresses[jumphost][network_id]['fqdn'] is defined and
+            ip_addresses[jumphost][network_id]['fqdn'] == 'NXDOMAIN' %}\
+        {{ ip_addresses[jumphost][network_id]['address'] }},\
+      {% endif %}\
+    {% endfor %}\
+  {% endfor %}\
+  {% for dthost in groups['data_transfer'] | default([]) %}\
+    *{{ dthost }}*,\
+    {% for network_id in ip_addresses[dthost] %}\
+      {% if ip_addresses[dthost][network_id]['fqdn'] is defined and
+            ip_addresses[dthost][network_id]['fqdn'] == 'NXDOMAIN' %}\
+        {{ ip_addresses[dthost][network_id]['address'] }},\
+      {% endif %}\
+    {% endfor %}\
+  {% endfor %}\
+  {% for adminhost in groups['administration'] | default([]) %}\
+    *{{ adminhost }},\
+  {% endfor %}\
+  {% for dochost in groups['docs'] | default([]) %}\
+    *{{ dochost }},\
+  {% endfor %}\
+  *{{ stack_prefix }}-*"
+...

--- a/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
+++ b/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
@@ -5,39 +5,9 @@
 # even if we couldf, that won't fix .bashrc if the home dir already exists
 # or functionality to load modules was lost or needs an update.
 #
-- name: Get details for regular users.
-  ansible.builtin.user:
-    name: "{{ item }}"
-  check_mode: true
-  register: user_account_settings
-  with_items: "{{ regular_users }}"
-
-- name: DEBUG
-  debug:
-    msg: "user {{ item.user }} has home dir {{ user_account_settings[item.user]['home'] }}."
-  with_items: "{{ regular_users }}"
-
-- meta: end_play
-
-- name: Insert/update block into ~/.bashrc to ensure we can load modules.
-  ansible.builtin.blockinfile:
-    path: "{{ user_account_settings[item.user]['home'] }}/{{ item.user }}/.bashrc"
-    block: |
-      if [ -f "/apps/modules//modules.bashrc" ]; then
-        source "/apps/modules//modules.bashrc"
-      fi
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - Setup environment for Lua, Lmod & EasyBuild."
-    insertbefore: '# User specific aliases and functions'
-    create: false
-    owner: "{{ item.user }}"
-    group: "{{ item.user }}"
-    mode: '0600'
-  with_items: "{{ regular_users }}"
-  become: true
-
 - name: Create ~/.ssh dir and subdirs.
   ansible.builtin.file:
-    path: "{{ user_account_settings[item.0.user]['home'] }}/{{ item.1 }}"
+    path: "/home/{{ item.0.user }}/{{ item.1 }}"
     state: 'directory'
     owner: "{{ item.0.user }}"
     group: "{{ item.0.user }}"
@@ -52,7 +22,7 @@
 
 - name: 'Configure ssh client config file ~/.ssh/config to include ~/.ssh/conf.d dir.'
   ansible.builtin.lineinfile:
-    path: "{{ user_account_settings[item.user]['home'] }}/.ssh/config"
+    path: "/home/{{ item.user }}/.ssh/config"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"
     mode: '0600'
@@ -66,7 +36,7 @@
 - name: "Create ~/.ssh/conf.d/{{ slurm_cluster_name }} config file."
   ansible.builtin.template:
     src: ssh_client_config.j2
-    dest: "{{ user_account_settings[item.user]['home'] }}/.ssh/conf.d/{{ slurm_cluster_name }}"
+    dest: "/home/{{ item.user }}/.ssh/conf.d/{{ slurm_cluster_name }}"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"
     mode: '0600'
@@ -75,7 +45,7 @@
 
 - name: "Add {{ slurm_cluster_name }} settings to ssh client ~/.ssh/known_hosts file."
   ansible.builtin.lineinfile:
-    path: "{{ user_account_settings[item.user]['home'] }}/.ssh/known_hosts"
+    path: "/home/{{ item.user }}/.ssh/known_hosts"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"
     mode: '0600'
@@ -88,7 +58,7 @@
 
 - name: 'Insert/update block into ~/.bashrc to ensure we can load modules.'
   ansible.builtin.blockinfile:
-    path: "{{ user_account_settings[item.user]['home'] }}/.bashrc"
+    path: "/home/{{ item.user }}/.bashrc"
     block: |
       if [ -f "/apps/modules//modules.bashrc" ]; then
         source "/apps/modules//modules.bashrc"

--- a/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
+++ b/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
@@ -14,7 +14,7 @@
 
 - name: DEBUG
   debug:
-    msg: "user {{item.user}} has home dir {{ user_account_settings[item.user]['home'] }}."
+    msg: "user {{ item.user }} has home dir {{ user_account_settings[item.user]['home'] }}."
   with_items: "{{ regular_users }}"
 
 - meta: end_play
@@ -47,12 +47,11 @@
       - '.ssh'
       - '.ssh/tmp'
       - '.ssh/conf.d'
-  become: true
   with_items: "{{ regular_users | product(ssh_client_dirs) | list }}"
   become: true
 
 - name: 'Configure ssh client config file ~/.ssh/config to include ~/.ssh/conf.d dir.'
-  ansible.posix.lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ user_account_settings[item.user]['home'] }}/.ssh/config"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"
@@ -75,7 +74,7 @@
   become: true
 
 - name: "Add {{ slurm_cluster_name }} settings to ssh client ~/.ssh/known_hosts file."
-  ansible.posix.lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ user_account_settings[item.user]['home'] }}/.ssh/known_hosts"
     owner: "{{ item.user }}"
     group: "{{ item.user }}"
@@ -83,7 +82,7 @@
     create: true
     insertbefore: BOF
     regexp: '(?i)^#?@cert-authority .* for {{ slurm_cluster_name }}$'
-    line: "@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key+'.pub') }} for {{ slurm_cluster_name }}"
+    line: "@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key + '.pub') }} for {{ slurm_cluster_name }}"
   with_items: "{{ regular_users }}"
   become: true
 

--- a/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
+++ b/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
@@ -17,7 +17,7 @@
       - '.ssh'
       - '.ssh/tmp'
       - '.ssh/conf.d'
-  with_items: "{{ regular_users | product(ssh_client_dirs) | list }}"
+  loop: "{{ regular_users | product(ssh_client_dirs) | list }}"
   become: true
 
 - name: 'Configure ssh client config file ~/.ssh/config to include ~/.ssh/conf.d dir.'

--- a/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
+++ b/roles/regular_users/tasks/functional_accounts_on_chaperones.yml
@@ -1,0 +1,105 @@
+---
+#
+# On most systems we already added relevant code to /ets/skel/ to create a proper .bashrc
+# when a home dir is created, but on chaperones we do not control /etc/skel and
+# even if we couldf, that won't fix .bashrc if the home dir already exists
+# or functionality to load modules was lost or needs an update.
+#
+- name: Get details for regular users.
+  ansible.builtin.user:
+    name: "{{ item }}"
+  check_mode: true
+  register: user_account_settings
+  with_items: "{{ regular_users }}"
+
+- name: DEBUG
+  debug:
+    msg: "user {{item.user}} has home dir {{ user_account_settings[item.user]['home'] }}."
+  with_items: "{{ regular_users }}"
+
+- meta: end_play
+
+- name: Insert/update block into ~/.bashrc to ensure we can load modules.
+  ansible.builtin.blockinfile:
+    path: "{{ user_account_settings[item.user]['home'] }}/{{ item.user }}/.bashrc"
+    block: |
+      if [ -f "/apps/modules//modules.bashrc" ]; then
+        source "/apps/modules//modules.bashrc"
+      fi
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - Setup environment for Lua, Lmod & EasyBuild."
+    insertbefore: '# User specific aliases and functions'
+    create: false
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
+    mode: '0600'
+  with_items: "{{ regular_users }}"
+  become: true
+
+- name: Create ~/.ssh dir and subdirs.
+  ansible.builtin.file:
+    path: "{{ user_account_settings[item.0.user]['home'] }}/{{ item.1 }}"
+    state: 'directory'
+    owner: "{{ item.0.user }}"
+    group: "{{ item.0.user }}"
+    mode: '0700'
+  vars:
+    ssh_client_dirs:
+      - '.ssh'
+      - '.ssh/tmp'
+      - '.ssh/conf.d'
+  become: true
+  with_items: "{{ regular_users | product(ssh_client_dirs) | list }}"
+  become: true
+
+- name: 'Configure ssh client config file ~/.ssh/config to include ~/.ssh/conf.d dir.'
+  ansible.posix.lineinfile:
+    path: "{{ user_account_settings[item.user]['home'] }}/.ssh/config"
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
+    mode: '0600'
+    create: true
+    insertbefore: BOF
+    regexp: '(?i)^#?Include'
+    line: 'Include conf.d/*'
+  with_items: "{{ regular_users }}"
+  become: true
+
+- name: "Create ~/.ssh/conf.d/{{ slurm_cluster_name }} config file."
+  ansible.builtin.template:
+    src: ssh_client_config.j2
+    dest: "{{ user_account_settings[item.user]['home'] }}/.ssh/conf.d/{{ slurm_cluster_name }}"
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
+    mode: '0600'
+  with_items: "{{ regular_users }}"
+  become: true
+
+- name: "Add {{ slurm_cluster_name }} settings to ssh client ~/.ssh/known_hosts file."
+  ansible.posix.lineinfile:
+    path: "{{ user_account_settings[item.user]['home'] }}/.ssh/known_hosts"
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
+    mode: '0600'
+    create: true
+    insertbefore: BOF
+    regexp: '(?i)^#?@cert-authority .* for {{ slurm_cluster_name }}$'
+    line: "@cert-authority {{ known_hosts_hostnames }} {{ lookup('file', ssh_host_signer_ca_private_key+'.pub') }} for {{ slurm_cluster_name }}"
+  with_items: "{{ regular_users }}"
+  become: true
+
+- name: 'Insert/update block into ~/.bashrc to ensure we can load modules.'
+  ansible.builtin.blockinfile:
+    path: "{{ user_account_settings[item.user]['home'] }}/.bashrc"
+    block: |
+      if [ -f "/apps/modules//modules.bashrc" ]; then
+        source "/apps/modules//modules.bashrc"
+      fi
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - Setup environment for Lua, Lmod & EasyBuild."
+    insertbefore: '# User specific aliases and functions'
+    create: false
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
+    mode: '0600'
+  with_items: "{{ regular_users }}"
+  become: true
+...

--- a/roles/regular_users/tasks/main.yml
+++ b/roles/regular_users/tasks/main.yml
@@ -31,4 +31,9 @@
     - inventory_hostname in groups['chaperone'] | default([])
     - remote_users_in_local_groups is defined
 
+- name: 'Configure functional local accounts on chaperones.'
+  ansible.builtin.include_tasks:
+    file: functional_accounts_on_chaperones.yml
+  when:
+    - inventory_hostname in groups['chaperone'] | default([])
 ...

--- a/roles/regular_users/templates/ssh_client_config.j2
+++ b/roles/regular_users/templates/ssh_client_config.j2
@@ -1,0 +1,63 @@
+#
+# Host settings.
+#
+Host {% for jumphost in groups['jumphost'] %}{{ jumphost }}* {% endfor %}{% raw %}{% endraw %}
+    #
+    # Default account name when not specified explicitly.
+    #
+    User {{ item.user }}
+    #
+    # Prevent timeouts
+    #
+    ServerAliveInterval 60
+    ServerAliveCountMax 5
+    #
+    # We use public-private key pairs for authentication.
+    # Do not use password based authentication as fallback,
+    # which may be confusing and won't work anyway.
+    #
+    IdentityFile "~/.ssh/id_ed25519"
+    PasswordAuthentication No
+    #
+    # Multiplex connections to
+    #   * reduce lag when logging in to the same host in a second terminal
+    #   * reduce the amount of connections that are made to prevent excessive DNS lookups
+    #     and to prevent getting blocked by a firewall, because it thinks we are executing a DoS attack.
+    #
+    # Name/location of sockets for connection multiplexing are configured using the ControlPath directive.
+    # In the ControlPath directive %C expands to a hashed value of %l_%h_%p_%r, where:
+    #    %l = local hostname
+    #    %h = remote hostname
+    #    %p = remote port
+    #    %r = remote username
+    # This makes sure that the ControlPath is
+    #   * a unique socket that is local to machine on which the sessions are created,
+    #     which means it works with home dirs from a shared network file system.
+    #     (as sockets cannot be shared by servers.)
+    #   * not getting to long as the hash has a fixed size not matter how long %l_%h_%p_%r was.
+    #
+    ControlMaster auto
+    ControlPath ~/.ssh/tmp/%C
+    ControlPersist 1m
+#
+# Expand short jumphost names to FQDN or IP address.
+#
+{% for jumphost in groups['jumphost'] %}
+  {%- set network_id = ip_addresses[jumphost]
+           | dict2items
+           | json_query('[?value.fqdn].key')
+           | first -%}
+  {%- if ip_addresses[jumphost][network_id]['fqdn'] == 'NXDOMAIN' -%}
+    {%- set ssh_hostname = ip_addresses[jumphost][network_id]['address'] -%}
+  {%- else -%}
+    {%- set ssh_hostname = ip_addresses[jumphost][network_id]['fqdn'] -%}
+  {%- endif -%}
+Host {{ jumphost }}
+    HostName {{ ssh_hostname }}
+    HostKeyAlias {{ jumphost }}
+{% endfor -%}
+#
+# Double-hop SSH settings to connect via specific jumphosts.
+#
+Host {% for jumphost in groups['jumphost'] %}{{ jumphost }}+* {% endfor %}{% raw %}{% endraw %}
+    ProxyCommand ssh -x -q $(echo "${JUMPHOST_USER:-%r}")@$(echo %h | sed 's/+[^+]*$//'){% if stack_domain | length %}.{{ stack_domain }}{% endif %} -W $(echo %h | sed 's/^[^+]*+//'):%p

--- a/roles/regular_users/templates/ssh_client_config.j2
+++ b/roles/regular_users/templates/ssh_client_config.j2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:False
 #
 # Host settings.
 #


### PR DESCRIPTION
* Added code to configure `~/.bashrc` and `~/.ssh/...` for functional accounts on chaperones.
* Send STDOUT from envsync cronjobs to `/var/log/messages` using `logger`. 