### PR TITLE
Prevent running wrong playbooks on chaperones.

### DIFF
--- a/single_role_playbooks/grub.yml
+++ b/single_role_playbooks/grub.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure grub on all hosts.
-  hosts: all,!openstack_api
+  hosts: all,!openstack_api,!chaperone
   roles:
     - grub
 ...

--- a/single_role_playbooks/iptables.yml
+++ b/single_role_playbooks/iptables.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all,!openstack_api
+- hosts: all,!openstack_api,!chaperone
   roles:
   - 'iptables'
 ...


### PR DESCRIPTION
Do not run `single_role_playbooks` on `chaperones` when the corresponding role is not listed in `single_group_playbooks/chaperone.yml`.