### PR TITLE
Simplified sudoers.

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -275,67 +275,46 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
-    name: 'umcg-gd-ateambot'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
-    name: 'umcg-gd-dm'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
-    name: 'umcg-genomescan-ateambot'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
-    name: 'umcg-genomescan-dm'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
-    name: 'umcg-gsad-ateambot'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
-    name: 'umcg-gst-ateambot'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
-    name: 'umcg-gst-dm'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
-    name: 'umcg-lab-ateambot'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
-    name: 'umcg-lab-dm'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
-    name: 'umcg-labgnkbh-ateambot'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
-    name: 'umcg-labgnkbh-dm'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
-    name: 'umcg-patho-ateambot'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
-    name: 'umcg-patho-dm'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
-    name: 'umcg-pr-ateambot'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
-    name: 'umcg-pr-dm'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
-    name: 'umcg-vipt-dm'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -276,87 +276,66 @@ sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
     name: 'umcg-gd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
     name: 'umcg-gd-dm'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
     name: 'umcg-genomescan-ateambot'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
     name: 'umcg-genomescan-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
     name: 'umcg-gsad-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
     name: 'umcg-gst-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
     name: 'umcg-gst-dm'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
     name: 'umcg-lab-ateambot'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
     name: 'umcg-lab-dm'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
     name: 'umcg-labgnkbh-ateambot'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
     name: 'umcg-labgnkbh-dm'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
     name: 'umcg-patho-ateambot'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
     name: 'umcg-patho-dm'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
     name: 'umcg-pr-ateambot'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
     name: 'umcg-pr-dm'
-    command: 'ALL'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
     name: 'umcg-vipt-dm'
-    command: 'ALL'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/group_vars/boxy_cluster/vars.yml
+++ b/group_vars/boxy_cluster/vars.yml
@@ -15,7 +15,6 @@ regular_users:
 sudoers:
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
-    name: 'umcg-lifelines-dm'
 pfs_mounts:
   - pfs: umcgst08
     source: '172.23.34.213@tcp:172.23.34.214@tcp:'

--- a/group_vars/boxy_cluster/vars.yml
+++ b/group_vars/boxy_cluster/vars.yml
@@ -16,7 +16,6 @@ sudoers:
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
     name: 'umcg-lifelines-dm'
-    command: 'ALL'
 pfs_mounts:
   - pfs: umcgst08
     source: '172.23.34.213@tcp:172.23.34.214@tcp:'

--- a/group_vars/build_library/vars.yml
+++ b/group_vars/build_library/vars.yml
@@ -48,7 +48,7 @@ regular_users:
 sudoers:
   - who: ['%vipt']
     become: 'ALL'
-    name: 'apptainer' 
+    name: 'apptainer'
     command: '/bin/apptainer'
 use_ldap: false
 create_ldap: false

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -278,87 +278,66 @@ sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
     name: 'umcg-gd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
     name: 'umcg-gd-dm'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
     name: 'umcg-genomescan-ateambot'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
     name: 'umcg-genomescan-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
     name: 'umcg-gsad-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
     name: 'umcg-gst-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
     name: 'umcg-gst-dm'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
     name: 'umcg-lab-ateambot'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
     name: 'umcg-lab-dm'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
     name: 'umcg-labgnkbh-ateambot'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
     name: 'umcg-labgnkbh-dm'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
     name: 'umcg-patho-ateambot'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
     name: 'umcg-patho-dm'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
     name: 'umcg-pr-ateambot'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
     name: 'umcg-pr-dm'
-    command: 'ALL'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
     name: 'umcg-vipt-dm'
-    command: 'ALL'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -277,67 +277,46 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
-    name: 'umcg-gd-ateambot'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
-    name: 'umcg-gd-dm'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
-    name: 'umcg-genomescan-ateambot'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
-    name: 'umcg-genomescan-dm'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
-    name: 'umcg-gsad-ateambot'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
-    name: 'umcg-gst-ateambot'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
-    name: 'umcg-gst-dm'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
-    name: 'umcg-lab-ateambot'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
-    name: 'umcg-lab-dm'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
-    name: 'umcg-labgnkbh-ateambot'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
-    name: 'umcg-labgnkbh-dm'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
-    name: 'umcg-patho-ateambot'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
-    name: 'umcg-patho-dm'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
-    name: 'umcg-pr-ateambot'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
-    name: 'umcg-pr-dm'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
-    name: 'umcg-vipt-dm'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -333,15 +333,12 @@ sudoers:
   - who: ['%solve-rd']
     become: 'solve-rd-dm'
     name: 'solve-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%solve-rd']
     become: 'solve-rd-ateambot'
     name: 'solve-rd-ateambot'
-    command: 'ALL'
 #
 # Shared storage related variables
 #

--- a/group_vars/fender_cluster/vars.yml
+++ b/group_vars/fender_cluster/vars.yml
@@ -332,13 +332,10 @@ regular_users:
 sudoers:
   - who: ['%solve-rd']
     become: 'solve-rd-dm'
-    name: 'solve-rd-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%solve-rd']
     become: 'solve-rd-ateambot'
-    name: 'solve-rd-ateambot'
 #
 # Shared storage related variables
 #

--- a/group_vars/forkhead_cluster/vars.yml
+++ b/group_vars/forkhead_cluster/vars.yml
@@ -152,55 +152,38 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gap']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['%umcg-gap']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gd']
     become: 'umcg-gd-ateambot'
-    name: 'umcg-gd-ateambot'
   - who: ['%umcg-gd']
     become: 'umcg-gd-dm'
-    name: 'umcg-gd-dm'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
-    name: 'umcg-genomescan-ateambot'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
-    name: 'umcg-genomescan-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-ateambot'
-    name: 'umcg-gsad-ateambot'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
-    name: 'umcg-gst-ateambot'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
-    name: 'umcg-gst-dm'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
-    name: 'umcg-labgnkbh-ateambot'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
-    name: 'umcg-labgnkbh-dm'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
-    name: 'umcg-patho-ateambot'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
-    name: 'umcg-patho-dm'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
-    name: 'umcg-vipt-dm'
 #
 # Shared storage related variables
 #

--- a/group_vars/forkhead_cluster/vars.yml
+++ b/group_vars/forkhead_cluster/vars.yml
@@ -153,71 +153,54 @@ sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gap']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gap']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gd']
     become: 'umcg-gd-ateambot'
     name: 'umcg-gd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gd']
     become: 'umcg-gd-dm'
     name: 'umcg-gd-dm'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
     name: 'umcg-genomescan-ateambot'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
     name: 'umcg-genomescan-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-ateambot'
     name: 'umcg-gsad-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
     name: 'umcg-gst-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
     name: 'umcg-gst-dm'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
     name: 'umcg-labgnkbh-ateambot'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
     name: 'umcg-labgnkbh-dm'
-    command: 'ALL'    
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
     name: 'umcg-patho-ateambot'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
     name: 'umcg-patho-dm'
-    command: 'ALL'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
     name: 'umcg-vipt-dm'
-    command: 'ALL'
 #
 # Shared storage related variables
 #

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -294,175 +294,118 @@ regular_users:
 sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
-    name: 'umcg-aad-dm'
   - who: ['%umcg-as']
     become: 'umcg-capicebot'
-    name: 'umcg-capicebot'
   - who: ['%umcg-as']
     become: 'umcg-vipbot'
-    name: 'umcg-vipbot'
   - who: ['%umcg-as']
     become: 'umcg-as-dm'
-    name: 'umcg-as-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
-    name: 'umcg-biogen-dm'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
-    name: 'umcg-bionic-mdd-gwama-dm'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
-    name: 'umcg-bios-dm'
   - who: ['%umcg-cineca-dms']
     become: 'umcg-cineca-dm'
-    name: 'umcg-cineca-dm'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
-    name: 'umcg-dag3-dm'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
-    name: 'umcg-datateam-dm'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
-    name: 'umcg-ejp-rd-dm'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
-    name: 'umcg-endocrinology-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
-    name: 'umcg-fg-dm'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
-    name: 'umcg-franke-scrna-dm'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
-    name: 'umcg-fu-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
-    name: 'umcg-gaf-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
-    name: 'umcg-gaf-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
-    name: 'umcg-gastrocol-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
-    name: 'umcg-gdi-dm'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
-    name: 'umcg-gdio-dm'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
-    name: 'umcg-gonl-dm'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
-    name: 'umcg-griac-dm'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
-    name: 'umcg-grip-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
-    name: 'umcg-hematology-dm'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
-    name: 'umcg-hlhs-dm'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
-    name: 'umcg-immunogenetics-dm'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
-    name: 'umcg-impact-dm'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
-    name: 'umcg-lifelines-dm'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
-    name: 'umcg-lld-dm'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
-    name: 'umcg-llnext-dm'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
-    name: 'umcg-mic-dm'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
-    name: 'umcg-micompany-dm'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
-    name: 'umcg-msb-dm'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
-    name: 'umcg-nawijn-dm'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
-    name: 'umcg-pmb-dm'
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
-    name: 'umcg-pub-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
-    name: 'umcg-radicon-dm'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
-    name: 'umcg-rehabilitation-dm'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
-    name: 'umcg-reki-dm'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
-    name: 'umcg-solve-rd-dm'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
-    name: 'umcg-sommer-dm'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
-    name: 'umcg-sysops-dm'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
-    name: 'umcg-tifn-dm'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
-    name: 'umcg-ukb-dm'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
-    name: 'umcg-ugli-dm'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
-    name: 'umcg-verbeek-dm'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
-    name: 'umcg-vdakker-dm'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
-    name: 'umcg-visclasataxia-dm'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
-    name: 'umcg-weersma-dm'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
-    name: 'umcg-wijmenga-dm'
 #
 # Shared storage related variables
 #

--- a/group_vars/gearshift_cluster/vars.yml
+++ b/group_vars/gearshift_cluster/vars.yml
@@ -295,231 +295,174 @@ sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
     name: 'umcg-aad-dm'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-capicebot'
     name: 'umcg-capicebot'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-vipbot'
     name: 'umcg-vipbot'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-as-dm'
     name: 'umcg-as-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
     name: 'umcg-biogen-dm'
-    command: 'ALL'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
     name: 'umcg-bionic-mdd-gwama-dm'
-    command: 'ALL'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
     name: 'umcg-bios-dm'
-    command: 'ALL'
   - who: ['%umcg-cineca-dms']
     become: 'umcg-cineca-dm'
     name: 'umcg-cineca-dm'
-    command: 'ALL'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
     name: 'umcg-dag3-dm'
-    command: 'ALL'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
     name: 'umcg-datateam-dm'
-    command: 'ALL'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
     name: 'umcg-ejp-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
     name: 'umcg-endocrinology-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
     name: 'umcg-fg-dm'
-    command: 'ALL'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
     name: 'umcg-franke-scrna-dm'
-    command: 'ALL'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
     name: 'umcg-fu-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
     name: 'umcg-gaf-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
     name: 'umcg-gaf-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
     name: 'umcg-gastrocol-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
     name: 'umcg-gdi-dm'
-    command: 'ALL'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
     name: 'umcg-gdio-dm'
-    command: 'ALL'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
     name: 'umcg-gonl-dm'
-    command: 'ALL'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
     name: 'umcg-griac-dm'
-    command: 'ALL'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
     name: 'umcg-grip-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
     name: 'umcg-hematology-dm'
-    command: 'ALL'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
     name: 'umcg-hlhs-dm'
-    command: 'ALL'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
     name: 'umcg-immunogenetics-dm'
-    command: 'ALL'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
     name: 'umcg-impact-dm'
-    command: 'ALL'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
     name: 'umcg-lifelines-dm'
-    command: 'ALL'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
     name: 'umcg-lld-dm'
-    command: 'ALL'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
     name: 'umcg-llnext-dm'
-    command: 'ALL'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
     name: 'umcg-mic-dm'
-    command: 'ALL'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
     name: 'umcg-micompany-dm'
-    command: 'ALL'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
     name: 'umcg-msb-dm'
-    command: 'ALL'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
     name: 'umcg-nawijn-dm'
-    command: 'ALL'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
     name: 'umcg-pmb-dm'
-    command: 'ALL' 
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
     name: 'umcg-pub-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
     name: 'umcg-radicon-dm'
-    command: 'ALL'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
     name: 'umcg-rehabilitation-dm'
-    command: 'ALL'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
     name: 'umcg-reki-dm'
-    command: 'ALL'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
     name: 'umcg-solve-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
     name: 'umcg-sommer-dm'
-    command: 'ALL'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
     name: 'umcg-sysops-dm'
-    command: 'ALL'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
     name: 'umcg-tifn-dm'
-    command: 'ALL'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
     name: 'umcg-ukb-dm'
-    command: 'ALL'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
     name: 'umcg-ugli-dm'
-    command: 'ALL'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
     name: 'umcg-verbeek-dm'
-    command: 'ALL'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
     name: 'umcg-vdakker-dm'
-    command: 'ALL'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
     name: 'umcg-visclasataxia-dm'
-    command: 'ALL'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
     name: 'umcg-weersma-dm'
-    command: 'ALL'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
     name: 'umcg-wijmenga-dm'
-    command: 'ALL'
 #
 # Shared storage related variables
 #

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -150,13 +150,10 @@ regular_users:
 sudoers:
   - who: ['%solve-rd']
     become: 'solve-rd-dm'
-    name: 'solve-rd-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
 #
 # Shared storage related variables
 #

--- a/group_vars/hyperchicken_cluster/vars.yml
+++ b/group_vars/hyperchicken_cluster/vars.yml
@@ -151,15 +151,12 @@ sudoers:
   - who: ['%solve-rd']
     become: 'solve-rd-dm'
     name: 'solve-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
 #
 # Shared storage related variables
 #

--- a/group_vars/marvin_cluster/vars.yml
+++ b/group_vars/marvin_cluster/vars.yml
@@ -111,10 +111,8 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
 #
 # Shared storage related variables
 #

--- a/group_vars/marvin_cluster/vars.yml
+++ b/group_vars/marvin_cluster/vars.yml
@@ -112,11 +112,9 @@ sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
 #
 # Shared storage related variables
 #

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -377,211 +377,159 @@ sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
     name: 'umcg-aad-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
     name: 'umcg-biogen-dm'
-    command: 'ALL'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
     name: 'umcg-bionic-mdd-gwama-dm'
-    command: 'ALL'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
     name: 'umcg-bios-dm'
-    command: 'ALL'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
     name: 'umcg-dag3-dm'
-    command: 'ALL'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
     name: 'umcg-datateam-dm'
-    command: 'ALL'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
     name: 'umcg-ejp-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
     name: 'umcg-endocrinology-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
     name: 'umcg-fg-dm'
-    command: 'ALL'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
     name: 'umcg-franke-scrna-dm'
-    command: 'ALL'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
     name: 'umcg-fu-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
     name: 'umcg-gaf-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
     name: 'umcg-gaf-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
     name: 'umcg-gastrocol-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
     name: 'umcg-gdi-dm'
-    command: 'ALL'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
     name: 'umcg-gdio-dm'
-    command: 'ALL'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
     name: 'umcg-gonl-dm'
-    command: 'ALL'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
     name: 'umcg-griac-dm'
-    command: 'ALL'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
     name: 'umcg-grip-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
     name: 'umcg-hematology-dm'
-    command: 'ALL'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
     name: 'umcg-hlhs-dm'
-    command: 'ALL'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
     name: 'umcg-immunogenetics-dm'
-    command: 'ALL'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
     name: 'umcg-impact-dm'
-    command: 'ALL'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
     name: 'umcg-lifelines-dm'
-    command: 'ALL'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
     name: 'umcg-lld-dm'
-    command: 'ALL'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
     name: 'umcg-llnext-dm'
-    command: 'ALL'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
     name: 'umcg-mic-dm'
-    command: 'ALL'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
     name: 'umcg-micompany-dm'
-    command: 'ALL'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
     name: 'umcg-msb-dm'
-    command: 'ALL'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
     name: 'umcg-nawijn-dm'
-    command: 'ALL'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
     name: 'umcg-pmb-dm'
-    command: 'ALL' 
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
     name: 'umcg-pub-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
     name: 'umcg-radicon-dm'
-    command: 'ALL'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
     name: 'umcg-rehabilitation-dm'
-    command: 'ALL'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
     name: 'umcg-reki-dm'
-    command: 'ALL'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
     name: 'umcg-solve-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
     name: 'umcg-sommer-dm'
-    command: 'ALL'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
     name: 'umcg-tifn-dm'
-    command: 'ALL'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
     name: 'umcg-ukb-dm'
-    command: 'ALL'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
     name: 'umcg-ugli-dm'
-    command: 'ALL'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
     name: 'umcg-verbeek-dm'
-    command: 'ALL'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
     name: 'umcg-vdakker-dm'
-    command: 'ALL'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
     name: 'umcg-visclasataxia-dm'
-    command: 'ALL'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
     name: 'umcg-weersma-dm'
-    command: 'ALL'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
     name: 'umcg-wijmenga-dm'
-    command: 'ALL'
 #
 # Local storage variables.
 #

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -376,160 +376,108 @@ regular_users:
 sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
-    name: 'umcg-aad-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
-    name: 'umcg-biogen-dm'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
-    name: 'umcg-bionic-mdd-gwama-dm'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
-    name: 'umcg-bios-dm'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
-    name: 'umcg-dag3-dm'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
-    name: 'umcg-datateam-dm'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
-    name: 'umcg-ejp-rd-dm'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
-    name: 'umcg-endocrinology-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
-    name: 'umcg-fg-dm'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
-    name: 'umcg-franke-scrna-dm'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
-    name: 'umcg-fu-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
-    name: 'umcg-gaf-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
-    name: 'umcg-gaf-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
-    name: 'umcg-gastrocol-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
-    name: 'umcg-gdi-dm'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
-    name: 'umcg-gdio-dm'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
-    name: 'umcg-gonl-dm'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
-    name: 'umcg-griac-dm'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
-    name: 'umcg-grip-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
-    name: 'umcg-hematology-dm'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
-    name: 'umcg-hlhs-dm'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
-    name: 'umcg-immunogenetics-dm'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
-    name: 'umcg-impact-dm'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
-    name: 'umcg-lifelines-dm'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
-    name: 'umcg-lld-dm'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
-    name: 'umcg-llnext-dm'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
-    name: 'umcg-mic-dm'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
-    name: 'umcg-micompany-dm'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
-    name: 'umcg-msb-dm'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
-    name: 'umcg-nawijn-dm'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
-    name: 'umcg-pmb-dm'
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
-    name: 'umcg-pub-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
-    name: 'umcg-radicon-dm'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
-    name: 'umcg-rehabilitation-dm'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
-    name: 'umcg-reki-dm'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
-    name: 'umcg-solve-rd-dm'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
-    name: 'umcg-sommer-dm'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
-    name: 'umcg-tifn-dm'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
-    name: 'umcg-ukb-dm'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
-    name: 'umcg-ugli-dm'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
-    name: 'umcg-verbeek-dm'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
-    name: 'umcg-vdakker-dm'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
-    name: 'umcg-visclasataxia-dm'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
-    name: 'umcg-weersma-dm'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
-    name: 'umcg-wijmenga-dm'
 #
 # Local storage variables.
 #

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -173,39 +173,30 @@ sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-cineca-dms']
     become: 'umcg-cineca-dm'
     name: 'umcg-cineca-dm'
-    command: 'ALL'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
     name: 'umcg-endocrinology-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-ateambot'
     name: 'umcg-gsad-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
     name: 'umcg-lifelines-dm'
-    command: 'ALL'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
     name: 'umcg-sysops-dm'
-    command: 'ALL'
 
 #
 # Shared storage related variables

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -172,31 +172,22 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-cineca-dms']
     become: 'umcg-cineca-dm'
-    name: 'umcg-cineca-dm'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
-    name: 'umcg-endocrinology-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-ateambot'
-    name: 'umcg-gsad-ateambot'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
-    name: 'umcg-lifelines-dm'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
-    name: 'umcg-sysops-dm'
 
 #
 # Shared storage related variables

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -373,227 +373,171 @@ sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
     name: 'umcg-aad-dm'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-capicebot'
     name: 'umcg-capicebot'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-vipbot'
     name: 'umcg-vipbot'
-    command: 'ALL'
   - who: ['%umcg-as']
     become: 'umcg-as-dm'
     name: 'umcg-as-dm'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
     name: 'umcg-biogen-dm'
-    command: 'ALL'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
     name: 'umcg-bionic-mdd-gwama-dm'
-    command: 'ALL'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
     name: 'umcg-bios-dm'
-    command: 'ALL'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
     name: 'umcg-dag3-dm'
-    command: 'ALL'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
     name: 'umcg-datateam-dm'
-    command: 'ALL'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
     name: 'umcg-ejp-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
     name: 'umcg-endocrinology-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
     name: 'umcg-fg-dm'
-    command: 'ALL'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
     name: 'umcg-franke-scrna-dm'
-    command: 'ALL'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
     name: 'umcg-fu-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
     name: 'umcg-gaf-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
     name: 'umcg-gaf-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
     name: 'umcg-gastrocol-dm'
-    command: 'ALL'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
     name: 'umcg-gcc-dm'
-    command: 'ALL'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
     name: 'umcg-gdi-dm'
-    command: 'ALL'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
     name: 'umcg-gdio-dm'
-    command: 'ALL'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
     name: 'umcg-gonl-dm'
-    command: 'ALL'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
     name: 'umcg-griac-dm'
-    command: 'ALL'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
     name: 'umcg-grip-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
     name: 'umcg-hematology-dm'
-    command: 'ALL'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
     name: 'umcg-hlhs-dm'
-    command: 'ALL'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
     name: 'umcg-immunogenetics-dm'
-    command: 'ALL'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
     name: 'umcg-impact-dm'
-    command: 'ALL'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
     name: 'umcg-lifelines-dm'
-    command: 'ALL'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
     name: 'umcg-lld-dm'
-    command: 'ALL'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
     name: 'umcg-llnext-dm'
-    command: 'ALL'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
     name: 'umcg-mic-dm'
-    command: 'ALL'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
     name: 'umcg-micompany-dm'
-    command: 'ALL'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
     name: 'umcg-msb-dm'
-    command: 'ALL'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
     name: 'umcg-nawijn-dm'
-    command: 'ALL'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
     name: 'umcg-pmb-dm'
-    command: 'ALL' 
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
     name: 'umcg-pub-dm'
-    command: 'ALL'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
     name: 'umcg-radicon-dm'
-    command: 'ALL'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
     name: 'umcg-rehabilitation-dm'
-    command: 'ALL'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
     name: 'umcg-reki-dm'
-    command: 'ALL'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
     name: 'umcg-solve-rd-dm'
-    command: 'ALL'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
     name: 'umcg-sommer-dm'
-    command: 'ALL'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
     name: 'umcg-sysops-dm'
-    command: 'ALL'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
     name: 'umcg-tifn-dm'
-    command: 'ALL'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
     name: 'umcg-ukb-dm'
-    command: 'ALL'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
     name: 'umcg-ugli-dm'
-    command: 'ALL'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
     name: 'umcg-verbeek-dm'
-    command: 'ALL'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
     name: 'umcg-vdakker-dm'
-    command: 'ALL'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
     name: 'umcg-visclasataxia-dm'
-    command: 'ALL'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
     name: 'umcg-weersma-dm'
-    command: 'ALL'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
     name: 'umcg-wijmenga-dm'
-    command: 'ALL'
 #
 # Local storage variables.
 #

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -372,172 +372,116 @@ regular_users:
 sudoers:
   - who: ['%umcg-aad']
     become: 'umcg-aad-dm'
-    name: 'umcg-aad-dm'
   - who: ['%umcg-as']
     become: 'umcg-capicebot'
-    name: 'umcg-capicebot'
   - who: ['%umcg-as']
     become: 'umcg-vipbot'
-    name: 'umcg-vipbot'
   - who: ['%umcg-as']
     become: 'umcg-as-dm'
-    name: 'umcg-as-dm'
   - who: ['%umcg-atd']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-biogen-dms']
     become: 'umcg-biogen-dm'
-    name: 'umcg-biogen-dm'
   - who: ['%umcg-bionic-mdd-gwama-dms']
     become: 'umcg-bionic-mdd-gwama-dm'
-    name: 'umcg-bionic-mdd-gwama-dm'
   - who: ['%umcg-bios']
     become: 'umcg-bios-dm'
-    name: 'umcg-bios-dm'
   - who: ['%umcg-dag3-dms']
     become: 'umcg-dag3-dm'
-    name: 'umcg-dag3-dm'
   - who: ['%umcg-datateam']
     become: 'umcg-datateam-dm'
-    name: 'umcg-datateam-dm'
   - who: ['%umcg-ejp-rd-dms']
     become: 'umcg-ejp-rd-dm'
-    name: 'umcg-ejp-rd-dm'
   - who: ['%umcg-endocrinology-dms']
     become: 'umcg-endocrinology-dm'
-    name: 'umcg-endocrinology-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-fg-dms']
     become: 'umcg-fg-dm'
-    name: 'umcg-fg-dm'
   - who: ['%umcg-franke-scrna-dms']
     become: 'umcg-franke-scrna-dm'
-    name: 'umcg-franke-scrna-dm'
   - who: ['%umcg-fu-dms']
     become: 'umcg-fu-dm'
-    name: 'umcg-fu-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-ateambot'
-    name: 'umcg-gaf-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gaf-dm'
-    name: 'umcg-gaf-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gastrocol-dms']
     become: 'umcg-gastrocol-dm'
-    name: 'umcg-gastrocol-dm'
   - who: ['%umcg-gcc']
     become: 'umcg-gcc-dm'
-    name: 'umcg-gcc-dm'
   - who: ['%umcg-gdi-dms']
     become: 'umcg-gdi-dm'
-    name: 'umcg-gdi-dm'
   - who: ['%umcg-gdio-dms']
     become: 'umcg-gdio-dm'
-    name: 'umcg-gdio-dm'
   - who: ['%umcg-gonl-dms']
     become: 'umcg-gonl-dm'
-    name: 'umcg-gonl-dm'
   - who: ['%umcg-griac-dms']
     become: 'umcg-griac-dm'
-    name: 'umcg-griac-dm'
   - who: ['%umcg-grip-dms']
     become: 'umcg-grip-dm'
-    name: 'umcg-grip-dm'
   - who: ['%umcg-gsad']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-hematology-dms']
     become: 'umcg-hematology-dm'
-    name: 'umcg-hematology-dm'
   - who: ['%umcg-hlhs-dms']
     become: 'umcg-hlhs-dm'
-    name: 'umcg-hlhs-dm'
   - who: ['%umcg-immunogenetics-dms']
     become: 'umcg-immunogenetics-dm'
-    name: 'umcg-immunogenetics-dm'
   - who: ['%umcg-impact']
     become: 'umcg-impact-dm'
-    name: 'umcg-impact-dm'
   - who: ['%umcg-lifelines-dms']
     become: 'umcg-lifelines-dm'
-    name: 'umcg-lifelines-dm'
   - who: ['%umcg-lld-dms']
     become: 'umcg-lld-dm'
-    name: 'umcg-lld-dm'
   - who: ['%umcg-llnext-dms']
     become: 'umcg-llnext-dm'
-    name: 'umcg-llnext-dm'
   - who: ['%umcg-mic-dms']
     become: 'umcg-mic-dm'
-    name: 'umcg-mic-dm'
   - who: ['%umcg-micompany-dms']
     become: 'umcg-micompany-dm'
-    name: 'umcg-micompany-dm'
   - who: ['%umcg-msb']
     become: 'umcg-msb-dm'
-    name: 'umcg-msb-dm'
   - who: ['%umcg-nawijn-dms']
     become: 'umcg-nawijn-dm'
-    name: 'umcg-nawijn-dm'
   - who: ['%umcg-pmb-dms']
     become: 'umcg-pmb-dm'
-    name: 'umcg-pmb-dm'
   - who: ['%umcg-pub-dms']
     become: 'umcg-pub-dm'
-    name: 'umcg-pub-dm'
   - who: ['umcg-gvdvries,umcg-kdelange,umcg-mbenjamins,umcg-mbijlsma,umcg-pneerincx,umcg-rkanninga']
     become: 'umcg-radicon-dm'
-    name: 'umcg-radicon-dm'
   - who: ['%umcg-rehabilitation-dms']
     become: 'umcg-rehabilitation-dm'
-    name: 'umcg-rehabilitation-dm'
   - who: ['%umcg-reki-dms']
     become: 'umcg-reki-dm'
-    name: 'umcg-reki-dm'
   - who: ['%umcg-solve-rd-dms']
     become: 'umcg-solve-rd-dm'
-    name: 'umcg-solve-rd-dm'
   - who: ['%umcg-sommer-dms']
     become: 'umcg-sommer-dm'
-    name: 'umcg-sommer-dm'
   - who: ['%umcg-sysops']
     become: 'umcg-sysops-dm'
-    name: 'umcg-sysops-dm'
   - who: ['%umcg-tifn-dms']
     become: 'umcg-tifn-dm'
-    name: 'umcg-tifn-dm'
   - who: ['%umcg-ukb-dms']
     become: 'umcg-ukb-dm'
-    name: 'umcg-ukb-dm'
   - who: ['%umcg-ugli-dms']
     become: 'umcg-ugli-dm'
-    name: 'umcg-ugli-dm'
   - who: ['%umcg-verbeek']
     become: 'umcg-verbeek-dm'
-    name: 'umcg-verbeek-dm'
   - who: ['%umcg-vdakker-dms']
     become: 'umcg-vdakker-dm'
-    name: 'umcg-vdakker-dm'
   - who: ['%umcg-visclasataxia-dms']
     become: 'umcg-visclasataxia-dm'
-    name: 'umcg-visclasataxia-dm'
   - who: ['%umcg-weersma-dms']
     become: 'umcg-weersma-dm'
-    name: 'umcg-weersma-dm'
   - who: ['%umcg-wijmenga-dms']
     become: 'umcg-wijmenga-dm'
-    name: 'umcg-wijmenga-dm'
 #
 # Local storage variables.
 #

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -288,67 +288,46 @@ regular_users:
 sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
-    name: 'umcg-atd-ateambot'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
-    name: 'umcg-atd-dm'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
-    name: 'umcg-gap-ateambot'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
-    name: 'umcg-gap-dm'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
-    name: 'umcg-gd-ateambot'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
-    name: 'umcg-gd-dm'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
-    name: 'umcg-genomescan-ateambot'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
-    name: 'umcg-genomescan-dm'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
-    name: 'umcg-gsad-ateambot'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
-    name: 'umcg-gsad-dm'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
-    name: 'umcg-gst-ateambot'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
-    name: 'umcg-gst-dm'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
-    name: 'umcg-lab-ateambot'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
-    name: 'umcg-lab-dm'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
-    name: 'umcg-labgnkbh-ateambot'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
-    name: 'umcg-labgnkbh-dm'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
-    name: 'umcg-patho-ateambot'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
-    name: 'umcg-patho-dm'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
-    name: 'umcg-pr-ateambot'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
-    name: 'umcg-pr-dm'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
-    name: 'umcg-vipt-dm'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -289,87 +289,66 @@ sudoers:
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-ateambot'
     name: 'umcg-atd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-atd,!charbonb,!hendriksend']
     become: 'umcg-atd-dm'
     name: 'umcg-atd-dm'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-ateambot'
     name: 'umcg-gap-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gap,!charbonb,!hendriksend']
     become: 'umcg-gap-dm'
     name: 'umcg-gap-dm'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-ateambot'
     name: 'umcg-gd-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gd,!charbonb,!hendriksend']
     become: 'umcg-gd-dm'
     name: 'umcg-gd-dm'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-ateambot'
     name: 'umcg-genomescan-ateambot'
-    command: 'ALL'
   - who: ['%umcg-genomescan']
     become: 'umcg-genomescan-dm'
     name: 'umcg-genomescan-dm'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-ateambot'
     name: 'umcg-gsad-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gsad,!charbonb,!hendriksend']
     become: 'umcg-gsad-dm'
     name: 'umcg-gsad-dm'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-ateambot'
     name: 'umcg-gst-ateambot'
-    command: 'ALL'
   - who: ['%umcg-gst']
     become: 'umcg-gst-dm'
     name: 'umcg-gst-dm'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-ateambot'
     name: 'umcg-lab-ateambot'
-    command: 'ALL'
   - who: ['%umcg-lab-dms']
     become: 'umcg-lab-dm'
     name: 'umcg-lab-dm'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-ateambot'
     name: 'umcg-labgnkbh-ateambot'
-    command: 'ALL'
   - who: ['%umcg-labgnkbh']
     become: 'umcg-labgnkbh-dm'
     name: 'umcg-labgnkbh-dm'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-ateambot'
     name: 'umcg-patho-ateambot'
-    command: 'ALL'
   - who: ['%umcg-patho']
     become: 'umcg-patho-dm'
     name: 'umcg-patho-dm'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-ateambot'
     name: 'umcg-pr-ateambot'
-    command: 'ALL'
   - who: ['%umcg-pr']
     become: 'umcg-pr-dm'
     name: 'umcg-pr-dm'
-    command: 'ALL'
   - who: ['%umcg-vipt']
     become: 'umcg-vipt-dm'
     name: 'umcg-vipt-dm'
-    command: 'ALL'
 remote_users_in_local_groups:
   - user: 'benjaminsm'
     groups: [

--- a/roles/sudoers/README.md
+++ b/roles/sudoers/README.md
@@ -1,0 +1,19 @@
+# sudoers role
+
+This role can be used to manage (create and delete) files in ```/etc/sudoers.d/``` to extend the sudoers config.
+
+The ```sudo``` permissions can be listed in a ```sudoers``` variable in ```group_vars/{{stack_name}}/vars.yml``` like this:
+
+```yaml
+sudoers:
+  - who: ['%some-group']
+    become: 'ALL'
+    name: 'apptainer'
+    command: '/bin/apptainer'
+  - who: ['%some-group']
+    become: 'some-group-dm'
+```
+
+* The ```who``` and ```become``` attributes are _required_.
+* ```name``` is used as part of the filename for the file in in ```/etc/sudoers.d/```. This attribute is _optional_ and will default to the value of the ```become``` attribute when not specified.
+* ```command``` is _optional_ and will default to ```ALL``` when not specified.

--- a/roles/sudoers/defaults/main.yml
+++ b/roles/sudoers/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+#
+# Tag / label in the filename of files in /etc/sudoers.d/ managed by this role:
+#  * Required files not yet present will be created
+#  * Files no longer required will be deleted
+#
+ansible_managed_sudoers_filename_tag: ansible-managed
+#
+# List of file names (without prefix) for all configured sudoers configs:
+# Use name attribute when specified or default to the become attribute when name was not specified.
+# E.g. this: 
+#
+#     sudoers:
+#       - who: ['%some-group']
+#         become: 'ALL'
+#         name: 'apptainer'
+#         command: '/bin/apptainer'
+#       - who: ['%some-group']
+#         become: 'some-group-dm'
+#
+# will result in name 'apptainer' for the first entry and 'some-group-dm' for the second entry
+#
+configured_ansible_managed_sudoers: "{{ sudoers | default([]) | selectattr('name', 'defined') | map(attribute='name') | list +
+                                        sudoers | default([]) | selectattr('name', 'undefined') | map(attribute='become') | list }}"
+...

--- a/roles/sudoers/defaults/main.yml
+++ b/roles/sudoers/defaults/main.yml
@@ -8,7 +8,7 @@ ansible_managed_sudoers_filename_tag: ansible-managed
 #
 # List of file names (without prefix) for all configured sudoers configs:
 # Use name attribute when specified or default to the become attribute when name was not specified.
-# E.g. this: 
+# E.g. this:
 #
 #     sudoers:
 #       - who: ['%some-group']

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -1,34 +1,32 @@
 ---
 #
 # Allow passwordless sudo to functional accounts (e.g. for datamanager accounts) for indivual users or %groups.
-# Who can become what can be specified in regular_users variable of group_vars/${clustername}/vars.yml.
+# Who can become what can be specified in the sudoers variable of group_vars/${stackname}/vars.yml.
 #
-
-- name: 'Find all ansible-managed files in /etc/sudoers.d/.'
+- name: "Find all {{ ansible_managed_sudoers_filename_tag }} tagged files in /etc/sudoers.d/."
   ansible.builtin.find:
     paths: '/etc/sudoers.d/'
     use_regex: true
-    patterns: '.*ansible-managed.*'
-  register: ansible_managed_sudoers
+    patterns: ".*{{ ansible_managed_sudoers_filename_tag }}.*"
+  register: found_ansible_managed_sudoers
   become: true
 
-- name: 'Remove outdated ansible-managed files from /etc/sudoers.d/.'
+- name: "Remove outdated {{ ansible_managed_sudoers_filename_tag }} tagged files from /etc/sudoers.d/."
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
-  with_items: "{{ ansible_managed_sudoers.files | map(attribute='path') | list }}"
-  when: item | regex_replace('.*ansible-managed-','') not in sudoers | default([]) | selectattr('name', 'defined') | map(attribute='name') | list
+  loop: "{{ found_ansible_managed_sudoers['files'] | map(attribute='path') | list }}"
+  when: item | regex_replace('.*' + ansible_managed_sudoers_filename_tag + '-', '') not in configured_ansible_managed_sudoers | default([])
   become: true
 
-- name: 'Allow passwordless sudo to functional accounts.'
+- name: "Create {{ ansible_managed_sudoers_filename_tag }} tagged files in /etc/sudoers.d/ for configured sudoers."
   ansible.builtin.template:
-    src: 'templates/92-ansible-managed'
-    dest: "/etc/sudoers.d/92-ansible-managed-{{ item.name }}"
+    src: "templates/92-{{ ansible_managed_sudoers_filename_tag }}"
+    dest: "/etc/sudoers.d/92-{{ ansible_managed_sudoers_filename_tag }}-{{ item['name'] | default(item['become']) }}"
     owner: 'root'
     group: 'root'
     mode: '0440'
     validate: '/usr/sbin/visudo -cf %s'
-  with_items:
-    - "{{ sudoers | default([]) }}"
+  loop: "{{ sudoers | default([]) }}"
   become: true
 ...

--- a/roles/sudoers/templates/92-ansible-managed
+++ b/roles/sudoers/templates/92-ansible-managed
@@ -6,4 +6,4 @@
 #
 # Allow specific users or groups to run specific commands
 #
-{% if functional_admin_group is defined and functional_admin_group | length %}%{{ functional_admin_group | regex_replace(' ', '\\ ') }},{% endif %}{% for user_group in item.who %}{{user_group}}{{ "," if not loop.last else "" }}{% endfor %}    ALL=({{ item.become }})    NOPASSWD:{{ item.command }}
+{% if functional_admin_group is defined and functional_admin_group | length %}%{{ functional_admin_group | regex_replace(' ', '\\ ') }},{% endif %}{% for user_group in item.who %}{{user_group}}{{ "," if not loop.last else "" }}{% endfor %}    ALL=({{ item.become }})    NOPASSWD:{{ item.command | default('ALL') }}


### PR DESCRIPTION
Simplified ```sudoers``` role:
* Added default ```ALL``` for sudo commands, which saves a lot of lines in group_vars.
* Added default for the ```name``` attribute in ```sudoers``` configs, so we can remove a lot of redundant lines from group_vars.
* Added a ```README.md``` for the role.
* Replaced some previously hard coded strings with variables from ```defaults/main.yml```.

