### PR TITLE
Switch Fender's and Hyperchicken's IP of the NFS server

### DIFF
--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -325,7 +325,7 @@ sudoers:
 #
 pfs_mounts:
   - pfs: ecst02
-    source: '10.35.141.253:/solve-rd-98599485/'
+    source: '10.35.141.252:/solve-rd-98599485/'
     type: nfs4
     rw_options: 'defaults,_netdev,noatime,nodiratime,rw'
     ro_options: 'defaults,_netdev,noatime,nodiratime,ro'

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -165,7 +165,7 @@ sudoers:
 #
 pfs_mounts:
   - pfs: ecst01
-    source: '10.35.141.252:/solve-rd-98599485'
+    source: '10.35.141.253:/solve-rd-98599485'
     type: nfs4
     rw_options: 'defaults,_netdev,noatime,nodiratime,rw'
     ro_options: 'defaults,_netdev,noatime,nodiratime,ro'


### PR DESCRIPTION
Already deployed on Fender - this will stay from now on.
After Embassy fix it: need to be deployed on HC - for now they are both using the .252