### PR TITLE
Bugfix for sshd_config

### DIFF
--- a/roles/sshd/templates/sshd_config
+++ b/roles/sshd/templates/sshd_config
@@ -23,13 +23,13 @@ Protocol 2
 #
 RequiredRSASize 4096
 
-{% endif %}
 #
 # Disable printing of MOTD by sshd itself,
 # which is already printed by the pluggable authentication module (PAM) motd.so
 # configured in /etc/pam.d/sshd
 #
 PrintMotd no
+{% endif %}
 
 #
 # Supported (Host)Key algorithms by order of preference.


### PR DESCRIPTION
Bugfix for `sshd_config`: `{% endif %}` was in the wrong place. Only set `PrintMotd no` on RHEL >= 8.