### PR TITLE
rsyncd role permissions fix.

### DIFF
--- a/roles/rsyncd/templates/rsyncd_all_groups.conf
+++ b/roles/rsyncd/templates/rsyncd_all_groups.conf
@@ -23,7 +23,7 @@ dont compress  = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2
 # More lenient outgoing perms to allow clients some freedom in setting perms,
 # but remove all perms for others to prevent data becoming accessible for anyone on a system after download.
 #
-incoming chmod = Du=rwx,Dg=rsx,Fu=rw,Fg=r,o-rwx
+incoming chmod = Du=rwx,Dg=rwsx,Fu=rw,Fg=rw,o-rwx
 outgoing chmod = o-rwx
 
 [groups]


### PR DESCRIPTION
Fix for permissions of incoming data when using rsync on a data transfer server: add write permissions for the group.