### PR TITLE
Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,11 @@ else
 fi
 pip3 install openstackclient
 pip3 install ruamel.yaml
-pip3 install netaddr
+#
+# Until https://github.com/ansible-collections/ansible.utils/issues/331 is fixed,
+# we cannot use netaddr >= 1.0.0.
+#
+pip3 install 'netaddr<1'
 #
 # Package dnspython is required for Ansible lookup plugin community.general.dig
 #

--- a/requirements-0.yml
+++ b/requirements-0.yml
@@ -6,8 +6,12 @@ roles:
   - src: geerlingguy.postgresql
     version: 3.1.1
 collections:
+  #
+  # Ansible core 2.13.x from Ansible 6.x is latest version compatible with Mitogen.
+  # ansible.utils <= 3.0.0 is latest compatible with Ansible core 2.13.x
+  #
   - name: ansible.utils
-    version: '>=2.0.1'
+    version: '>=2.0.1,<3.0.0'
   - name: ansible.posix
     version: '>=1.2.0'
   - name: community.crypto

--- a/requirements-1.yml
+++ b/requirements-1.yml
@@ -6,8 +6,12 @@ roles:
   - src: geerlingguy.postgresql
     version: 3.5.0
 collections:
+  #
+  # Ansible core 2.13.x from Ansible 6.x is latest version compatible with Mitogen.
+  # ansible.utils <= 3.0.0 is latest compatible with Ansible core 2.13.x
+  #
   - name: ansible.utils
-    version: '>=2.10.3'
+    version: '>=2.10.3,<3.0.0'
   - name: ansible.posix
     version: '>=1.5.4'
   - name: community.crypto

--- a/requirements-2.yml
+++ b/requirements-2.yml
@@ -6,8 +6,12 @@ roles:
   - src: geerlingguy.postgresql
     version: 3.5.0
 collections:
+  #
+  # Ansible core 2.13.x from Ansible 6.x is latest version compatible with Mitogen.
+  # ansible.utils <= 3.0.0 is latest compatible with Ansible core 2.13.x
+  #
   - name: ansible.utils
-    version: '>=2.10.3'
+    version: '>=2.10.3,<3.0.0'
   - name: ansible.posix
     version: '>=1.5.4'
   - name: community.crypto


### PR DESCRIPTION
* [Do not use latest Python netaddr package due to breaking changes.](https://github.com/rug-cit-hpc/league-of-robots/commit/f78dc6324b9d90db41e29777519efb990f9f2552)
* [Do not use ```ansible.utils >= 3.0.0``` yet, because it is not compatible with older Ansible versions still compatible with Mitogen.](https://github.com/rug-cit-hpc/league-of-robots/commit/daa33cf3359a7868a1b0c6058e58c36cd02363c2)