### PR TITLE
Redeployed Vaxtron nodes vt-node-a[01,03].

### DIFF
--- a/group_vars/vaxtron_cluster/ip_addresses.yml
+++ b/group_vars/vaxtron_cluster/ip_addresses.yml
@@ -31,10 +31,10 @@ ip_addresses:
       netmask: /32
   vt-node-a01:
     DH4 Lustre:
-      address: 172.23.58.46
+      address: 172.23.58.67
       netmask: /32
     lustre:
-      address: 172.23.12.225
+      address: 172.23.13.16
       netmask: /32
     vt_internal_management:
       address: 10.10.1.182
@@ -51,10 +51,10 @@ ip_addresses:
       netmask: /32
   vt-node-a03:
     DH4 Lustre:
-      address: 172.23.58.27
+      address: 172.23.58.50
       netmask: /32
     lustre:
-      address: 172.23.13.87
+      address: 172.23.14.193
       netmask: /32
     vt_internal_management:
       address: 10.10.1.226


### PR DESCRIPTION
Machines were not reachable over network anymore and console was also not available -> had to redeploy from scratch resulting in updated IP addresses.