### PR TITLE
Changed VLAN985 IPs for Nibbler machines

### DIFF
--- a/group_vars/nibbler_cluster/ip_addresses.yml
+++ b/group_vars/nibbler_cluster/ip_addresses.yml
@@ -37,7 +37,7 @@ ip_addresses:
       address: 172.23.60.3
       netmask: /32
     vlan985:
-      address: 172.23.59.142
+      address: 172.23.59.22
       netmask: /32
   nb-node-a01:
     nb_internal_management:
@@ -50,7 +50,7 @@ ip_addresses:
       address: 172.23.60.6
       netmask: /32
     vlan985:
-      address: 172.23.59.75
+      address: 172.23.59.95
       netmask: /32
   nb-node-a02:
     nb_internal_management:
@@ -63,7 +63,7 @@ ip_addresses:
       address: 172.23.60.29
       netmask: /32
     vlan985:
-      address: 172.23.59.67
+      address: 172.23.59.90
       netmask: /32
   nb-node-a03:
     nb_internal_management:
@@ -76,7 +76,7 @@ ip_addresses:
       address: 172.23.60.15
       netmask: /32
     vlan985:
-      address: 172.23.59.85
+      address: 172.23.59.213
       netmask: /32
   nb-node-b01:
     nb_internal_management:
@@ -89,7 +89,7 @@ ip_addresses:
       address: 172.23.60.22
       netmask: /32
     vlan985:
-      address: 172.23.59.65
+      address: 172.23.59.247
       netmask: /32
   nb-node-b02:
     nb_internal_management:
@@ -102,7 +102,7 @@ ip_addresses:
       address: 172.23.60.14
       netmask: /32
     vlan985:
-      address: 172.23.59.189
+      address: 172.23.59.177
       netmask: /32
   nb-repo:
     nb_internal_management:
@@ -119,7 +119,7 @@ ip_addresses:
       address: 172.23.60.7
       netmask: /32
     vlan985:
-      address: 172.23.59.195
+      address: 172.23.59.171
       netmask: /32
   nb-transfer:
     nb_internal_management:
@@ -141,7 +141,7 @@ ip_addresses:
       address: 172.23.60.4
       netmask: /32
     vlan985:
-      address: 172.23.59.176
+      address: 172.23.59.144
       netmask: /32
   tunnel:
     nb_internal_management:


### PR DESCRIPTION
Data handling lustre mounts now finally work with the new vlan 985 settings.