### PR TITLE
Smarter cgroup limits on UIs

### DIFF
--- a/roles/cgroups/tasks/configure_cgroups_v1.yml
+++ b/roles/cgroups/tasks/configure_cgroups_v1.yml
@@ -47,7 +47,7 @@
     cgroups_regular_users_mem_limit_soft: "\
       {% if (ansible_memtotal_mb | float / 1024) | int < 32 %}\
         {{ (ansible_memtotal_mb | float * 0.45 / 1024) | int }}\
-      {% elif (ansible_memtotal_mb | float * 0.3 / 1024) | int < 96 %}\
+      {% elif (ansible_memtotal_mb | float / 1024) | int < 320 %}\
         {{ (ansible_memtotal_mb | float * 0.7 / 1024) | int }}\
       {% else %}\
         {{ (ansible_memtotal_mb | float / 1024) | int - 96 }}\
@@ -55,7 +55,7 @@
     cgroups_regular_users_mem_limit_hard: "\
       {% if (ansible_memtotal_mb | float / 1024) | int < 32 %}\
         {{ (ansible_memtotal_mb | float * 0.55 / 1024) | int }}\
-      {% elif (ansible_memtotal_mb | float * 0.2 / 1024) | int < 64 %}\
+      {% elif (ansible_memtotal_mb | float / 1024) | int < 320 %}\
          {{ (ansible_memtotal_mb | float * 0.8 / 1024) | int }}\
       {% else %}\
         {{ (ansible_memtotal_mb | float / 1024) | int - 64 }}\

--- a/roles/cgroups/tasks/configure_cgroups_v1.yml
+++ b/roles/cgroups/tasks/configure_cgroups_v1.yml
@@ -44,6 +44,22 @@
   vars:
     cgroups_cpuset_mems_range: "{{ cgroups_cpuset_mems.stdout }}"
     cgroups_cpuset_max_core_number: "{{ cgroups_cpuset_cpus.stdout }}"
+    cgroups_regular_users_mem_limit_soft: "\
+      {% if (ansible_memtotal_mb | float / 1024) | int < 32 %}\
+        {{ (ansible_memtotal_mb | float * 0.45 / 1024) | int }}\
+      {% elif (ansible_memtotal_mb | float * 0.3 / 1024) | int < 96 %}\
+        {{ (ansible_memtotal_mb | float * 0.7 / 1024) | int }}\
+      {% else %}\
+        {{ (ansible_memtotal_mb | float / 1024) | int - 96 }}\
+      {% endif %}"
+    cgroups_regular_users_mem_limit_hard: "\
+      {% if (ansible_memtotal_mb | float / 1024) | int < 32 %}\
+        {{ (ansible_memtotal_mb | float * 0.55 / 1024) | int }}\
+      {% elif (ansible_memtotal_mb | float * 0.2 / 1024) | int < 64 %}\
+         {{ (ansible_memtotal_mb | float * 0.8 / 1024) | int }}\
+      {% else %}\
+        {{ (ansible_memtotal_mb | float / 1024) | int - 64 }}\
+      {% endif %}"
   notify: restart_cgconfig
   become: true
 

--- a/roles/cgroups/templates/regular_users.conf.j2
+++ b/roles/cgroups/templates/regular_users.conf.j2
@@ -27,9 +27,9 @@ group regular_users {
 		cpuset.mems={{ cgroups_cpuset_mems_range }};
 	}
 	memory {
-		memory.limit_in_bytes={{ (ansible_memtotal_mb | float * 0.80 / 1024) | int }}G;
-		memory.soft_limit_in_bytes={{ (ansible_memtotal_mb | float * 0.70 / 1024) | int }}G;
-		memory.memsw.limit_in_bytes={{ (ansible_memtotal_mb | float * 0.80 / 1024) | int }}G;
+		memory.limit_in_bytes={{ cgroups_regular_users_mem_limit_hard }}G;
+		memory.soft_limit_in_bytes={{ cgroups_regular_users_mem_limit_soft }}G;
+		memory.memsw.limit_in_bytes={{ cgroups_regular_users_mem_limit_hard }}G;
 	}
 }
 


### PR DESCRIPTION
* Reserve more RAM for OS and overhead on small UIs with less than 32 GB RAM.
* And limit RAM reserved for OS and overhead on big mem machines with lots of RAM.