### PR TITLE
Logs server: added log rotate for the collected logs

### DIFF
--- a/roles/logs_client/files/rsyslog.service
+++ b/roles/logs_client/files/rsyslog.service
@@ -11,12 +11,10 @@ Documentation=https://www.rsyslog.com/doc/
 TimeoutSec=300
 ; restart the service every day, this way we keep the amount of used resources down to bare minimum
 WatchdogSec=86400
-; don't go trough the failed/inactive state, just restart the process
-RestartMode=direct
 ; limit the restart attempts to 5
 StartLimitBurst=5
 ; check the number of failed ^ attempts to this time window
-StartLimitInterval=600
+;StartLimitInterval=600
 Type=notify
 EnvironmentFile=-/etc/sysconfig/rsyslog
 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS

--- a/roles/logs_client/files/rsyslog.service
+++ b/roles/logs_client/files/rsyslog.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=System Logging Service
+;Requires=syslog.socket
+Wants=network.target network-online.target
+After=network.target network-online.target
+Documentation=man:rsyslogd(8)
+Documentation=https://www.rsyslog.com/doc/
+
+[Service]
+; sometimes it takes a long time for the service to cleanly exit
+TimeoutSec=300
+; restart the service every day, this way we keep the amount of used resources down to bare minimum
+WatchdogSec=86400
+; don't go trough the failed/inactive state, just restart the process
+RestartMode=direct
+; limit the restart attempts to 5
+StartLimitBurst=5
+; check the number of failed ^ attempts to this time window
+StartLimitInterval=600
+Type=notify
+EnvironmentFile=-/etc/sysconfig/rsyslog
+ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
+Restart=on-failure
+UMask=0066
+StandardOutput=null
+Restart=always
+# Increase the default a bit in order to allow many simultaneous
+# files to be monitored, we might need a lot of fds.
+LimitNOFILE=16384
+
+[Install]
+WantedBy=multi-user.target
+;Alias=syslog.service

--- a/roles/logs_client/handlers/main.yml
+++ b/roles/logs_client/handlers/main.yml
@@ -10,13 +10,6 @@
   notify: client_restart_rsyslog
   listen: restart_server_firewall
 
-- name: Restart client rsyslog.service
-  ansible.builtin.service:
-    name: rsyslog.service
-    state: restarted
-  listen: client_restart_rsyslog
-  become: true
-
 - name: Restart server rsyslog.service
   ansible.builtin.service:
     name: rsyslog.service
@@ -30,12 +23,12 @@
   ansible.builtin.systemd:
     daemon_reload: true
   become: true
-  listen: reconfigure_rsyslog_service
+  listen: systemd_reload
 
-- name: Reload or restart the rsyslog
-  ansible.builtin.systemd:
-    name: 'rsyslog.service'
+- name: Restart client rsyslog.service
+  ansible.builtin.service:
+    name: rsyslog.service
     state: restarted
+  listen: client_restart_rsyslog
   become: true
-  listen: reconfigure_rsyslog_service
 ...

--- a/roles/logs_client/handlers/main.yml
+++ b/roles/logs_client/handlers/main.yml
@@ -26,7 +26,7 @@
   become: true
   listen: restart_server_rsyslog
 
-- name: Just force systemd to reread configs
+- name: Force systemd to reread configs
   ansible.builtin.systemd:
     daemon_reload: true
   become: true

--- a/roles/logs_client/handlers/main.yml
+++ b/roles/logs_client/handlers/main.yml
@@ -25,4 +25,17 @@
   loop: "{{ rsyslogs_ext_ips }}"
   become: true
   listen: restart_server_rsyslog
+
+- name: Just force systemd to reread configs
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+  listen: reconfigure_rsyslog_service
+
+- name: Reload or restart the rsyslog
+  ansible.builtin.systemd:
+    name: 'rsyslog.service'
+    state: restarted
+  become: true
+  listen: reconfigure_rsyslog_service
 ...

--- a/roles/logs_client/tasks/deploy.yml
+++ b/roles/logs_client/tasks/deploy.yml
@@ -59,6 +59,15 @@
   become: true
   notify: client_restart_rsyslog
 
+- name: Deploy the systemd custom rsyslog.service
+  ansible.builtin.template:
+    src: templates/rsyslog.service
+    dest: /usr/lib/systemd/system/rsyslog.service
+    force: true
+    mode: '0644'
+  become: true
+  notify: systemd_reload
+
 - name: Make sure that the rsyslog service is started and enabled
   ansible.builtin.systemd:
     name: rsyslog.service
@@ -81,49 +90,6 @@
     force: true
   become: true
 
-- name: Checking if "Restart=always" is present in /usr/lib/systemd/system/rsyslog.service
-  ansible.builtin.command:
-    cmd: "grep 'Restart=always' /usr/lib/systemd/system/rsyslog.service"
-  register: rsyslog_service_restart
-  changed_when: false
-  failed_when: rsyslog_service_restart.rc >= 2
-  become: true
-
-- name: Checking if "WatchdogSec=" is present in /usr/lib/systemd/system/rsyslog.service
-  ansible.builtin.command:
-    cmd: "grep 'WatchdogSec=' /usr/lib/systemd/system/rsyslog.service"
-  register: rsyslog_service_watchdogsec
-  changed_when: false
-  failed_when: rsyslog_service_watchdogsec.rc >= 2
-  become: true
-
-- name: Configure the rsyslog service, to restart regardless of exit state
-  ansible.builtin.lineinfile:
-    path: '/usr/lib/systemd/system/rsyslog.service'
-    backup: true
-    insertafter: "[Service]"
-    regexp: '^Restart=.*$'
-    line: 'Restart=always'
-    owner: root
-    group: root
-    mode: '0644'
-  when:
-    - "'Restart=always' not in rsyslog_service_restart.stdout"
-  notify: reconfigure_rsyslog_service
-  become: true
-
-- name: Configure the rsyslog service, to restart after a day
-  ansible.builtin.lineinfile:
-    path: '/usr/lib/systemd/system/rsyslog.service'
-    backup: true
-    insertafter: '\[Service\]'
-    state: present
-    line: 'WatchdogSec=86400'           # 1 day = 86400 seconds
-    owner: root
-    group: root
-    mode: '0644'
-  when:
-    - "'WatchdogSec=' not in rsyslog_service_watchdogsec.stdout"
-  notify: reconfigure_rsyslog_service
-  become: true
+- name: Force all services to restart, before next tasks
+  ansible.builtin.meta: flush_handlers
 ...

--- a/roles/logs_client/tasks/deploy.yml
+++ b/roles/logs_client/tasks/deploy.yml
@@ -80,4 +80,50 @@
     mode: '0644'
     force: true
   become: true
+
+- name: Checking if "Restart=always" is present in /usr/lib/systemd/system/rsyslog.service
+  ansible.builtin.command:
+    cmd: "grep 'Restart=always' /usr/lib/systemd/system/rsyslog.service"
+  register: rsyslog_service_restart
+  changed_when: false
+  failed_when: rsyslog_service_restart.rc >= 2
+  become: true
+
+- name: Checking if "WatchdogSec=" is present in /usr/lib/systemd/system/rsyslog.service
+  ansible.builtin.command:
+    cmd: "grep 'WatchdogSec=' /usr/lib/systemd/system/rsyslog.service"
+  register: rsyslog_service_watchdogsec
+  changed_when: false
+  failed_when: rsyslog_service_watchdogsec.rc >= 2
+  become: true
+
+- name: Configure the rsyslog service, to restart regardless of exit state
+  ansible.builtin.lineinfile:
+    path: '/usr/lib/systemd/system/rsyslog.service'
+    backup: true
+    insertafter: "[Service]"
+    regexp: '^Restart=.*$'
+    line: 'Restart=always'
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - "'Restart=always' not in rsyslog_service_restart.stdout"
+  notify: reconfigure_rsyslog_service
+  become: true
+
+- name: Configure the rsyslog service, to restart after a day
+  ansible.builtin.lineinfile:
+    path: '/usr/lib/systemd/system/rsyslog.service'
+    backup: true
+    insertafter: '\[Service\]'
+    state: present
+    line: 'WatchdogSec=86400'           # 1 day = 86400 seconds
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - "'WatchdogSec=' not in rsyslog_service_watchdogsec.stdout"
+  notify: reconfigure_rsyslog_service
+  become: true
 ...

--- a/roles/logs_client/tasks/deploy.yml
+++ b/roles/logs_client/tasks/deploy.yml
@@ -60,8 +60,8 @@
   notify: client_restart_rsyslog
 
 - name: Deploy the systemd custom rsyslog.service
-  ansible.builtin.template:
-    src: templates/rsyslog.service
+  ansible.builtin.copy:
+    src: files/rsyslog.service
     dest: /usr/lib/systemd/system/rsyslog.service
     force: true
     mode: '0644'

--- a/roles/logs_server/README.md
+++ b/roles/logs_server/README.md
@@ -123,7 +123,16 @@ on the server in the files `/etc/iptables_extras.d/[stack].allow`.
 Additionally, the rsyslog accepts only the communication from the clients with certificate singed by apropriate
 certificate authority (each type of logs server has different CA).
 
-## VII. Debugging
+## VII. Weekly logrotate of collected logs
+
+The script named `/etc/logrotate.d/remote` is weekly collecting all the `/var/log/remote/[machine]/[yyyy-mm]/*`
+logs, creates (if needed) `compressed_logs` subfolder, compress every log, and moves it into the subfolder.
+Then (for the rsyslog to continue to work) recreates an empty log file and then sends `HUP` signal to the rsyslog
+service. As according to the [rsyslog documentation](https://www.rsyslog.com/doc/v8-stable/configuration/modules/omprog.html):
+
+*... Rsyslog will reopen the file whenever it receives a HUP signal. This allows the file to be externally rotated (using a tool like logrotate): after each rotation of the file, make sure a HUP signal is sent to rsyslogd.*
+
+## VIII. Debugging
 
 Get the connections to the server from the clients
 
@@ -149,7 +158,7 @@ and restart the service with `systemctl restart rsyslog`. A new file should appe
 in the `/var/log/rsyslog.log`. Note that the logs are quite verbose and can grow with
 rate of approximately 100MB per hour (with current default settings).
 
-## VIII. Remove packages from logs servers
+## IX. Remove packages from logs servers
 
 ```
   sudo yum remove -y rsyslog* librelp*

--- a/roles/logs_server/files/rsyslog.service
+++ b/roles/logs_server/files/rsyslog.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=System Logging Service
+;Requires=syslog.socket
+Wants=network.target network-online.target
+After=network.target network-online.target
+Documentation=man:rsyslogd(8)
+Documentation=https://www.rsyslog.com/doc/
+
+[Service]
+; sometimes it takes a long time for the service to cleanly exit
+TimeoutSec=300
+; restart the service every day, this way we keep the amount of used resources down to bare minimum
+WatchdogSec=86400
+; don't go trough the failed/inactive state, just restart the process
+RestartMode=direct
+; limit the restart attempts to 5
+StartLimitBurst=5
+; check the number of failed ^ attempts to this time window
+StartLimitInterval=600
+Type=notify
+EnvironmentFile=-/etc/sysconfig/rsyslog
+ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
+Restart=on-failure
+UMask=0066
+StandardOutput=null
+Restart=always
+# Increase the default a bit in order to allow many simultaneous
+# files to be monitored, we might need a lot of fds.
+LimitNOFILE=16384
+
+[Install]
+WantedBy=multi-user.target
+;Alias=syslog.service

--- a/roles/logs_server/files/rsyslog.service
+++ b/roles/logs_server/files/rsyslog.service
@@ -11,8 +11,6 @@ Documentation=https://www.rsyslog.com/doc/
 TimeoutSec=300
 ; restart the service every day, this way we keep the amount of used resources down to bare minimum
 WatchdogSec=86400
-; don't go trough the failed/inactive state, just restart the process
-RestartMode=direct
 ; limit the restart attempts to 5
 StartLimitBurst=5
 ; check the number of failed ^ attempts to this time window

--- a/roles/logs_server/handlers/main.yml
+++ b/roles/logs_server/handlers/main.yml
@@ -5,4 +5,17 @@
     state: restarted
   listen: restart-rsyslog.service
   become: true
+
+- name: Force systemd to reread configs
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+  listen: reconfigure_rsyslog_service
+
+- name: Reload or restart the rsyslog
+  ansible.builtin.systemd:
+    name: 'rsyslog.service'
+    state: restarted
+  become: true
+  listen: reconfigure_rsyslog_service
 ...

--- a/roles/logs_server/tasks/rsyslog.yml
+++ b/roles/logs_server/tasks/rsyslog.yml
@@ -106,12 +106,66 @@
   ansible.builtin.include_tasks: server_certificate.yml
   register: created_certificate
 
+- name: Checking if "Restart=always" is present in /usr/lib/systemd/system/rsyslog.service
+  ansible.builtin.command:
+    cmd: "grep 'Restart=always' /usr/lib/systemd/system/rsyslog.service"
+  register: rsyslog_service_restart
+  changed_when: false
+  failed_when: rsyslog_service_restart.rc >= 2
+  become: true
+
+- name: Checking if "WatchdogSec=" is present in /usr/lib/systemd/system/rsyslog.service
+  ansible.builtin.command:
+    cmd: "grep 'WatchdogSec=' /usr/lib/systemd/system/rsyslog.service"
+  register: rsyslog_service_watchdogsec
+  changed_when: false
+  failed_when: rsyslog_service_watchdogsec.rc >= 2
+  become: true
+
+- name: Configure the rsyslog service, to restart regardless of exit state
+  ansible.builtin.lineinfile:
+    path: '/usr/lib/systemd/system/rsyslog.service'
+    backup: true
+    insertafter: "[Service]"
+    regexp: '^Restart=.*$'
+    line: 'Restart=always'
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - "'Restart=always' not in rsyslog_service_restart.stdout"
+  notify: reconfigure_rsyslog_service
+  become: true
+
+- name: Configure the rsyslog service, to restart after a day
+  ansible.builtin.lineinfile:
+    path: '/usr/lib/systemd/system/rsyslog.service'
+    backup: true
+    insertafter: '\[Service\]'
+    state: present
+    line: 'WatchdogSec=86400'           # 1 day = 86400 seconds
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - "'WatchdogSec=' not in rsyslog_service_watchdogsec.stdout"
+  notify: reconfigure_rsyslog_service
+  become: true
+
 - name: Remove problematic /etc/rsyslog.d/listen.conf file
   ansible.builtin.file:
     path: /etc/rsyslog.d/listen.conf
     state: absent
   become: true
   notify: restart-rsyslog.service
+
+- name: Add logrotate to compress and move old logs to subfolder called 'compressed_logs'
+  ansible.builtin.template:
+    src: templates/remote.logrotate
+    dest: /etc/logrotate.d/remote
+    mode: '0644'
+    force: true
+  become: true
 
 - name: Deploy server rsyslog.conf
   ansible.builtin.template:

--- a/roles/logs_server/tasks/rsyslog.yml
+++ b/roles/logs_server/tasks/rsyslog.yml
@@ -106,51 +106,14 @@
   ansible.builtin.include_tasks: server_certificate.yml
   register: created_certificate
 
-- name: Checking if "Restart=always" is present in /usr/lib/systemd/system/rsyslog.service
-  ansible.builtin.command:
-    cmd: "grep 'Restart=always' /usr/lib/systemd/system/rsyslog.service"
-  register: rsyslog_service_restart
-  changed_when: false
-  failed_when: rsyslog_service_restart.rc >= 2
-  become: true
-
-- name: Checking if "WatchdogSec=" is present in /usr/lib/systemd/system/rsyslog.service
-  ansible.builtin.command:
-    cmd: "grep 'WatchdogSec=' /usr/lib/systemd/system/rsyslog.service"
-  register: rsyslog_service_watchdogsec
-  changed_when: false
-  failed_when: rsyslog_service_watchdogsec.rc >= 2
-  become: true
-
-- name: Configure the rsyslog service, to restart regardless of exit state
-  ansible.builtin.lineinfile:
-    path: '/usr/lib/systemd/system/rsyslog.service'
-    backup: true
-    insertafter: "[Service]"
-    regexp: '^Restart=.*$'
-    line: 'Restart=always'
-    owner: root
-    group: root
+- name: Deploy the systemd custom rsyslog.service
+  ansible.builtin.copy:
+    src: files/rsyslog.service
+    dest: /usr/lib/systemd/system/rsyslog.service
+    force: true
     mode: '0644'
-  when:
-    - "'Restart=always' not in rsyslog_service_restart.stdout"
-  notify: reconfigure_rsyslog_service
   become: true
-
-- name: Configure the rsyslog service, to restart after a day
-  ansible.builtin.lineinfile:
-    path: '/usr/lib/systemd/system/rsyslog.service'
-    backup: true
-    insertafter: '\[Service\]'
-    state: present
-    line: 'WatchdogSec=86400'           # 1 day = 86400 seconds
-    owner: root
-    group: root
-    mode: '0644'
-  when:
-    - "'WatchdogSec=' not in rsyslog_service_watchdogsec.stdout"
   notify: reconfigure_rsyslog_service
-  become: true
 
 - name: Remove problematic /etc/rsyslog.d/listen.conf file
   ansible.builtin.file:

--- a/roles/logs_server/templates/remote.logrotate
+++ b/roles/logs_server/templates/remote.logrotate
@@ -1,0 +1,30 @@
+/var/log/remote/*/*/*
+{
+    # run this script for each and every log file
+    nosharedscripts
+    # logrotate each file only if it was modified more than n*24 hours ago
+    prerotate
+        logfile=$1
+        find $logfile -mtime +1 | grep . > /dev/null
+        exit $?
+    endscript
+    # rotate logs once a week
+    weekly
+    # keeping compressed logs for the last ~6 months
+    # during this time, they are already copied
+    rotate 24
+    # compress old logs
+    compress
+    # append the date extension to the compressed logs
+    dateext
+    # move compressed files into copressed_logs subdirectory
+    olddir compressed_logs
+    # create compressed_logs directory, if missing
+    createolddir 0600 root root
+    # after moving and compressing, create a new empty logfile
+    create 0600 root root
+    # after compression and new wilf, inform the rsyslog to reload the file
+    postrotate
+        /usr/bin/systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
+    endscript
+}

--- a/single_group_playbooks/pre_deploy_checks.yml
+++ b/single_group_playbooks/pre_deploy_checks.yml
@@ -51,7 +51,7 @@
       delegate_to: localhost
       connection: local
       register: openstacksdk_major_version
-      changed_when: true
+      changed_when: false
     - name: 'Download dependencies from Ansible Galaxy on the Ansible control host.'
       ansible.builtin.command:
         cmd: |


### PR DESCRIPTION
Updates for the rsyslog services:
- added customized systemd rsyslog.service file with few extra options, for the
   - automatic restart of the service once a day
   - after a month of nice uptime, the service suddenly crashed, and service restart took a really long time
   - I believe it has something to do with the number of open files
   - with time both increase: the time for the service to restart and active memory consumption
 -  added new `remote` logrotate file on the server side, to weekly compress the log files and move them to the subfolder
   - this paves the way for the followup work on storing file to prm
   - the log files are already in format for permanent storage
   - the total size of remote log size consumed approximately 1.6GB in 6 weeks on diagnostic clusters
   - after the compression, the log size was 71MB
   - logrotate will store and keep logs for the last 6 months
   - this will give us plenty of time to move them to permanent storage
   - with compression and automatic removal (24 weeks) we manage to use system disk wisely
 - fix for single_group_playbooks/pre_deploy_checks.yml: as it was returning status `changed` even when nothing was changed