### PR TITLE
Fix/coredumps

### DIFF
--- a/roles/coredumps/tasks/main.yml
+++ b/roles/coredumps/tasks/main.yml
@@ -36,6 +36,7 @@
     masked: "{{ false if coredumps_enabled | bool else true }}"
     state: "{% if coredumps_enabled is sameas true %}started{% else %}stopped{% endif %}"
     daemon_reload: true
+  retries: 3  # Tends to fail the first time due to some caching issue.
   loop:
     - systemd-coredump.socket
     - kdump.service


### PR DESCRIPTION
* [Added retry option to task for disabling systemd-coredump.socket, which tends to fail the first time due to a caching bug.](https://github.com/rug-cit-hpc/league-of-robots/commit/0bbc2a926a437416beadbae91730b6486ff2317e)