### PR TITLE
rsyslog: v4, updated repos, added OS designation

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -94,86 +94,97 @@ data_transfer_only_group: sftp-only
 # Pulp repos.
 #
 pulp_repos:
-  - name: centos7-base
-    description: 'CentOS-7 - Base.'
-    remote_url: http://mirror.centos.org/centos/7/os/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-base/"
-  - name: centos7-updates
-    description: 'CentOS-7 - Updates.'
-    remote_url: http://mirror.centos.org/centos/7/updates/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-updates/"
-  - name: centos7-extras
-    description: 'CentOS-7 - Extras.'
-    remote_url: http://mirror.centos.org/centos/7/extras/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-extras/"
-  - name: epel7
-    description: 'Extra Packages for Enterprise Linux 7 (EPEL).'
-    remote_url: https://download.fedoraproject.org/pub/epel/7/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/epel7/"
-  - name: cpel7
-    description: 'UMCG Custom Packages for Enterprise Linux 7 (CPEL).'
-    #remote_url: no remote for our homebrew packages.
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/cpel7/"
-  - name: irods7
-    description: 'RENCI iRODS Repository for Enterprise Linux 7.'
-    remote_url: https://packages.irods.org/yum/pool/centos7/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/irods7/"
-  - name: lustre7
-    description: 'Lustre client Long Term Support (LTS) releases for Enterprise Linux 7.'
-    remote_url: https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/lustre7/"
-  - name: e2fsprogs7  # Dependency for Lustre project quota.
-    description: 'Ext filesystem utility releases for Enterprise Linux 7.'
-    remote_url: https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/e2fsprogs7/"
-  - name: ltb7
-    description: 'LTB (LDAP Tool Box) project OpenLDAP packages for Enterprise Linux 7.'
-    remote_url: https://ltb-project.org/rpm/openldap25/7/x86_64/
-    client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/ltb7/"
+  centos7:
+    - name: centos7-base
+      description: 'CentOS-7 - Base.'
+      remote_url: http://mirror.centos.org/centos/7/os/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-base/"
+    - name: centos7-updates
+      description: 'CentOS-7 - Updates.'
+      remote_url: http://mirror.centos.org/centos/7/updates/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-updates/"
+    - name: centos7-extras
+      description: 'CentOS-7 - Extras.'
+      remote_url: http://mirror.centos.org/centos/7/extras/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/centos7-extras/"
+    - name: epel
+      description: 'Extra Packages for Enterprise Linux 7 (EPEL).'
+      remote_url: https://download.fedoraproject.org/pub/epel/7/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/epel/"
+    - name: cpel7
+      description: 'UMCG Custom Packages for Enterprise Linux 7 (CPEL).'
+      #remote_url: no remote for our homebrew packages.
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/cpel7/"
+    - name: irods7
+      description: 'RENCI iRODS Repository for Enterprise Linux 7.'
+      remote_url: https://packages.irods.org/yum/pool/centos7/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/irods7/"
+    - name: lustre7
+      description: 'Lustre client Long Term Support (LTS) releases for Enterprise Linux 7.'
+      remote_url: https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/lustre7/"
+    - name: e2fsprogs7  # Dependency for Lustre project quota.
+      description: 'Ext filesystem utility releases for Enterprise Linux 7.'
+      remote_url: https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/e2fsprogs7/"
+    - name: ltb7
+      description: 'LTB (LDAP Tool Box) project OpenLDAP packages for Enterprise Linux 7.'
+      remote_url: https://ltb-project.org/rpm/openldap25/7/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/ltb7/"
+    - name: rsyslog7
+      description: 'Rsyslog (Adiscon CentOS7 for x86_64)'
+      remote_url: http://rpms.adiscon.com/v8-stable/epel-7/x86_64/
+      client_baseurl: "https://{{ stack_prefix }}-repo/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/rsyslog7/"
 #
 # List of repos for machines that do not use Pulp or Spacewalk
 #
 yum_repos:
-  - name: centos7-base
-    description: 'CentOS-7 - Base.'
-    baseurl: http://mirror.centos.org/centos/7/os/x86_64/
-    gpgcheck: 'true'
-    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
-  - name: centos7-updates
-    description: 'CentOS-7 - Updates.'
-    baseurl: http://mirror.centos.org/centos/7/updates/x86_64/
-    gpgcheck: 'true'
-    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
-  - name: centos7-extras
-    description: 'CentOS-7 - Extras.'
-    baseurl: http://mirror.centos.org/centos/7/extras/x86_64/
-    gpgcheck: 'true'
-    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
-  - name: epel7
-    description: 'Extra Packages for Enterprise Linux 7 (EPEL).'
-    baseurl: https://download.fedoraproject.org/pub/epel/7/x86_64/
-    gpgcheck: 'true'
-    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7' # comes preinstalled with epel-release
-  - name: irods7
-    description: 'RENCI iRODS Repository for Enterprise Linux 7.'
-    baseurl: https://packages.irods.org/yum/pool/centos7/x86_64/
-    gpgcheck: 'false'
-    gpgkey: ''
-  - name: lustre7
-    description: 'Lustre client Long Term Support (LTS) releases for Enterprise Linux 7.'
-    baseurl: https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client/
-    gpgcheck: 'false'
-    gpgkey: ''
-  - name: e2fsprogs7  # Dependency for Lustre project quota.
-    description: 'Ext filesystem utility releases for Enterprise Linux 7.'
-    baseurl: https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
-    gpgcheck: 'false'
-    gpgkey: ''
-  - name: ltb7
-    description: 'LTB (LDAP Tool Box) project OpenLDAP packages for Enterprise Linux 7.'
-    baseurl: https://ltb-project.org/rpm/openldap25/7/x86_64/
-    gpgcheck: 'false'
-    gpgkey: ''
+  centos7:
+    - name: centos7-base
+      description: 'CentOS-7 - Base.'
+      baseurl: http://mirror.centos.org/centos/7/os/x86_64/
+      gpgcheck: 'true'
+      gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+    - name: centos7-updates
+      description: 'CentOS-7 - Updates.'
+      baseurl: http://mirror.centos.org/centos/7/updates/x86_64/
+      gpgcheck: 'true'
+      gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+    - name: centos7-extras
+      description: 'CentOS-7 - Extras.'
+      baseurl: http://mirror.centos.org/centos/7/extras/x86_64/
+      gpgcheck: 'true'
+      gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7'
+    - name: epel
+      description: 'Extra Packages for Enterprise Linux 7 (EPEL).'
+      baseurl: https://download.fedoraproject.org/pub/epel/7/x86_64/
+      gpgcheck: 'true'
+      gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7' # comes preinstalled with epel-release
+    - name: irods7
+      description: 'RENCI iRODS Repository for Enterprise Linux 7.'
+      baseurl: https://packages.irods.org/yum/pool/centos7/x86_64/
+      gpgcheck: 'false'
+      gpgkey: ''
+    - name: lustre7
+      description: 'Lustre client Long Term Support (LTS) releases for Enterprise Linux 7.'
+      baseurl: https://downloads.whamcloud.com/public/lustre/latest-2.12-release/el7/client/
+      gpgcheck: 'false'
+      gpgkey: ''
+    - name: e2fsprogs7  # Dependency for Lustre project quota.
+      description: 'Ext filesystem utility releases for Enterprise Linux 7.'
+      baseurl: https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+      gpgcheck: 'false'
+      gpgkey: ''
+    - name: ltb7
+      description: 'LTB (LDAP Tool Box) project OpenLDAP packages for Enterprise Linux 7.'
+      baseurl: https://ltb-project.org/rpm/openldap25/7/x86_64/
+      gpgcheck: 'false'
+      gpgkey: ''
+    - name: rsyslog7
+      description: 'Rsyslog (Adiscon CentOS7 for x86_64)'
+      baseurl: http://rpms.adiscon.com/v8-stable/epel-7/x86_64/
+      gpgcheck: 'false'
+      gpgkey: ''
 
 # Iptables additional configurations 
 iptables_extras_dir: '/etc/iptables_extras.d/'

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -32,6 +32,7 @@ slurm_qos_limit_fractions:
   interactive-short:
     user: 0.5
 repo_manager: 'none'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       =========================================================

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -32,6 +32,7 @@ slurm_qos_limit_fractions:
   interactive-short:
     user: 0.5
 repo_manager: 'none'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       =========================================================

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -24,6 +24,7 @@ slurm_partitions:
     features: "{{ groups['user_interface'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long'
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'slant'
 motd: "To solve or not to solve, that's the question."
 additional_etc_hosts:

--- a/group_vars/forkhead_cluster/vars.yml
+++ b/group_vars/forkhead_cluster/vars.yml
@@ -15,6 +15,7 @@ slurm_partitions:
     features: "{{ groups['regular'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.25G"'
 repo_manager: 'none'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       =========================================================

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -24,6 +24,7 @@ slurm_partitions:
     features: "{{ groups['user_interface'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long'
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'cyberlarge'
 motd: |
       ===============================================================

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -24,6 +24,7 @@ slurm_partitions:
     features: "{{ groups['user_interface'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long'
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'lockergnome'
 motd: "To solve or not to solve, that's the question."
 additional_etc_hosts:

--- a/group_vars/jumphost.yml
+++ b/group_vars/jumphost.yml
@@ -18,4 +18,7 @@ ssh_host_signer_hostnames: "{{ inventory_hostname }}\
         {% endif %}\
       {% endif %}\
     {% endfor %}"
+# This is enforcing that jumphosts use `yum_repos` for defining repositories,
+# since jumphosts cannot use Pulp
+repo_manager: 'none'
 ...

--- a/group_vars/logs.yml
+++ b/group_vars/logs.yml
@@ -29,4 +29,7 @@ iptables_allow_ssh_inbound:
   - "{{ copperfist_cluster.ip_addresses['cf-porch']['vlan16'] }}"
 iptables_allow_logs_inbound:
   - ANY
+# This is enforcing that log servers uses `yum_repos` to create
+# yum repositories, since repo servers cannot use Pulp
+repo_manager: 'none'
 ...

--- a/group_vars/marvin_cluster/vars.yml
+++ b/group_vars/marvin_cluster/vars.yml
@@ -24,6 +24,7 @@ slurm_partitions:
     features: "{{ groups['user_interface'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long'
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'speed'
 motd: "It is rare, but not unheard of."
 additional_etc_hosts:

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -50,6 +50,7 @@ slurm_qos_limit_fractions:
   interactive-short:
     user: 0.5
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       ===============================================================

--- a/group_vars/repo.yml
+++ b/group_vars/repo.yml
@@ -1,0 +1,5 @@
+---
+# This is enforcing that repo server uses `yum_repos` to create
+# yum repositories, since repo servers cannot use Pulp
+repo_manager: 'none'
+...

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -25,6 +25,7 @@ slurm_partitions:
     features: "{{ groups['user_interface'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=1.0G" AllowQos=ds-short,ds-medium,ds-long'
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       =========================================================

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -41,6 +41,7 @@ slurm_qos_limit_fractions:
   interactive-short:
     user: 0.5
 repo_manager: 'pulp'
+os_distribution: 'centos7'
 figlet_font: 'ogre'
 motd: |
       =========================================================
@@ -97,13 +98,12 @@ external_jumphosts:
 #
 # Remote logging settings - for diagnostics servers
 #
-# Prepared, but commented out for now
-# logs_ca_name: 'diagnostics'
-# stacks_logs_servers:    # selected servers from the 'logs_library' static inventory
-#    - name: 'earl3'
-#      external_network: 'logs_external_network'
-#    - name: 'earl4'
-#      external_network: 'vlan16' # to retrieve public IP from
+logs_ca_name: 'diagnostics'
+stacks_logs_servers:    # selected servers from the 'logs_library' static inventory
+   - name: 'earl3'
+     external_network: 'logs_external_network'
+   - name: 'earl4'
+     external_network: 'vlan16' # to retrieve public IP from
 #
 # Ldap settings
 #

--- a/roles/logs_client/README.md
+++ b/roles/logs_client/README.md
@@ -68,6 +68,9 @@ This role is the second of the logs ansible playbooks. It expects predefined
       - CA certificate
       - configures to access the remote rsyslog server over SSL
 
+! Note: CA and client certificates are generated with `gnutls`, while the communication has
+been later switched to `openssl`.
+
 ## III. Redeploying individual client
 
 By default, the playbook always check that the correct CA certificate (one from the

--- a/roles/logs_client/tasks/deploy.yml
+++ b/roles/logs_client/tasks/deploy.yml
@@ -1,13 +1,26 @@
 ---
+- name: Install gnutls and newer openssl
+  ansible.builtin.yum:
+    name:
+      - gnutls
+      - gnutls-utils
+      - openssl11
+      - openssl11-devel
+    state: latest
+    update_cache: true
+  become: true
+  notify: client_restart_rsyslog
+
 - name: Install rsyslog and gnutls with all plugins
   ansible.builtin.yum:
     name:
+      - librelp
       - rsyslog
       - rsyslog-relp
-      - gnutls
-      - gnutls-utils
     state: latest
     update_cache: true
+    disablerepo: '*'
+    enablerepo: 'rsyslog7'
   become: true
   notify: client_restart_rsyslog
 

--- a/roles/logs_client/templates/rsyslog_managed.conf
+++ b/roles/logs_client/templates/rsyslog_managed.conf
@@ -12,6 +12,7 @@ action( type="omrelp"
         target="{{ server }}"       # remote server location
         port="{{ hostvars[server].rsyslog_port | default('41514') }}"   # non-default port
         tls="on"                    # enable tls connection, with following certificates
+        tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"   # disable SSL allow only TLS
         tls.caCert="{{ rsyslog_remote_path_cert_dir }}/{{ rsyslog_ca_cert_file }}"
         tls.myCert="{{ rsyslog_remote_path_cert_dir }}/{{ inventory_hostname }}.pem"
         tls.myPrivKey="{{ rsyslog_remote_path_key_dir }}/{{ inventory_hostname }}.key"

--- a/roles/logs_server/README.md
+++ b/roles/logs_server/README.md
@@ -75,6 +75,8 @@ and on the repository at the
 
    `files/{{stack or library name}}/rsyslog-ca.[key and pem]`
 
+! Note: CA and client certificates are generated with `gnutls`, while the communication has
+been later switched to `openssl`.
 
 ## V. Deploying a new type of logs server f.e. 'diagnostics'
 

--- a/roles/logs_server/tasks/rsyslog.yml
+++ b/roles/logs_server/tasks/rsyslog.yml
@@ -24,19 +24,33 @@
     path: "{{ rsyslog_remote_path_cert_dir }}/{{ rsyslog_ca_key_file }}"
   register: rsyslog_ca_cert_on_server
 
-- name: 'Install rsyslog and gnutls, with all the plugins'
+- name: Install gnutls and newer openssl
   ansible.builtin.yum:
     name:
-      - rsyslog
-      - rsyslog-relp
-      - rsyslog-gnutls
       - gnutls
       - gnutls-utils
       - python-firewall
       - firewalld
+      - openssl11
+      - openssl11-devel
     state: latest
     update_cache: true
   become: true
+  notify: restart-rsyslog.service
+
+- name: Install rsyslog and gnutls with all plugins
+  ansible.builtin.yum:
+    name:
+      - rsyslog
+      - librelp
+      - rsyslog-relp
+      - rsyslog-gnutls
+    state: latest
+    update_cache: true
+    disablerepo: '*'
+    enablerepo: 'rsyslog7'
+  become: true
+  notify: restart-rsyslog.service
 
 - name: If rsyslog keys and certificate in repository and on server are missing, then create CA
   ansible.builtin.include_tasks: create_ca.yml

--- a/roles/logs_server/templates/rsyslog.conf
+++ b/roles/logs_server/templates/rsyslog.conf
@@ -78,7 +78,7 @@ local7.*                                                /var/log/boot.log
 
 #### INCOMING SERVER SETTINGS #### 
 
-module(load="imrelp" ruleset="relp")
+module(load="imrelp" ruleset="relp" tls.tlslib="openssl")
 
 # configured with accordance of instructions from the
 # https://www.rsyslog.com/doc/v8-stable/configuration/modules/imrelp.html
@@ -88,6 +88,7 @@ module(load="imrelp" ruleset="relp")
 input(type="imrelp"
       ruleset="remote_rule"
       tls="on"
+      tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"
       port="41514"
       tls.cacert="{{ rsyslog_remote_path_cert_dir }}/logs_{{ logs_ca_name }}.pem"
       tls.mycert="{{ rsyslog_remote_path_cert_dir }}/{{ inventory_hostname }}.pem"

--- a/roles/pulp_client/defaults/main.yml
+++ b/roles/pulp_client/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+os_distribution: 'centos7'
+...

--- a/roles/pulp_client/tasks/main.yml
+++ b/roles/pulp_client/tasks/main.yml
@@ -12,7 +12,7 @@
     description: "{{ item.description }}"
     baseurl: "{{ item.client_baseurl }}"
     gpgcheck: false
-  with_items: "{{ pulp_repos }}"
+  with_items: "{{ pulp_repos[os_distribution] }}"
   become: true
 
 - name: Copy pulp web server certificates to pulp clients.
@@ -41,7 +41,7 @@
     path: "{{ item }}"
     state: absent
   with_items: "{{ yum_repo_configs.files | map(attribute='path') | list }}"
-  when: item | basename | regex_replace('.repo$','') not in pulp_repos | map(attribute='name') | list
+  when: item | basename | regex_replace('.repo$','') not in pulp_repos[os_distribution] | map(attribute='name') | list
   become: true
 
 - name: Remove RHN/SpaceWalk if it was installed.

--- a/roles/pulp_server/defaults/main.yml
+++ b/roles/pulp_server/defaults/main.yml
@@ -125,3 +125,4 @@ prereq_pip_packages:
   - xlwt==1.3.0
   - yarl==1.7.2
   - zipp==3.6.0
+os_distribution: 'centos7'

--- a/roles/pulp_server/tasks/main.yml
+++ b/roles/pulp_server/tasks/main.yml
@@ -230,7 +230,7 @@
     username: "{{ pulp_api_user }}"
     password: "{{ pulp_api_password }}"
     validate_certs: false
-  with_items: "{{ pulp_repos | selectattr('remote_url', 'defined') | list }}"
+  with_items: "{{ pulp_repos[os_distribution] | selectattr('remote_url', 'defined') | list }}"
   become: true
   become_user: "{{ repo_management_user }}"
   no_log: true
@@ -244,7 +244,7 @@
     username: "{{ pulp_api_user }}"
     password: "{{ pulp_api_password }}"
     validate_certs: false
-  with_items: "{{ pulp_repos }}"
+  with_items: "{{ pulp_repos[os_distribution] }}"
   become: true
   become_user: "{{ repo_management_user }}"
   no_log: true

--- a/roles/yum_repos/tasks/main.yml
+++ b/roles/yum_repos/tasks/main.yml
@@ -15,7 +15,7 @@
     path: "{{ item }}"
     state: absent
   with_items: "{{ yum_existing_repos.files | map(attribute='path') | list }}"
-  when: item | basename | regex_replace('.repo$','') not in yum_repos | map(attribute='name') | list
+  when: item | basename | regex_replace('.repo$','') not in yum_repos[os_distribution] | map(attribute='name') | list
   become: true
 
 - name: Add custom yum repos.
@@ -25,6 +25,6 @@
     baseurl: "{{ item.baseurl }}"
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
-  with_list: "{{ yum_repos }}"
+  with_list: "{{ yum_repos[os_distribution] }}"
   become: true
 ...

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -23,6 +23,7 @@
     - figlet_motd
     - node_exporter
     - cluster
+    - {role: logs_client, when: stacks_logs_servers is defined}
     - gpu            # needs to run after role 'cluster'
     - resolver
     - coredumps

--- a/single_group_playbooks/jumphost.yml
+++ b/single_group_playbooks/jumphost.yml
@@ -11,6 +11,8 @@
     - iptables
     - ssh_known_hosts
     - {role: yum_local, when: local_yum_repository is defined}
+    - {role: yum_repos, when: repo_manager == 'none'}
+    - {role: logs_client, when: additional_etc_hosts is defined}
     - logrotate
     - remove
     - update

--- a/single_group_playbooks/jumphost.yml
+++ b/single_group_playbooks/jumphost.yml
@@ -12,7 +12,6 @@
     - ssh_known_hosts
     - {role: yum_local, when: local_yum_repository is defined}
     - {role: yum_repos, when: repo_manager == 'none'}
-    - {role: logs_client, when: additional_etc_hosts is defined}
     - logrotate
     - remove
     - update
@@ -30,6 +29,7 @@
     - static_hostname_lookup
     - node_exporter
     - {role: geerlingguy.security, become: true}
+    - {role: logs_client, when: stacks_logs_servers is defined}
     # Disabled monitoring: needs update. See also:
     # https://github.com/rug-cit-hpc/league-of-robots/issues/294
     # - {role: grafana_proxy, when: ansible_hostname == 'airlock'}

--- a/single_group_playbooks/logs.yml
+++ b/single_group_playbooks/logs.yml
@@ -10,6 +10,7 @@
     - ssh_known_hosts
     - update
     - {role: yum_local, when: local_yum_repository is defined}
+    - {role: yum_repos, when: repo_manager == 'none'}
     - logrotate
     - {role: geerlingguy.repo-epel, become: true}
     - sshd

--- a/single_group_playbooks/repo.yml
+++ b/single_group_playbooks/repo.yml
@@ -10,6 +10,7 @@
     - ssh_known_hosts
     - swap
     - {role: geerlingguy.repo-epel, become: true}
+    - {role: yum_repos, when: repo_manager == 'none'}
     - logrotate
     - logins
     - static_hostname_lookup

--- a/single_group_playbooks/repo.yml
+++ b/single_group_playbooks/repo.yml
@@ -19,4 +19,5 @@
     - remove
     - update
     - pulp_server
+    - {role: logs_client, when: stacks_logs_servers is defined}
 ...

--- a/static_inventories/hyperchicken_cluster.yml
+++ b/static_inventories/hyperchicken_cluster.yml
@@ -104,5 +104,4 @@ hyperchicken_cluster:
     repo:
     cluster:
     docs:
-    rsyslog:
 ...

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -214,7 +214,6 @@ wingedhelix_cluster:
     chaperone:
     data_transfer:
     docs:
-    rsyslog:
     nfs_server:
     smb_server:
 ...


### PR DESCRIPTION
pulp
 - new rsyslog external repository for pulp
 - `epel7` renamed to `epel` and changed it on HC and WH (which are the others that need change? tl, fd?)
 - updated a documentation a bit

variables
 - added label `os_distribution` for centos7 machines

rsyslogv4
 - added `wingedhelix` to rsyslog `diagnostics`
 - deployed playbooks on HC and WH

to-do ... see the rsyslog in progress, wait for logs to increase
 - check the rsyslog service status
 - check the logs on the rsyslog server side