### PR TITLE
Fine tuned NHC check_hw_mem_free test.

### DIFF
--- a/roles/slurm/templates/nhc.conf
+++ b/roles/slurm/templates/nhc.conf
@@ -52,7 +52,7 @@
    * || check_hw_physmem_free 1MB
 
 # Check for some sort of free memory of either type.
-   * || check_hw_mem_free 2GB
+   * || check_hw_mem_free {{ [2048, (ansible_memtotal_mb | float * 0.02) | int] | min }}MB
 
 # Checks for an active ethernet interfaces.
 {% for ethernet_interface in slurm_ethernet_interfaces %}


### PR DESCRIPTION
Fine tuned NHC `check_hw_mem_free` test to scale a bit with available RAM on a node and prevent false positive warnings.