### PR TITLE
Logs: added systemd 24h restart interval for the client and server rsyslog service

### DIFF
--- a/roles/logs_client/files/rsyslog-restart.service
+++ b/roles/logs_client/files/rsyslog-restart.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Restart rsyslog.service
+Requires=rsyslog.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart rsyslog

--- a/roles/logs_client/files/rsyslog-restart.timer
+++ b/roles/logs_client/files/rsyslog-restart.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Restating rsyslog.service 15min after boot and every 224 hours
+Requires=rsyslog.service rsyslog-restart.service
+
+[Timer]
+; after boot wait for 15min before start the time for the first time 
+OnBootSec=15min
+; timer can be executed anytime
+OnCalendar=* *-*-* *:*:*
+; execute the timer every 24 hours
+OnUnitActiveSec=24hour
+; command to be executed
+Unit=rsyslog-restart.service
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/logs_client/files/rsyslog.service
+++ b/roles/logs_client/files/rsyslog.service
@@ -8,22 +8,26 @@ Documentation=https://www.rsyslog.com/doc/
 
 [Service]
 ; sometimes it takes a long time for the service to cleanly exit
-TimeoutSec=300
-; restart the service every day, this way we keep the amount of used resources down to bare minimum
-WatchdogSec=86400
-; limit the restart attempts to 5
-StartLimitBurst=5
-; check the number of failed ^ attempts to this time window
-;StartLimitInterval=600
+; but default value of 90 seconds seems a bit too low for how the
+; service actually behaved
+TimeoutSec=120
+; increase the limit of the restart attempts from 5 to 10, as this
+; was already an issue in our implementation
+StartLimitBurst=10
+; and at the same time also increase the number of failed attempts
+; interval window from 10 seconds to 30 second
+StartLimitInterval=30
+; make sure the service is always restarted
+Restart=always
+; the rest of the service settings are good, as-is
 Type=notify
 EnvironmentFile=-/etc/sysconfig/rsyslog
 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
 Restart=on-failure
 UMask=0066
 StandardOutput=null
-Restart=always
-# Increase the default a bit in order to allow many simultaneous
-# files to be monitored, we might need a lot of fds.
+; Increase the default a bit in order to allow many simultaneous
+; files to be monitored, we might need a lot of fds.
 LimitNOFILE=16384
 
 [Install]

--- a/roles/logs_client/handlers/main.yml
+++ b/roles/logs_client/handlers/main.yml
@@ -31,4 +31,27 @@
     state: restarted
   listen: client_restart_rsyslog
   become: true
+
+- name: Start and enable rsyslog.service
+  ansible.builtin.service:
+    name: rsyslog.service
+    state: started
+    enabled: true
+  become: true
+  listen: rsyslog_enable
+
+- name: Enable rsyslog-restart.service
+  ansible.builtin.service:
+    name: rsyslog-restart.service
+    enabled: true
+  become: true
+  listen: restart_service_enable
+
+- name: Start and enable rsyslog-restart.timer
+  ansible.builtin.service:
+    name: rsyslog-restart.timer
+    state: started
+    enabled: true
+  become: true
+  listen: restart_timer_enable
 ...

--- a/roles/logs_client/tasks/deploy.yml
+++ b/roles/logs_client/tasks/deploy.yml
@@ -59,20 +59,37 @@
   become: true
   notify: client_restart_rsyslog
 
-- name: Deploy the systemd custom rsyslog.service
+- name: Deploy custom rsyslog.service
   ansible.builtin.copy:
     src: files/rsyslog.service
     dest: /usr/lib/systemd/system/rsyslog.service
     force: true
     mode: '0644'
+  notify:
+    - systemd_reload
+    - rsyslog_enable
   become: true
-  notify: systemd_reload
 
-- name: Make sure that the rsyslog service is started and enabled
-  ansible.builtin.systemd:
-    name: rsyslog.service
-    state: started
-    enabled: true
+- name: Deploy rsyslog-restart.service
+  ansible.builtin.copy:
+    src: files/rsyslog-restart.service
+    dest: /usr/lib/systemd/system/rsyslog-restart.service
+    force: true
+    mode: '0644'
+  notify:
+    - systemd_reload
+    - restart_service_enable
+  become: true
+
+- name: Deploy rsyslog-restart.timer
+  ansible.builtin.copy:
+    src: files/rsyslog-restart.timer
+    dest: /usr/lib/systemd/system/rsyslog-restart.timer
+    force: true
+    mode: '0644'
+  notify:
+    - systemd_reload
+    - restart_timer_enable
   become: true
 
 - name: Remove problematic /etc/rsyslog.d/listen.conf file

--- a/roles/logs_client/tasks/test.yml
+++ b/roles/logs_client/tasks/test.yml
@@ -1,8 +1,15 @@
 ---
-- name: Force all services to restart, before we start testing logs clients
+- name: Force all handlers to flush, before we start testing logs clients
   ansible.builtin.meta: flush_handlers
   tags:
     - test
+
+- name: Wait for rsyslog.service to be running (this can take some time ...)
+  service_facts:
+  register: services_status
+  until: services_status.ansible_facts.services['rsyslog.service'].state == 'running'
+  retries: 24
+  delay: 15
 
 - name: Generate random 12-character HEX token
   ansible.builtin.set_fact:
@@ -26,18 +33,14 @@
   tags:
     - test
 
-- name: Sleep for 30 seconds for logs to propagate to server
-  ansible.builtin.wait_for:
-    timeout: 30
-  tags:
-    - test
-
-- name: Check that remote server has token logged
+- name: Check that remote server has received the token
   ansible.builtin.command:
     fgrep -q -nirI '{{ random_tag }}' /var/log/remote/{{ inventory_hostname }}
   register: remote_test_result
   changed_when: false
-  failed_when: remote_test_result.rc != 0
+  until: remote_test_result.rc == 0
+  retries: 12
+  delay: 5
   delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   loop: "{{ rsyslogs_ext_ips }}"
   become: true

--- a/roles/logs_client/tasks/test.yml
+++ b/roles/logs_client/tasks/test.yml
@@ -5,7 +5,7 @@
     - test
 
 - name: Wait for rsyslog.service to be running (this can take some time ...)
-  service_facts:
+  ansible.builtin.service_facts:
   register: services_status
   until: services_status.ansible_facts.services['rsyslog.service'].state == 'running'
   retries: 24

--- a/roles/logs_server/files/rsyslog-restart.service
+++ b/roles/logs_server/files/rsyslog-restart.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Restart rsyslog.service
+Requires=rsyslog.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart rsyslog

--- a/roles/logs_server/files/rsyslog-restart.timer
+++ b/roles/logs_server/files/rsyslog-restart.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Restating rsyslog.service 15min after boot and every 224 hours
+Requires=rsyslog.service rsyslog-restart.service
+
+[Timer]
+; after boot wait for 15min before start the time for the first time 
+OnBootSec=15min
+; timer can be executed anytime
+OnCalendar=* *-*-* *:*:*
+; execute the timer every 24 hours
+OnUnitActiveSec=24hour
+; command to be executed
+Unit=rsyslog-restart.service
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/logs_server/files/rsyslog.service
+++ b/roles/logs_server/files/rsyslog.service
@@ -8,22 +8,26 @@ Documentation=https://www.rsyslog.com/doc/
 
 [Service]
 ; sometimes it takes a long time for the service to cleanly exit
-TimeoutSec=300
-; restart the service every day, this way we keep the amount of used resources down to bare minimum
-WatchdogSec=86400
-; limit the restart attempts to 5
-StartLimitBurst=5
-; check the number of failed ^ attempts to this time window
-StartLimitInterval=600
+; but default value of 90 seconds seems a bit too low for how the
+; service actually behaved
+TimeoutSec=120
+; increase the limit of the restart attempts from 5 to 10, as this
+; was already an issue in our implementation
+StartLimitBurst=10
+; and at the same time also increase the number of failed attempts
+; interval window from 10 seconds to 30 second
+StartLimitInterval=30
+; make sure the service is always restarted
+Restart=always
+; the rest of the service settings are good, as-is
 Type=notify
 EnvironmentFile=-/etc/sysconfig/rsyslog
 ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
 Restart=on-failure
 UMask=0066
 StandardOutput=null
-Restart=always
-# Increase the default a bit in order to allow many simultaneous
-# files to be monitored, we might need a lot of fds.
+; Increase the default a bit in order to allow many simultaneous
+; files to be monitored, we might need a lot of fds.
 LimitNOFILE=16384
 
 [Install]

--- a/roles/logs_server/handlers/main.yml
+++ b/roles/logs_server/handlers/main.yml
@@ -10,12 +10,35 @@
   ansible.builtin.systemd:
     daemon_reload: true
   become: true
-  listen: reconfigure_rsyslog_service
+  listen: systemd_reload
 
 - name: Reload or restart the rsyslog
   ansible.builtin.systemd:
     name: 'rsyslog.service'
     state: restarted
+  listen: systemd_reload
   become: true
-  listen: reconfigure_rsyslog_service
+
+- name: Start and enable rsyslog.service
+  ansible.builtin.service:
+    name: rsyslog.service
+    state: started
+    enabled: true
+  become: true
+  listen: rsyslog_enable
+
+- name: Enable rsyslog-restart.service
+  ansible.builtin.service:
+    name: rsyslog-restart.service
+    enabled: true
+  become: true
+  listen: restart_service_enable
+
+- name: Start and enable rsyslog-restart.timer
+  ansible.builtin.service:
+    name: rsyslog-restart.timer
+    state: started
+    enabled: true
+  become: true
+  listen: restart_timer_enable
 ...

--- a/roles/logs_server/tasks/rsyslog.yml
+++ b/roles/logs_server/tasks/rsyslog.yml
@@ -113,7 +113,7 @@
     force: true
     mode: '0644'
   become: true
-  notify: reconfigure_rsyslog_service
+  notify: systemd_reload
 
 - name: Remove problematic /etc/rsyslog.d/listen.conf file
   ansible.builtin.file:
@@ -121,6 +121,39 @@
     state: absent
   become: true
   notify: restart-rsyslog.service
+
+- name: Deploy custom rsyslog.service
+  ansible.builtin.copy:
+    src: files/rsyslog.service
+    dest: /usr/lib/systemd/system/rsyslog.service
+    force: true
+    mode: '0644'
+  notify:
+    - systemd_reload
+    - rsyslog_enable
+  become: true
+
+- name: Deploy rsyslog-restart.service
+  ansible.builtin.copy:
+    src: files/rsyslog-restart.service
+    dest: /usr/lib/systemd/system/rsyslog-restart.service
+    force: true
+    mode: '0644'
+  notify:
+    - systemd_reload
+    - restart_service_enable
+  become: true
+
+- name: Deploy rsyslog-restart.timer
+  ansible.builtin.copy:
+    src: files/rsyslog-restart.timer
+    dest: /usr/lib/systemd/system/rsyslog-restart.timer
+    force: true
+    mode: '0644'
+  notify:
+    - systemd_reload
+    - restart_timer_enable
+  become: true
 
 - name: Add logrotate to compress and move old logs to subfolder called 'compressed_logs'
   ansible.builtin.template:
@@ -140,10 +173,6 @@
   become: true
   notify: restart-rsyslog.service
 
-- name: Start and enable rsyslog service
-  ansible.builtin.systemd:
-    name: rsyslog.service
-    state: started
-    enabled: true
-  become: true
+- name: Force all services to restart, before next tasks
+  ansible.builtin.meta: flush_handlers
 ...


### PR DESCRIPTION
Because the systemd is quite old (version 219) does not enable all the needed service calls for the automatic periodical service restart. The update of systemd to newer version is not an option.
The original idea of using watchdog does not work, as the service is being restarted in a "burst" (this is due to the `type` of the rsyslog service).

The solution implemented in this PR provides three new rsyslog service files:
- `rsyslog.service` that overwrites original one, extended with few extra options
- `rsyslog-restart.service` is new one, created to restart the `rsyslog.service` when triggered
- `rsyslog-restart.timer` is a timer that trigger/calls the `rsyslog-restart.service` every 24 hours

This implementation should work with old and new systemd versions.

Deployed on:
- Hyperchicken
- Talos

and if all goes OK after a week or so, it will be deployed to the diagnostic servers.