### PR TITLE
Added new init.yml play.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ Deployment and functional administration of all clusters is a joined effort of t
 [Genomics Coordination Center (GCC)](http://wiki.gcc.rug.nl/)
 and the 
 [Center for Information Technology (CIT)](https://www.rug.nl/society-business/centre-for-information-technology/)
-from the [University Medical Center](https://www.umcg.nl) and [University](https://www.rug.nl) of Groningen, in collaboration with [ELIXIR compute platform](https://www.elixir-europe.org/platforms/compute), [EXCELERATE](https://www.elixir-europe.org/about-us/how-funded/eu-projects/excelerate), [EU-Solve-RD](http://solve-rd.eu/), European Joint Project for Rare disease and [CORBEL](https://www.corbel-project.eu/home.html) projects.
+from the [University Medical Center](https://www.umcg.nl) and [University](https://www.rug.nl) of Groningen,
+in collaboration with [ELIXIR compute platform](https://www.elixir-europe.org/platforms/compute),
+[EXCELERATE](https://www.elixir-europe.org/about-us/how-funded/eu-projects/excelerate),
+[EU-Solve-RD](http://solve-rd.eu/),
+[European Joint Programme on Rare Diseases](https://www.ejprarediseases.org/) and
+[CORBEL](https://www.corbel-project.eu/home.html) projects.
 
 #### Cluster components
 
@@ -519,22 +524,20 @@ Once configured correctly you should be able to do a multi-hop SSH via a jumphos
   default_cloud_image_user='centos|cloud-user'
   lor_admin_user='your_admin_account'
   ```
-* Firstly, create the jumphost, which is required to access the other machines.
-* Deploy the signed hosts keys and create local admin accounts.
-* Configure other stuff on the jumphost, which contains amongst others the settings required to access the other machines behind the jumphost.
+* Firstly, create the jumphost, which is required to access the other machines.  
+  Deploy the signed hosts keys and create local admin accounts with ```init.yml``` and
+  configure other stuff on the jumphost (contains amongst others the settings required to access the other machines behind the jumphost)
+  with ```cluster.yml```:
   ```
-  ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "${default_cloud_image_user}" -l 'jumphost' single_role_playbooks/ssh_host_signer.yml
-  ansible-playbook -u "${default_cloud_image_user}" -l 'jumphost' single_role_playbooks/admin_users.yml
+  ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "${default_cloud_image_user}" -l 'jumphost' single_group_playbooks/init.yml
   ansible-playbook -u "${lor_admin_user}" -l 'jumphost' cluster.yml
   ```
-* Secondly, deploy the rest of the machines in the same order.
-  For creation of the local admin accounts you must (temporarily) set ```JUMPHOST_USER``` for the jumphost to _your local admin account_,
-  because the ```${default_cloud_image_user}``` user will no longer be able to login to the jumphost.
+* Secondly, deploy the rest of the machines in the same order.  
+  For ```init.yml``` you must (temporarily) set ```JUMPHOST_USER``` for access to the jumphost to _your local admin account_,
+  because the ```${default_cloud_image_user}``` user will no longer be able to login to the jumphost:
   ```bash
-  export JUMPHOST_USER='your_admin_account' # Requires SSH client config as per end user documentation: see above.
-  ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "${default_cloud_image_user}" -l '!jumphost' single_role_playbooks/ssh_host_signer.yml
-  ansible-playbook -u "${default_cloud_image_user}" -l '!jumphost,!docs' single_role_playbooks/admin_users.yml
-  ansible-playbook -u root                          -l 'docs'            single_role_playbooks/admin_users.yml
+  export JUMPHOST_USER="${lor_admin_user}" # Requires SSH client config as per end user documentation: see above.
+  ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u "${default_cloud_image_user}" -l '!jumphost' single_group_playbooks/init.yml
   unset JUMPHOST_USER
   ansible-playbook -u "${lor_admin_user}" -l '!jumphost' cluster.yml
   ```

--- a/group_vars/docs.yml
+++ b/group_vars/docs.yml
@@ -1,5 +1,8 @@
 ---
 os_distribution: 'centos7'
+# This is enforcing that docs server uses `yum_repos` to create
+# yum repositories, since docs servers do not use Pulp.
+repo_manager: 'none'
 #
 # Firewall configuration.
 #

--- a/roles/static_hostname_lookup/templates/hosts.j2
+++ b/roles/static_hostname_lookup/templates/hosts.j2
@@ -17,10 +17,10 @@
 # Stack {{ stack_name }} hosts.
 #
 {% set this_host_network_names = host_networks
+    | default([])
     | map(attribute='name')
     | flatten
-    | unique
-    | default([]) %}
+    | unique %}
 {% for other_host in groups['all'] %}
   {% if hostvars[other_host]['host_networks'] is defined %}
     {% set other_host_network_names = hostvars[other_host]['host_networks']

--- a/single_group_playbooks/build_server.yml
+++ b/single_group_playbooks/build_server.yml
@@ -2,15 +2,15 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for build servers. <-==###'
   hosts:
     - build_server
   roles:
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
-    - yum_repos
     - locale
     - logrotate
     - remove

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -9,8 +9,8 @@
   hosts:
     - cluster
   roles:
-   - role: yum_local
-     when: local_yum_repository is defined
+    - role: yum_local
+      when: local_yum_repository is defined
     #
     # ToDo: Management of network interfaces changed in Rocky 9,
     # which uses NetworkManager and a different way of device naming.

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -2,13 +2,15 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Basic roles for all cluster machines part 1. <-==###'
   hosts:
     - cluster
   roles:
-    - static_hostname_lookup
-    - admin_users
-    - ssh_host_signer
+   - role: yum_local
+     when: local_yum_repository is defined
     #
     # ToDo: Management of network interfaces changed in Rocky 9,
     # which uses NetworkManager and a different way of device naming.
@@ -22,12 +24,6 @@
     - ssh  # client
     - grub
     - swap
-    - role: pulp_client
-      when: repo_manager == 'pulp'
-    - role: yum_repos
-      when: repo_manager == 'none'
-    - role: yum_local
-      when: local_yum_repository is defined
     - locale
     - logrotate
     - remove
@@ -42,7 +38,7 @@
     - cluster
     - role: logs_client
       when: logs_class is defined
-    - gpu            # needs to run after role 'cluster'
+    - gpu  # Needs to run after 'cluster' role.
     - resolver
     - coredumps
 ...

--- a/single_group_playbooks/data_transfer.yml
+++ b/single_group_playbooks/data_transfer.yml
@@ -2,15 +2,15 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for data transfer servers. <-==###'
   hosts:
     - data_transfer
   roles:
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
-    - yum_repos
     - locale
     - logrotate
     - remove

--- a/single_group_playbooks/docs.yml
+++ b/single_group_playbooks/docs.yml
@@ -2,15 +2,15 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for documentation servers. <-==###'
   hosts:
     - docs
   roles:
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
-    - yum_repos
     - locale
     - logrotate
     - remove

--- a/single_group_playbooks/init.yml
+++ b/single_group_playbooks/init.yml
@@ -1,0 +1,26 @@
+---
+- name: Initialization roles for most hosts.
+  hosts:
+    - jumphost
+    - repo
+    - cluster
+    - irods
+    - ldap_server
+  roles:
+    - role: static_hostname_lookup
+
+- name: Initialization roles for most hosts.
+  hosts: all,!openstack_api,!chaperone
+  roles:
+    - ssh_host_signer
+    #
+    # Either pulp_client or yum_repos must be deployed first
+    # before any other role that installs/updates RPMs.
+    # Note: Static host names in /etc/hosts are required for Pulp clients to resolve the Pulp server.
+    #
+    - role: pulp_client
+      when: repo_manager == 'pulp'
+    - role: yum_repos
+      when: repo_manager == 'none'
+    - admin_users
+...

--- a/single_group_playbooks/irods.yml
+++ b/single_group_playbooks/irods.yml
@@ -2,16 +2,15 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: 'Satisfy dependencies and install iCAT'
   hosts: irods
   roles:
-    - static_hostname_lookup
-    - admin_users
-    - ssh_host_signer
     - iptables
     - ssh  # client
     - grub
-    - pulp_client
     - locale
     - logrotate
     - logins

--- a/single_group_playbooks/jenkins.yml
+++ b/single_group_playbooks/jenkins.yml
@@ -2,12 +2,13 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for Jenkins servers. <-==###'
   hosts:
     - jenkins
   roles:
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
     - locale

--- a/single_group_playbooks/jumphost.yml
+++ b/single_group_playbooks/jumphost.yml
@@ -2,18 +2,18 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for jumphosts. <-==###'
   hosts:
     - jumphost
   roles:
-    - static_hostname_lookup
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
     - ssh  # client
-    - {role: yum_local, when: local_yum_repository is defined}
-    - {role: yum_repos, when: repo_manager == 'none'}
+    - role: yum_local
+      when: local_yum_repository is defined
     - locale
     - logrotate
     - remove

--- a/single_group_playbooks/logs.yml
+++ b/single_group_playbooks/logs.yml
@@ -2,18 +2,18 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
-- name: Configure syslog > servers <
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
+- name: '##==-> Configure syslog servers. <-==###'
   roles:
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
-    - yum_repos
     - locale
     - ssh  # client
     - update
-    - {role: yum_local, when: local_yum_repository is defined}
-    - {role: yum_repos, when: repo_manager == 'none'}
+    - role: yum_local
+      when: local_yum_repository is defined
     - logrotate
     - sshd
     - basic_security

--- a/single_group_playbooks/repo.yml
+++ b/single_group_playbooks/repo.yml
@@ -2,17 +2,16 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for repo management servers. <-==###'
   hosts: repo
   roles:
-    - static_hostname_lookup
-    - admin_users
-    - ssh_host_signer
     - iptables
     - ssh  # client
     - grub
     - swap
-    - {role: yum_repos, when: repo_manager == 'none'}
     - locale
     - logrotate
     - logins

--- a/single_group_playbooks/standalone_ldap_server.yml
+++ b/single_group_playbooks/standalone_ldap_server.yml
@@ -2,17 +2,16 @@
 - name: Import pre deploy checks.
   ansible.builtin.import_playbook: pre_deploy_checks.yml
 
+- name: Import initialization playbook for all hosts.
+  ansible.builtin.import_playbook: init.yml
+
 - name: '###==-> Roles for standalone LDAP servers. <-==###'
   hosts:
     - ldap_server
   roles:
-    - static_hostname_lookup
-    - admin_users
-    - ssh_host_signer
     - iptables
     - grub
     - ssh             # client
-    - {role: yum_repos, when: repo_manager == 'none'}
     - locale
     - logrotate
     - remove

--- a/single_role_playbooks/static_hostname_lookup.yml
+++ b/single_role_playbooks/static_hostname_lookup.yml
@@ -7,6 +7,8 @@
 - hosts:
     - repo
     - cluster
+    - irods
+    - ldap_server
   roles:
     - static_hostname_lookup
 ...


### PR DESCRIPTION
Added new `init.yml` play
 * Simplifies initialization of new machines.
 * In addition re-ordered several roles, to prevent issues due to installation of RPMs before the `pulp_client` is deployed, which causes these RPMs to be missing from the Pulp cache. This is no problem as long as the upstream remotes have not yet been updated to a new minor version. But when the remotes have been updated the RPM (version) will be missing from the remote and hence has to be in the Pulp cache for successful redeployment.