### PR TITLE
Small fixes

### DIFF
--- a/group_vars/build_library/vars.yml
+++ b/group_vars/build_library/vars.yml
@@ -50,7 +50,6 @@ sudoers:
 use_ldap: false
 create_ldap: false
 use_sssd: false
-ssh_host_signer_ca_private_key: "{{ ssh_host_signer_ca_keypair_dir }}/build_library-ca"
 #
 # Jumphosts from other stack-name infra groups.
 # We will restrict SSH login on port 22 to these jumphosts using OpenStack security rules.

--- a/group_vars/template/secrets.yml
+++ b/group_vars/template/secrets.yml
@@ -20,12 +20,13 @@ ldap_credentials:
 # Database user and password to be used by slurmdbd
 slurm_storage_user: slurm
 slurm_storage_pass: ''
+#slurm_notification_slack_webhook: 'https://hooks.slack.com/.... For NHC messages forwarded to Slack'
 # Password of the (external) prometheus alertmanager to contact.
-alertmanager_pass: ''
+#alertmanager_pass: ''
 # Root password for slurm MySQL/MariaDB database.
 MYSQL_ROOT_PASSWORD: ''
 # The password of the CA's ssh host signing private key.
 ssh_host_signer_ca_private_key_pass: ''
 # The htaccess for the reverse proxy that proxies Prometheus.
-prom_proxy_htpasswd: ''
+#prom_proxy_htpasswd: ''
 ...

--- a/roles/pulp_server/defaults/main.yml
+++ b/roles/pulp_server/defaults/main.yml
@@ -28,7 +28,7 @@ pulp_install_plugins:
   # pulp-container: {}
   # pulp-cookbook: {}
   # pulp-deb: {}
-  pulp-file: {}
+  # pulp-file: {}
   # pulp-gem: {}
   # pulp-maven: {}
   # pulp-npm: {}


### PR DESCRIPTION
* [Removed unnecessary ssh_host_signer_ca_private_key var from build_library as it is using the default.](https://github.com/rug-cit-hpc/league-of-robots/pull/835/commits/bb43ab054f88763aa370a59fbbaeb6c778003d8e)
[bb43ab0](https://github.com/rug-cit-hpc/league-of-robots/pull/835/commits/bb43ab054f88763aa370a59fbbaeb6c778003d8e)
* [Commented rarely used vars in group_vars/template/secrets.yml.](https://github.com/rug-cit-hpc/league-of-robots/pull/835/commits/9c029200085c5f2aa9f84b6a83e0ba0fd394774e)
* [Disabled pulp-file plugin, which is not used, in roles/pulp_server/defaults/main.yml.](https://github.com/rug-cit-hpc/league-of-robots/pull/835/commits/35e97fac005a2e6af46e6a3706d7665c07b503b3)
[35e97fa](https://github.com/rug-cit-hpc/league-of-robots/pull/835/commits/35e97fac005a2e6af46e6a3706d7665c07b503b3)