### PR TITLE
Fixed NHC file system checks

### DIFF
--- a/roles/slurm/meta/main.yml
+++ b/roles/slurm/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
-    - role: mariadb
-      when: inventory_hostname in groups['sys_admin_interface']
+  - role: mariadb
+    when: inventory_hostname in groups['sys_admin_interface']
 ...

--- a/roles/slurm/templates/nhc.conf
+++ b/roles/slurm/templates/nhc.conf
@@ -26,11 +26,11 @@
 # In out-of-band contexts, enable all checks
 #   * || export NHC_CHECK_ALL=1
 
-# Run df only for local file systems of type ext4.
+# Run df only for local file systems excluding various "special" file system types.
 # This prevents running df for large shared file systems resulting in
 # "NHC: Watchdog timer unable to terminate hung NHC process" errors.
-   * || export DFI_FLAGS='-Tiltext4'
-   * || export DF_FLAGS='-Tkltext4'
+   * || export DFI_FLAGS='-T -i -l -x tmpfs -x devtmpfs -x devfs -x specfs'
+   * || export DF_FLAGS='-T -k -l -x tmpfs -x devtmpfs -x devfs -x specfs'
 
 # Use short hostname instead of FQDN to mark nodes online/offline.
 # This prevents the


### PR DESCRIPTION
Previously NHC file system checks were limited to ext4 volumes, but we have several clusters where the local disks are XFS volumes. Therefore, we did not receive warnings when we we running out of disk space. The updated checks are not limited to include specific file system types, but instead exclude certain types for which these checks are not relevant / possible.