### PR TITLE
Update firewalls of new data transfer servers.

### DIFF
--- a/group_vars/all/ip_addresses.yml
+++ b/group_vars/all/ip_addresses.yml
@@ -118,6 +118,11 @@ ip_addresses:
       address: '145.88.35.10'
       netmask: '/32'
       desc: 'Jumphost for LUMC Shark cluster.'
+  genomescan:
+    portal:
+      address: '145.88.209.231'
+      netmask: '/32'
+      desc: 'Genomescan data transfer server.'
   #
   # EBI & Sanger servers.
   #
@@ -251,7 +256,6 @@ ip_addresses:
       address: '74.125.143.127'
       netmask: '/32'
       desc: 'stun.l.google.com for connection to STUN server when setting up a session with another Globus Connect Personal endpoint.'
-
   #
   # GitHub hooks
   #

--- a/group_vars/betabarrel_cluster/ip_addresses.yml
+++ b/group_vars/betabarrel_cluster/ip_addresses.yml
@@ -37,4 +37,12 @@ ip_addresses:
       address: 74.234.160.235
       netmask: /32
       fqdn: 'NXDOMAIN'
+  bb_internal_management-vlan16-router:
+    bb_internal_management:
+      address: 10.10.1.1
+      netmask: /32
+    vlan16:
+      address: 195.169.22.174
+      netmask: /32
+      fqdn: 'NXDOMAIN'
 ...

--- a/group_vars/copperfist_cluster/ip_addresses.yml
+++ b/group_vars/copperfist_cluster/ip_addresses.yml
@@ -28,4 +28,12 @@ ip_addresses:
     vlan990:
       address: 192.168.1.22
       netmask: /32
+  cf_internal_management-vlan16-router:
+    cf_internal_management:
+      address: 10.10.1.1
+      netmask: /32
+    vlan16:
+      address: 195.169.22.186
+      netmask: /32
+      fqdn: 'NXDOMAIN'
 ...

--- a/group_vars/jenkins.yml
+++ b/group_vars/jenkins.yml
@@ -26,7 +26,7 @@ iptables_allow_ssh_inbound:
   - "{{ talos_cluster.ip_addresses['reception']['vlan16'] }}"
   - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['vlan16'] }}"
   - "{{ betabarrel_cluster.ip_addresses['bb-porch']['vlan16'] }}"
-  - "{{ copperfist_cluster.ip_addresses['cf-porch']['vlan16'] }}"  
+  - "{{ copperfist_cluster.ip_addresses['cf-porch']['vlan16'] }}"
 iptables_allow_ssh_outbound:
   - "{{ gearshift_cluster.ip_addresses['airlock']['vlan16'] }}"
   - "{{ hyperchicken_cluster.ip_addresses['portal']['public'] }}"

--- a/group_vars/template/ip_addresses.yml.j2
+++ b/group_vars/template/ip_addresses.yml.j2
@@ -33,4 +33,23 @@ ip_addresses:
     {% endif %}
   {% endfor %}
 {% endfor %}
+{% for stack_network in stack_networks
+   | selectattr('router_network', 'defined')
+   | sort(attribute='name') %}
+  {% set router_name = 'Router bridging ' + stack_network.router_network + ' and ' + stack_network.name %}
+  {{ stack_network.name }}-{{ stack_network.router_network }}-router:
+    {{ stack_network.name }}:
+      address: {{ stack_network.gateway }}
+      netmask: /32
+    {{ stack_network.router_network }}:
+      address: {{ api_routers_info['openstack_routers']
+                  | selectattr('name', 'equalto', router_name)
+                  | map(attribute='external_gateway_info')
+                  | map (attribute='external_fixed_ips')
+                  | first
+                  | map (attribute='ip_address')
+                  | first }}
+      netmask: /32
+      fqdn: 'NXDOMAIN'
+{% endfor %}
 ...

--- a/group_vars/wingedhelix_cluster/ip_addresses.yml
+++ b/group_vars/wingedhelix_cluster/ip_addresses.yml
@@ -60,4 +60,12 @@ ip_addresses:
     wh_internal_storage:
       address: 10.10.2.245
       netmask: /32
+  wh_internal_management-vlan16-router:
+    wh_internal_management:
+      address: 10.10.1.1
+      netmask: /32
+    vlan16:
+      address: 195.169.22.169
+      netmask: /32
+      fqdn: 'NXDOMAIN'
 ...

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -76,6 +76,9 @@
   notify: configure_iptables
   become: true
 
+- name: Flush handlers for iptables role.
+  ansible.builtin.meta: flush_handlers
+
 - name: Configure the firewall service.
   ansible.builtin.service:
     name: "{{ item }}"

--- a/roles/openstack_computing/tasks/main.yml
+++ b/roles/openstack_computing/tasks/main.yml
@@ -22,6 +22,10 @@
   openstack.cloud.networks_info:
   register: api_network_info
   run_once: true
+- name: Get info on routers from OpenStack API.
+  openstack.cloud.routers_info:
+  register: api_routers_info
+  run_once: true
 - name: Get server info from OpenStack API.
   openstack.cloud.server_info:
   register: api_server_info

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -54,8 +54,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -69,8 +71,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
             - "{{ all.ip_addresses['umcg']['net2'] }}"
@@ -83,8 +87,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -50,8 +50,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
@@ -62,8 +65,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -73,8 +79,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -42,6 +42,40 @@ all:
               security_group: "{{ stack_prefix }}_ds"
               assign_floating_ip: true
           local_volume_size_extra: 2000
+          iptables_allow_icmp_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_https_inbound:
+            # On data_transfer servers port 443 is used for SSH too.
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_ssh_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -42,8 +42,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -57,8 +59,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
             - "{{ all.ip_addresses['umcg']['net2'] }}"
@@ -71,8 +75,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -38,8 +38,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
@@ -50,8 +53,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -61,8 +67,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -30,6 +30,40 @@ all:
               security_group: "{{ stack_prefix }}_ds"
               assign_floating_ip: true
           local_volume_size_extra: 2000
+          iptables_allow_icmp_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_https_inbound:
+            # On data_transfer servers port 443 is used for SSH too.
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_ssh_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -38,6 +38,40 @@ all:
               security_group: "{{ stack_prefix }}_ds"
               assign_floating_ip: true
           local_volume_size_extra: 800
+          iptables_allow_icmp_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_https_inbound:
+            # On data_transfer servers port 443 is used for SSH too.
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+          iptables_allow_ssh_inbound:
+            - "{{ all.ip_addresses['umcg']['net1'] }}"
+            - "{{ all.ip_addresses['umcg']['net2'] }}"
+            - "{{ all.ip_addresses['umcg']['net3'] }}"
+            - "{{ all.ip_addresses['umcg']['net4'] }}"
+            - "{{ all.ip_addresses['rug']['bwp_net'] }}"
+            - "{{ all.ip_addresses['rug']['operator'] }}"
+            - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:
         docs_on_merlin:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -46,8 +46,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
@@ -58,8 +61,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -69,8 +75,11 @@ all:
             - "{{ all.ip_addresses['rug']['bwp_net'] }}"
             - "{{ all.ip_addresses['rug']['operator'] }}"
             - "{{ all.ip_addresses['genomescan']['portal'] }}"
+            - "{{ wingedhelix_cluster.ip_addresses['wh-porch']['wh_internal_management'] }}"
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
     docs:
       hosts:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -50,8 +50,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_https_inbound:
             # On data_transfer servers port 443 is used for SSH too.
             - "{{ all.ip_addresses['umcg']['net1'] }}"
@@ -65,8 +67,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
           iptables_allow_ssh_inbound:
             - "{{ all.ip_addresses['umcg']['net1'] }}"
             - "{{ all.ip_addresses['umcg']['net2'] }}"
@@ -79,8 +83,10 @@ all:
             - "{{ wingedhelix_cluster.ip_addresses['wh_internal_management-vlan16-router']['vlan16'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb-porch']['bb_internal_management'] }}"
             - "{{ betabarrel_cluster.ip_addresses['bb_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ betabarrel_cluster.ip_addresses['betabarrel']['vlan13'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf-porch']['cf_internal_management'] }}"
             - "{{ copperfist_cluster.ip_addresses['cf_internal_management-vlan16-router']['vlan16'] }}"
+            - "{{ copperfist_cluster.ip_addresses['copperfist']['vlan13'] }}"
     docs:
       hosts:
         docs_on_merlin:


### PR DESCRIPTION
* [Added IP address for Genomescan data transfer server to group_vars/all/ip_addresses.yml.](https://github.com/rug-cit-hpc/league-of-robots/commit/d5b083a27a548fc289526bf2e613bbf166fd8a7a)
* [Feature: add network addresses of OpenStack routers to the ip_addresses.yml file generated for a stack.](https://github.com/rug-cit-hpc/league-of-robots/commit/a8e7b72dcf96caf77a9af69c773e2e7c63ffb721)
* [Added IPs of routers to ip_addresses.yml for BB, CF and WH.](https://github.com/rug-cit-hpc/league-of-robots/commit/8308ec5d7107637ae8478a1b5faa199f50b221ce)
* [Update firewalls of BB, CF and WH data transfer servers to allow access only from machines of these stacks and the Genomescan data transfer server.](https://github.com/rug-cit-hpc/league-of-robots/commit/4b86dbbe6a1070d36b48f06dff8dd12e30222951)