### PR TITLE
Recreate RSA host keys if they are not 4096 bits.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,4 +8,9 @@ skip_list:
   - 'experimental'  # All rules tagged as experimental.
   - 'name[template]'  # Allow jinja templating anywhere in a task name.
   - 'var-naming[no-role-prefix]'  # Temporarily disable this new check: will be fixed in a dedicated PR.
+  #
+  # https://github.com/ansible/ansible-lint/issues/4035
+  # https://github.com/ansible/ansible-lint/issues/4168
+  #
+  - 'name[casing]'  # Temporarily disable this new check: bug causes false positive errors when handler uses 'listen'.
 ...

--- a/roles/ssh_host_signer/tasks/main.yml
+++ b/roles/ssh_host_signer/tasks/main.yml
@@ -4,6 +4,28 @@
     name: "{{ hostvars[inventory_hostname].fqdn | default(inventory_hostname) }}"
   become: true
 
+- name: '(Re)create RSA host key with 4096 bits.'
+  community.crypto.openssh_keypair:
+    path: "{{ ssh_host_signer_key_directory }}/ssh_host_rsa_key"
+    type: rsa
+    size: 4096
+  become: true
+
+- name: "Fix permissions for RSA host key."
+  ansible.builtin.file:
+    path: "{{ ssh_host_signer_key_directory }}/{{ item.filename }}"
+    owner: root
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - filename: ssh_host_rsa_key
+      group: ssh_keys
+      mode: '0640'
+    - filename: ssh_host_rsa_key.pub
+      group: root
+      mode: '0644'
+  become: true
+
 - name: 'Find SSH host keys.'
   ansible.builtin.find:
     path: "{{ ssh_host_signer_key_directory }}"


### PR DESCRIPTION
Default RSA host keys are still only 2048 bits resulting in lots of errors in /var/log/messages for ignored RSA host keys upon each login.