### PR TITLE
Resized local disks for VMs on the same Shikra node.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,4 +7,5 @@ skip_list:
   - 'meta-no-info'  # "No 'galaxy_info' found in meta/main.yml of a role (701)."
   - 'experimental'  # All rules tagged as experimental.
   - 'name[template]'  # Allow jinja templating anywhere in a task name.
+  - 'var-naming[no-role-prefix]'  # Temporarily disable this new check: will be fixed in a dedicated PR.
 ...

--- a/roles/openstack_networking/tasks/security_groups.yml
+++ b/roles/openstack_networking/tasks/security_groups.yml
@@ -6,6 +6,7 @@
 # Jumphosts security groups.
 #
 - name: "Create security groups for machines in 'jumphost' inventory group."
+  when: "'jumphost' in inventory_groups_with_hosts_created_in_openstack"
   block:
     - name: "Create security group for {{ stack_prefix }} jumphosts."
       openstack.cloud.security_group:
@@ -37,11 +38,11 @@
           port: 636  # LDAPS
         - protocol: icmp
           port: -1  # ICMP protocol does not have any ports.
-  when: "'jumphost' in inventory_groups_with_hosts_created_in_openstack"
 #
 # Data staging security groups.
 #
 - name: "Create security groups for machines in 'data_transfer' inventory group."
+  when: "'data_transfer' in inventory_groups_with_hosts_created_in_openstack"
   block:
     - name: "Create security group for {{ stack_prefix }} data transfer servers."
       openstack.cloud.security_group:
@@ -73,11 +74,11 @@
           port: 636  # LDAPS; ToDo: restrict to {{ ldap_uri }}
         - protocol: icmp
           port: -1  # ICMP protocol does not have any ports.
-  when: "'data_transfer' in inventory_groups_with_hosts_created_in_openstack"
 #
 # Cluster security groups.
 #
 - name: "Create security groups for machines in 'cluster' inventory group."
+  when: "'cluster' in inventory_groups_with_hosts_created_in_openstack"
   block:
     #
     # Management network security
@@ -215,11 +216,11 @@
                 | map(attribute='name')
                 | intersect(network_names_of_all_hosts_created_in_openstack)
                 | length >= 1
-  when: "'cluster' in inventory_groups_with_hosts_created_in_openstack"
 #
 # Configure IRODS security group using Openstack API.
 #
 - name: "Create security groups for machines in 'irods' inventory group."
+  when: "'irods' in inventory_groups_with_hosts_created_in_openstack"
   block:
     - name: "Create security group for {{ stack_prefix }} IRODs machines."
       openstack.cloud.security_group:
@@ -291,13 +292,13 @@
         - tcp
         - udp
         - icmp
-  when: "'irods' in inventory_groups_with_hosts_created_in_openstack"
 #
 # (Pulp) repo server security group.
 #
 # Note: only local admin accounts on repo machines, so no need for LDAPS traffic on port 636.
 #
 - name: "Create security groups for machines in 'repo' inventory group."
+  when: "'repo' in inventory_groups_with_hosts_created_in_openstack"
   block:
     - name: "Create security group for {{ stack_prefix }} repo machines."
       openstack.cloud.security_group:
@@ -351,11 +352,13 @@
           port: -1  # ICMP protocol does not have any ports.
           remote_group: "{{ stack_prefix }}_irods"
       when: groups['irods'] | default([]) | length >= 1
-  when: "'repo' in inventory_groups_with_hosts_created_in_openstack"
 #
 # Webservers security group.
 #
 - name: "Create security groups for webservers in 'docs' or 'jenkins' or 'build_servers' inventory group."
+  when: ('docs' in inventory_groups_with_hosts_created_in_openstack) or
+        ('jenkins' in inventory_groups_with_hosts_created_in_openstack) or
+        ('build_servers' in inventory_groups_with_hosts_created_in_openstack)
   block:
     - name: "Create security group for webservers."
       openstack.cloud.security_group:
@@ -403,7 +406,4 @@
           port: 443  # HTTPS
         - protocol: icmp
           port: -1  # ICMP protocol does not have any ports.
-  when: ('docs' in inventory_groups_with_hosts_created_in_openstack) or
-        ('jenkins' in inventory_groups_with_hosts_created_in_openstack) or
-        ('build_servers' in inventory_groups_with_hosts_created_in_openstack)
 ...

--- a/roles/slurm/templates/slurm.conf.22.05.2-1.el7.umcg
+++ b/roles/slurm/templates/slurm.conf.22.05.2-1.el7.umcg
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks:True, lstrip_blocks:True
 ClusterName={{ slurm_cluster_name }}
 SlurmctldHost={{ hostvars[groups['sys_admin_interface'][0]]['ansible_hostname'] }}
 SlurmUser=slurm
@@ -93,7 +94,8 @@ AccountingStorageEnforce=limits,qos  # Will also enable: associations
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost={{ hostvars[groups['sys_admin_interface'][0]]['ansible_hostname'] }}
 MaxJobCount=100000
-{% if slurm_cluster_gpus_total | int > 0 %}GresTypes=gpu
+{% if slurm_cluster_gpus_total | int > 0 %}
+GresTypes=gpu
 AccountingStorageTRES=gres/gpu
 {% endif %}
 #
@@ -113,14 +115,13 @@ PartitionName={{ partition.name }} Default={{ partition.default }} Nodes={{ part
 # Compute nodes
 #
 {% for node in groups['compute_vm'] %}
-NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif %}
-
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif +%}
 {% endfor %}
 #
 # User Interface nodes (only for data staging jobs).
 #
 {% for node in groups['user_interface'] %}
-{% if node not in groups['compute_vm'] %}{# this checks if the cluster is a single machine and prevents double entry of UI and node #}
-NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif %}
-{% endif %}
+  {% if node not in groups['compute_vm'] %}{# this checks if the cluster is a single machine and prevents double entry of UI and node #}
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif +%}
+  {% endif %}
 {% endfor %}

--- a/static_inventories/gearshift_cluster.yml
+++ b/static_inventories/gearshift_cluster.yml
@@ -55,19 +55,25 @@ all:
       children:
         regular:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
-            gs-vcompute[01:10]:
+            gs-vcompute[01:05]:
+              local_volume_size_extra: 2900
+              slurm_local_disk: 2800000
+            gs-vcompute06:
+              local_volume_size_extra: 2015
+              slurm_local_disk: 2063000
+            gs-vcompute[07:10]:
+              local_volume_size_extra: 2900
+              slurm_local_disk: 2800000
           vars:
             host_networks:
               - name: vlan983
               - name: vlan985
             cloud_flavor: 24C-240GB
-            local_volume_size_extra: 2900
             slurm_sockets: 2
             slurm_cores_per_socket: 12
             slurm_real_memory: 217778
             slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
             slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
-            slurm_local_disk: 2800000
             slurm_features: 'rsc01,tmp01'
             slurm_ethernet_interfaces:
               - 'vlan983'

--- a/static_inventories/talos_cluster.yml
+++ b/static_inventories/talos_cluster.yml
@@ -40,7 +40,6 @@ all:
           host_networks:
             - name: vlan983
             - name: vlan985
-          local_volume_size_extra: 290
     deploy_admin_interface:
       hosts:
         tl-dai:
@@ -48,7 +47,7 @@ all:
           host_networks:
             - name: vlan983
             - name: vlan985
-          local_volume_size_extra: 290
+          local_volume_size_extra: 614
     user_interface:
       hosts:
         talos:


### PR DESCRIPTION
Resized local disks of `gs-vcompute06` and `tl-dai` to let them coexist on the same physical host without overprovisioned storage, which is an epic fail.