### PR TITLE
Dh migration part1

### DIFF
--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -642,7 +642,7 @@ lfs_mounts:
       - name: umcg-vdakker
       - name: umcg-weersma
       - name: umcg-wijmenga
-    rw_machines: "{{ groups['user_interface'] }}"
+    ro_machines: "{{ groups['user_interface'] }}"
   - lfs: prm03
     pfs: umcgst02
     quota_type: 'project'
@@ -750,8 +750,7 @@ lfs_mounts:
       - name: umcg-vdakker
       - name: umcg-weersma
       - name: umcg-wijmenga
-    ro_machines: "{{ groups['compute_vm'] }}"
-    rw_machines: "{{ groups['user_interface'] }}"
+    ro_machines: "{{ groups['compute_vm'] + groups['user_interface'] }}"
   - lfs: env01
     pfs: umcgst10
     ro_machines: "{{ groups['compute_vm'] + groups['user_interface'] }}"

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -145,7 +145,9 @@
     opts: "{{ pfs_mounts | selectattr('pfs', 'match', item.pfs) | map(attribute='rw_options') | first }}"
     state: 'mounted'
   with_items: "{{ lfs_mounts | selectattr('lfs', 'search', 'home') | list }}"
-  when: inventory_hostname in item.rw_machines and not inventory_hostname in groups['nfs_server'] | default([])
+  when:
+    - inventory_hostname in item.rw_machines | default ([])
+    - not inventory_hostname in groups['nfs_server'] | default([])
   become: true
 
 - name: 'Create root /groups folder.'
@@ -189,7 +191,7 @@
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'tmp[0-9]+$') | list }}"
     - 'groups'
-  when: inventory_hostname in item.0.rw_machines
+  when: inventory_hostname in item.0.rw_machines | default ([])
   become: true
 
 - name: 'Mount "rsc" Logical File Systems (LFSs) per group from shared storage read-write.'
@@ -203,7 +205,7 @@
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'rsc[0-9]+$') | list }}"
     - 'groups'
-  when: inventory_hostname in item.0.rw_machines
+  when: inventory_hostname in item.0.rw_machines | default ([])
   become: true
 
 - name: 'Mount "rsc" Logical File Systems (LFSs) per group from shared storage read-only.'
@@ -217,7 +219,7 @@
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'rsc[0-9]+$') | list }}"
     - 'groups'
-  when: inventory_hostname in item.0.ro_machines
+  when: inventory_hostname in item.0.ro_machines | default ([])
   become: true
 
 - name: 'Mount "prm" Logical File Systems (LFSs) per group from shared storage read-write.'
@@ -236,7 +238,26 @@
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'prm[0-9]+$') | list }}"
     - 'groups'
-  when: inventory_hostname in item.0.rw_machines
+  when: inventory_hostname in item.0.rw_machines | default ([])
+  become: true
+
+- name: 'Mount "prm" Logical File Systems (LFSs) per group from shared storage read-only.'
+  ansible.posix.mount:
+    path: "/groups/{{ item.1.name }}/{{ item.0.lfs }}"
+    src: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='source') | first }}/\
+          {{ item.0.pfs }}/groups/{{ item.1.name }}/{{ item.0.lfs }}"
+    fstype: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='type') | first }}"
+    opts: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='ro_options') | first }}{{ extra_opts }}"
+    state: 'mounted'
+  vars:
+    extra_opts: >-
+      {%- if pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='type') | first == 'cifs' -%}
+      ,credentials=/etc/sysconfig/{{ item.0.pfs | regex_replace('\$$', '') }}.cifs,uid={{ item.1.name }}-dm,gid={{ item.1.name }}
+      {%- endif -%}
+  with_subelements:
+    - "{{ lfs_mounts | selectattr('lfs', 'search', 'prm[0-9]+$') | list }}"
+    - 'groups'
+  when: inventory_hostname in item.0.ro_machines | default ([])
   become: true
 
 - name: 'Mount "dat" Logical File Systems (LFSs) per group from shared storage read-write.'
@@ -255,7 +276,7 @@
   with_subelements:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'dat[0-9]+$') | list }}"
     - 'groups'
-  when: inventory_hostname in item.0.rw_machines
+  when: inventory_hostname in item.0.rw_machines | default ([])
   become: true
 
 - name: 'Mount "env" Logical File Systems (LFSs) from shared storage read-write.'
@@ -267,7 +288,7 @@
     opts: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.pfs) | map(attribute='rw_options') | first }}"
     state: 'mounted'
   with_items: "{{ lfs_mounts | selectattr('lfs', 'search', 'env[0-9]+$') | list }}"
-  when: inventory_hostname in item.rw_machines
+  when: inventory_hostname in item.rw_machines | default ([])
   become: true
 
 - name: 'Mount "apps" from one "env" Logical File System (LFS) from shared storage read-only as /apps.'
@@ -280,7 +301,7 @@
     state: 'mounted'
   with_items:
     - "{{ lfs_mounts | selectattr('lfs', 'search', 'env[0-9]+$') | list }}"
-  when: inventory_hostname in item.ro_machines
+  when: inventory_hostname in item.ro_machines | default ([])
   become: true
 
 #


### PR DESCRIPTION
* Data Handling Lustre migration to new data center part 1: [Switched dh1 mounts from read-write to read-only.](https://github.com/rug-cit-hpc/league-of-robots/pull/764/commits/a3646cbd2a2c216bff083f1e22a8b00482c9b7ad)
[a3646cb](https://github.com/rug-cit-hpc/league-of-robots/pull/764/commits/a3646cbd2a2c216bff083f1e22a8b00482c9b7ad)
* `shared_storage` role: [added defaults to handle empty lists and added option to mount prm file systems read-only.](https://github.com/rug-cit-hpc/league-of-robots/pull/764/commits/06bf12b6673316db55bb96d93aac521c842cd3e5)
[06bf12b](https://github.com/rug-cit-hpc/league-of-robots/pull/764/commits/06bf12b6673316db55bb96d93aac521c842cd3e5)