### PR TITLE
List correct distribution and distribution version in online documentation.

### DIFF
--- a/roles/online_docs/defaults/main.yml
+++ b/roles/online_docs/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 external_hrefs:
   pulp: 'https://pulpproject.org/'
+  Rocky: 'https://rockylinux.org/'
+  CentOS: 'https://www.centos.org/'
 known_hosts_hostnames: "\
   {% for jumphost in groups['jumphost'] %}\
     {{ jumphost }}*,\

--- a/roles/online_docs/templates/mkdocs/docs/cluster.md
+++ b/roles/online_docs/templates/mkdocs/docs/cluster.md
@@ -10,7 +10,8 @@ The jobs are submitted to a workload manager, which distributes them efficiently
 
 The key features of the {{ slurm_cluster_name | capitalize }} cluster include:
 
- * Linux OS: [CentOS](https://www.centos.org/) 7.x
+ * Linux OS: [{{ hostvars[groups['user_interface'][0]]['ansible_distribution'] }}]({{ external_hrefs[hostvars[groups['user_interface'][0]]['ansible_distribution']] }})
+   version {{ hostvars[groups['user_interface'][0]]['ansible_distribution_version'] }}
    {% if repo_manager | default('none') != 'none' %}with [{{ repo_manager | capitalize }}]({{ external_hrefs[repo_manager] }}) for package distribution/management{% endif %}.
  * Completely virtualised on an [OpenStack](https://www.openstack.org/) cloud.
  * Deployment of HPC cluster with [Ansible playbooks](https://docs.ansible.com/ansible/latest/index.html) under version control in a Git repo: [league-of-robots](https://github.com/rug-cit-hpc/league-of-robots)

--- a/roles/online_docs/templates/mkdocs/docs/specifications.md
+++ b/roles/online_docs/templates/mkdocs/docs/specifications.md
@@ -5,7 +5,8 @@
 
 Key ingredients of the High Performance Computing (HPC) environment of the {{ slurm_cluster_name | capitalize }} cluster
 
- * Linux OS: [CentOS](https://www.centos.org/) {{ hostvars[groups['user_interface'][0]]['ansible_distribution_version'] }}
+ * Linux OS: [{{ hostvars[groups['user_interface'][0]]['ansible_distribution'] }}]({{ external_hrefs[hostvars[groups['user_interface'][0]]['ansible_distribution']] }})
+   version {{ hostvars[groups['user_interface'][0]]['ansible_distribution_version'] }}
    {% if repo_manager | default('none') != 'none' %}with [{{ repo_manager | capitalize }}]({{ external_hrefs[repo_manager] }}) for package distribution/management{% endif %}.
  * Job scheduling: [Slurm Workload Manager](https://slurm.schedmd.com/) {{ slurm_version.stdout }}
  * Module system: [Lmod](https://github.com/TACC/Lmod) {{ lmod_version.stdout }}


### PR DESCRIPTION
Deployed on Vaxtron, which incorrectly listed CentOS 7.x for the OS.