### PR TITLE
Temporarily disable UMCG Isilon mounts for umcg-pr group.

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -439,12 +439,12 @@ pfs_mounts:
     rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
     ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
     machines: "{{ groups['chaperone'] }}"
-  - pfs: 'research$'
-    source: '//storage3.umcg.nl/'
-    type: cifs    # checked with cat /proc/filesystem
-    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
-    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
-    machines: "{{ groups['chaperone'] }}"
+#  - pfs: 'research$'
+#    source: '//storage3.umcg.nl/'
+#    type: cifs    # checked with cat /proc/filesystem
+#    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
+#    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
+#    machines: "{{ groups['chaperone'] }}"
 lfs_mounts:
   - lfs: home
     pfs: local_raid
@@ -585,36 +585,36 @@ lfs_mounts:
     groups:
       - name: umcg-labgnkbh
     rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
   - lfs: env05
     pfs: local_raid
     rw_machines: "{{ groups['deploy_admin_interface'] + groups['compute_node'] + groups['user_interface'] }}"

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -441,12 +441,12 @@ pfs_mounts:
     rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
     ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
     machines: "{{ groups['chaperone'] }}"
-  - pfs: 'research$'
-    source: '//storage3.umcg.nl/'
-    type: cifs    # checked with cat /proc/filesystem
-    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
-    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
-    machines: "{{ groups['chaperone'] }}"
+#  - pfs: 'research$'
+#    source: '//storage3.umcg.nl/'
+#    type: cifs    # checked with cat /proc/filesystem
+#    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
+#    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
+#    machines: "{{ groups['chaperone'] }}"
 lfs_mounts:
   - lfs: home
     pfs: local_raid
@@ -587,36 +587,36 @@ lfs_mounts:
     groups:
       - name: umcg-labgnkbh
     rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
   - lfs: env06
     pfs: local_raid
     rw_machines: "{{ groups['deploy_admin_interface'] + groups['compute_node'] + groups['user_interface'] }}"

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -472,12 +472,12 @@ pfs_mounts:
     rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
     ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
     machines: "{{ groups['chaperone'] }}"
-  - pfs: 'research$'
-    source: '//storage3.umcg.nl/'
-    type: cifs    # checked with cat /proc/filesystem
-    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
-    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
-    machines: "{{ groups['chaperone'] }}"
+#  - pfs: 'research$'
+#    source: '//storage3.umcg.nl/'
+#    type: cifs    # checked with cat /proc/filesystem
+#    rw_options: 'vers=3.0,mfsymlinks,rw,soft,perm'
+#    ro_options: 'vers=3.0,mfsymlinks,ro,soft,perm'
+#    machines: "{{ groups['chaperone'] }}"
 lfs_mounts:
   - lfs: home
     pfs: umcgst12
@@ -618,36 +618,36 @@ lfs_mounts:
     groups:
       - name: umcg-labgnkbh
     rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat55
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat56
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: prm57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
-  - lfs: dat57
-    pfs: 'research$'
-    groups:
-      - name: umcg-pr
-    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat55
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat56
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: prm57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
+#  - lfs: dat57
+#    pfs: 'research$'
+#    groups:
+#      - name: umcg-pr
+#    rw_machines: "{{ groups['chaperone'] }}"
   - lfs: env07
     pfs: umcgst12
     ro_machines: "{{ groups['compute_node'] + groups['user_interface'] }}"


### PR DESCRIPTION
Temporarily disable UMCG Isilon mounts for umcg-pr group, which will fail to mount due to missing credentials. Workaround for #961.