### PR TITLE
Fixed check_ps_service for sshd on EL 9.x machines.

### DIFF
--- a/roles/nhc_standalone/templates/nhc_standalone.conf
+++ b/roles/nhc_standalone/templates/nhc_standalone.conf
@@ -163,7 +163,7 @@
 ### Process checks
 ###
 # Everybody needs sshd running, right?  But don't use -r (restart)!
-   * || check_ps_service -u root -S sshd
+   * || check_ps_service -u root -S {% if ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] >= "9"%}-m 'sshd:'{% endif %} sshd
 
 # The cron daemon is another useful critter...
    * || check_ps_service -r crond


### PR DESCRIPTION
Fixed `check_ps_service` for `sshd` on EL 9.x machines, which have slightly different `ps` output.