### PR TITLE
Change: /etc/ssh/ssh_known_hosts contain CA public keys from all clusters

### DIFF
--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -22,7 +22,7 @@
     line: '@cert-authority * {{ item.stdout }}'
     path: /etc/ssh/ssh_known_hosts
     create: true
-    mode: 0644
+    mode: '0644'
   loop: "{{ ssh_ca_content.results }}"
   loop_control:
     label: "{{ item.item }}"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -5,16 +5,16 @@
     patterns: "*.pub"
     follow: yes
   register: ssh_ca_pub_files
-  changed_when: false
   delegate_to: localhost
   connection: local
 
 - name: Collect content from all the .pub files
   ansible.builtin.command: cat {{ item.path }}
+  loop: "{{ ssh_ca_pub_files.files }}"
   register: ssh_ca_content
+  changed_when: false
   delegate_to: localhost
   connection: local
-  loop: "{{ ssh_ca_pub_files.files }}"
 
 - name: Make sure that /etc/ssh/ssh_known_hosts contains the .pub files
   ansible.builtin.lineinfile:

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -5,6 +5,7 @@
     patterns: "*.pub"
     follow: yes
   register: ssh_ca_pub_files
+  changed_when: false
   delegate_to: localhost
   connection: local
 

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,14 +1,29 @@
 ---
-- name: Add public keys from CAs that signed {{ stack_name }} host keys to /etc/ssh/ssh_known_hosts.
+- name: Find CA public key files
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/ssh-host-ca/"
+    patterns: "*.pub"
+    follow: yes
+  register: ssh_ca_pub_files
+  delegate_to: localhost
+  connection: local
+
+- name: Collect content from all the .pub files
+  ansible.builtin.command: cat {{ item.path }}
+  register: ssh_ca_content
+  delegate_to: localhost
+  connection: local
+  loop: "{{ ssh_ca_pub_files.files }}"
+
+- name: Make sure that /etc/ssh/ssh_known_hosts contains the .pub files
   ansible.builtin.lineinfile:
-    dest: /etc/ssh/ssh_known_hosts
-    mode: '0644'
-    owner: root
-    group: root
+    regex: "^#?.*{{ item.stdout }}$"
+    line: '@cert-authority * {{ item.stdout }}'
+    path: /etc/ssh/ssh_known_hosts
     create: true
-    insertbefore: BOF
-    regexp: "(?i)^#?@cert-authority .* for {{ stack_name }}$"
-    line: "@cert-authority * {{ lookup('file', ssh_host_signer_ca_private_key + '.pub') }} for {{ stack_name }}"
+  loop: "{{ ssh_ca_content.results }}"
+  loop_control:
+    label: "{{ item.item }}"
   become: true
 
 - name: Make sure /etc/ssh/ssh_config.d/*.conf config files are included.

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.find:
     paths: "{{ playbook_dir }}/ssh-host-ca/"
     patterns: "*.pub"
-    follow: yes
+    follow: true
   register: ssh_ca_pub_files
   delegate_to: localhost
   connection: local
@@ -22,6 +22,7 @@
     line: '@cert-authority * {{ item.stdout }}'
     path: /etc/ssh/ssh_known_hosts
     create: true
+    mode: 0644
   loop: "{{ ssh_ca_content.results }}"
   loop_control:
     label: "{{ item.item }}"


### PR DESCRIPTION
Our systems should be able to talk to each other (when needed) without user needing first to add host to ~/.ssh/known_hosts file.
This implements it.