### PR TITLE
Makes openstack.cloud.port tasks idempotent.

### DIFF
--- a/roles/openstack_computing/tasks/main.yml
+++ b/roles/openstack_computing/tasks/main.yml
@@ -2,6 +2,24 @@
 # Create network ports, volumes and finally instances a.k.a. servers.
 #
 ---
+#
+# Get networks and routers from API.
+#
+# Note: we fetch info for all networks and reouters relevant or not
+# as filtering directly during the API call is problematic.
+# Will filter the results for the relevant info later on.
+#
+- name: Get info on networks from OpenStack API.
+  openstack.cloud.networks_info:
+  register: api_network_info
+  run_once: true
+- name: Get info on routers from OpenStack API.
+  openstack.cloud.routers_info:
+  register: api_router_info
+  run_once: true
+#
+# Create the servers.
+#
 - name: Create network ports, volumes and servers.
   ansible.builtin.include_tasks:
     file: servers.yml
@@ -17,14 +35,6 @@
 - name: Get info on floating IPs from OpenStack API.
   openstack.cloud.floating_ip_info:
   register: api_fip_info
-  run_once: true
-- name: Get info on networks from OpenStack API.
-  openstack.cloud.networks_info:
-  register: api_network_info
-  run_once: true
-- name: Get info on routers from OpenStack API.
-  openstack.cloud.routers_info:
-  register: api_router_info
   run_once: true
 - name: Get server info from OpenStack API.
   openstack.cloud.server_info:

--- a/roles/openstack_computing/tasks/servers.yml
+++ b/roles/openstack_computing/tasks/servers.yml
@@ -9,7 +9,15 @@
         security_groups: "{{ item.security_group }}"
         binding_vnic_type: "{{ hostvars[inventory_hostname]['host_type'] | default('normal') }}"
         fixed_ips:
+          #
+          # We must specify the subnet ID in addition to the IP address in order for the openstack.cloud.port task to be idempotent.
+          # When the task is not idempotent it will fail to update ports in certain external network,
+          # because we are allowed to create new ports but cannot update existing ones.
+          # Theoretically a network can have multiple subnets in OpenStack,
+          # but we do not have/use any networks with multiple subnets yet and simply use the first subnet for the required network.
+          #
           - ip_address: "{{ ip_addresses[inventory_hostname][item.name]['address'] }}"
+            subnet_id: "{{ api_network_info['networks'] | selectattr('name', 'equalto', item.name) | map(attribute='subnet_ids') | first | first }}"
         wait: true
         timeout: "{{ openstack_api_timeout }}"
       with_items: "{{ hostvars[inventory_hostname]['host_networks'] }}"

--- a/roles/openstack_computing/tasks/servers.yml
+++ b/roles/openstack_computing/tasks/servers.yml
@@ -11,7 +11,7 @@
         fixed_ips:
           #
           # We must specify the subnet ID in addition to the IP address in order for the openstack.cloud.port task to be idempotent.
-          # When the task is not idempotent it will fail to update ports in certain external network,
+          # When the task is not idempotent it will fail to update ports in certain external networks,
           # because we are allowed to create new ports but cannot update existing ones.
           # Theoretically a network can have multiple subnets in OpenStack,
           # but we do not have/use any networks with multiple subnets yet and simply use the first subnet for the required network.


### PR DESCRIPTION
Workaround for idempotency issue when creating network ports with ```openstack.cloud.port``` tasks.