### PR TITLE
Added functionality to add Slurm node weights.

### DIFF
--- a/roles/slurm/templates/slurm.conf.22.05.2-1.el7.umcg
+++ b/roles/slurm/templates/slurm.conf.22.05.2-1.el7.umcg
@@ -115,7 +115,7 @@ PartitionName={{ partition.name }} Default={{ partition.default }} Nodes={{ part
 # Compute nodes
 #
 {% for node in groups['compute_node'] %}
-NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif +%}
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif %}{% if hostvars[node]['slurm_weight'] is defined %} Weight={{ hostvars[node]['slurm_weight'] }}{% endif +%}
 {% endfor %}
 #
 # User Interface nodes (only for data staging jobs).

--- a/roles/slurm/templates/slurm.conf.23.02.4-1.el9.umcg
+++ b/roles/slurm/templates/slurm.conf.23.02.4-1.el9.umcg
@@ -115,7 +115,7 @@ PartitionName={{ partition.name }} Default={{ partition.default }} Nodes={{ part
 # Compute nodes
 #
 {% for node in groups['compute_node'] %}
-NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif +%}
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore=1 State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif %}{% if hostvars[node]['slurm_weight'] is defined %} Weight={{ hostvars[node]['slurm_weight'] }}{% endif +%}
 {% endfor %}
 #
 # User Interface nodes (only for data staging jobs).

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -207,6 +207,7 @@ all:
             slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
             slurm_local_disk: 975
             slurm_features: 'tmp02,gpu,A40'
+            slurm_weight: 10
             slurm_ethernet_interfaces:
               - eth0
               - eth1


### PR DESCRIPTION
The default Slurm node weight is 1. In this PR the weight of the Nibbler GPU jobs was increased to 10. The weight is an arbitrary number, but when a job fits on multiple nodes the scheduler will put it on the node with the lowest weight. This means CPU-only jobs will preferably land on nodes without GPUs. Only when there is no slot available on a node without GPUs, a CPU-only job can start on a node with GPUs.