### PR TITLE
Make mounts from original dh5 volume read-write again.

### DIFF
--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -548,8 +548,7 @@ lfs_mounts:
   - lfs: home
     pfs: umcgst05
     quota_type: 'project'
-    #rw_machines: "{{ groups['cluster'] }}"
-    ro_machines: "{{ groups['cluster'] }}"
+    rw_machines: "{{ groups['cluster'] }}"
   - lfs: tmp03
     pfs: umcgst05
     quota_type: 'project'
@@ -581,8 +580,7 @@ lfs_mounts:
         mode: '2750'
       - name: umcg-ugli
         mode: '2750'
-    #rw_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] + groups['compute_node'] }}"
-    ro_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] + groups['compute_node'] }}"
+    rw_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] + groups['compute_node'] }}"
   - lfs: tmp04
     pfs: umcgst06
     quota_type: 'project'
@@ -737,7 +735,6 @@ lfs_mounts:
   - lfs: env03
     pfs: umcgst05
     quota_type: 'project'
-    #ro_machines: "{{ groups['compute_node'] + groups['user_interface'] }}"
-    #rw_machines: "{{ groups['deploy_admin_interface'] }}"
-    ro_machines: "{{ groups['deploy_admin_interface'] + groups['compute_node'] + groups['user_interface'] }}"
+    ro_machines: "{{ groups['compute_node'] + groups['user_interface'] }}"
+    rw_machines: "{{ groups['deploy_admin_interface'] }}"
 ...


### PR DESCRIPTION
Reverts temporary read-only changes due to incident in CBC.