### PR TITLE
Disable unused services to speed up logins and reduce log file clutter.

### DIFF
--- a/roles/logins/tasks/authselect.yml
+++ b/roles/logins/tasks/authselect.yml
@@ -62,7 +62,6 @@
     - inventory_hostname in groups['jumphost'] | default([]) or
       inventory_hostname in groups['data_transfer'] | default([])
     - hostvars[inventory_hostname]['ansible_mounts'] | selectattr('mount', 'equalto', '/') | map(attribute='fstype') | first == 'xfs'
-
   become: true
 
 - name: "Force enable authselect {{ stack_name }} profile."

--- a/roles/logins/tasks/main.yml
+++ b/roles/logins/tasks/main.yml
@@ -138,4 +138,10 @@
   when:
     - ansible_facts['os_family'] == "RedHat"
     - ansible_facts['distribution_major_version'] >= "8"
+
+- name: 'Update systemd default user presets.'
+  ansible.builtin.import_tasks: systemd-user-preset.yml
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] >= "8"
 ...

--- a/roles/logins/tasks/systemd-user-preset.yml
+++ b/roles/logins/tasks/systemd-user-preset.yml
@@ -1,0 +1,19 @@
+---
+- name: 'Patch /usr/lib/systemd/user-preset/90-default-user.preset to disable unused units.'
+  ansible.builtin.lineinfile:
+    path: /usr/lib/systemd/user-preset/90-default-user.preset
+    create: false
+    state: present
+    regexp: '#?(dis|en)able\s*{{ item }}'
+    line: 'disable {{ item }}'
+    owner: root
+    group: root
+    mode: '0644'
+  loop:
+    - pipewire.socket
+    - pipewire-pulse.socket
+    - pipewire-media-session.service
+    - wireplumber.service
+    - obex.service
+  become: true
+...

--- a/roles/remove/tasks/main.yml
+++ b/roles/remove/tasks/main.yml
@@ -28,6 +28,7 @@
     name:
       - tuned
       - polkit  # Security risk due to bug and we don't need it!
+      - polkit-pkla-compat # polkit dependency.
       - cockpit-system  # EL9 only
       - cockpit-bridge  # EL9 only
       - cockpit-ws  # EL9 only


### PR DESCRIPTION
* [Remove unused dependency.](https://github.com/rug-cit-hpc/league-of-robots/commit/9b8f6a87b2ac066ff7602f77101e68d3dd7383c2)
* [Disable various audio driver and bluetooth services, which we do not need upon login on headless servers.](https://github.com/rug-cit-hpc/league-of-robots/commit/252ca5fdcd60033039f383543eb6451de741fdc0)