### PR TITLE
WingedHelix updates and some bug fixes.

### DIFF
--- a/group_vars/compute_node.yml
+++ b/group_vars/compute_node.yml
@@ -5,6 +5,11 @@ volumes:
     mounted_owner: root
     mounted_group: root
     mounted_mode: '0755'
-    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
+    mount_options: >-
+      rw,relatime
+      {%- if ansible_facts['os_family'] == 'RedHat' and
+             ansible_facts['distribution_major_version'] >= '8' -%}
+        ,nofail,x-systemd.device-timeout=10
+      {%- endif -%}
     type: ext4
 ...

--- a/group_vars/compute_node.yml
+++ b/group_vars/compute_node.yml
@@ -5,6 +5,6 @@ volumes:
     mounted_owner: root
     mounted_group: root
     mounted_mode: '0755'
-    mount_options: 'rw,relatime'
+    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
     type: ext4
 ...

--- a/group_vars/data_transfer.yml
+++ b/group_vars/data_transfer.yml
@@ -30,6 +30,6 @@ volumes:
     mounted_owner: root
     mounted_group: root
     mounted_mode: '0755'
-    mount_options: 'rw,relatime'
+    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
     type: ext4
 ...

--- a/group_vars/data_transfer.yml
+++ b/group_vars/data_transfer.yml
@@ -30,6 +30,11 @@ volumes:
     mounted_owner: root
     mounted_group: root
     mounted_mode: '0755'
-    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
+    mount_options: >-
+      rw,relatime
+      {%- if ansible_facts['os_family'] == 'RedHat' and
+             ansible_facts['distribution_major_version'] >= '8' -%}
+        ,nofail,x-systemd.device-timeout=10
+      {%- endif -%}
     type: ext4
 ...

--- a/group_vars/deploy_admin_interface.yml
+++ b/group_vars/deploy_admin_interface.yml
@@ -5,6 +5,11 @@ volumes:
     mounted_owner: root
     mounted_group: "{{ envsync_group }}"
     mounted_mode: '2775'
-    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
+    mount_options: >-
+      rw,relatime
+      {%- if ansible_facts['os_family'] == 'RedHat' and
+             ansible_facts['distribution_major_version'] >= '8' -%}
+        ,nofail,x-systemd.device-timeout=10
+      {%- endif -%}
     type: ext4
 ...

--- a/group_vars/deploy_admin_interface.yml
+++ b/group_vars/deploy_admin_interface.yml
@@ -5,6 +5,6 @@ volumes:
     mounted_owner: root
     mounted_group: "{{ envsync_group }}"
     mounted_mode: '2775'
-    mount_options: 'rw,relatime'
+    mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
     type: ext4
 ...

--- a/group_vars/vaxtron_cluster/ip_addresses.yml
+++ b/group_vars/vaxtron_cluster/ip_addresses.yml
@@ -53,7 +53,7 @@ ip_addresses:
     DH4 Lustre:
       address: 172.23.58.40
       netmask: /32
-   lustre:
+    lustre:
      address: 172.23.12.50
      netmask: /32
     vt_internal_management:
@@ -63,7 +63,7 @@ ip_addresses:
     DH4 Lustre:
       address: 172.23.58.87
       netmask: /32
-   lustre:
+    lustre:
      address: 172.23.12.51
      netmask: /32
     vt_internal_management:

--- a/group_vars/wingedhelix_cluster/ip_addresses.yml
+++ b/group_vars/wingedhelix_cluster/ip_addresses.yml
@@ -30,6 +30,16 @@ ip_addresses:
     wh_internal_storage:
       address: 10.10.2.73
       netmask: /32
+  wh-node-b01:
+    vlan1068:
+      address: 172.23.60.2
+      netmask: /32
+    wh_internal_management:
+      address: 10.10.1.168
+      netmask: /32
+    wh_internal_storage:
+      address: 10.10.2.127
+      netmask: /32
   wh-porch:
     wh_internal_management:
       address: 10.10.1.148

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -14,6 +14,15 @@ slurm_partitions:
     local_disk: "{{ groups['regular'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
     features: "{{ groups['regular'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
+  - name: regular_big_vm  # Must be in sync with group listed in Ansible inventory.
+    default: no
+    nodes: "{{ stack_prefix }}-node-b01"  # Must be in sync with Ansible hostnames listed in inventory.
+    max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['regular_big_vm']|list|length }}{% else %}1{% endif %}"
+    max_cores_per_node: "{{ groups['regular_big_vm'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
+    max_mem_per_node: "{{ groups['regular_big_vm'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
+    local_disk: "{{ groups['regular_big_vm'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
+    features: "{{ groups['regular_big_vm'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
+    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
   - name: user_interface  # Must be in sync with group listed in Ansible inventory.
     default: no
     nodes: "{{ slurm_cluster_name }}"  # Must be in sync with Ansible hostnames listed in inventory.

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -5,17 +5,8 @@ stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name
 stack_prefix: 'wh'
 slurm_version: '23.02.7-2.el9.umcg'
 slurm_partitions:
-  - name: regular  # Must be in sync with group listed in Ansible inventory.
-    default: yes
-    nodes: "{{ stack_prefix }}-node-a[01-02]"  # Must be in sync with Ansible hostnames listed in inventory.
-    max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['regular']|list|length }}{% else %}1{% endif %}"
-    max_cores_per_node: "{{ groups['regular'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
-    max_mem_per_node: "{{ groups['regular'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
-    local_disk: "{{ groups['regular'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
-    features: "{{ groups['regular'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
-    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
   - name: regular_big_vm  # Must be in sync with group listed in Ansible inventory.
-    default: no
+    default: yes
     nodes: "{{ stack_prefix }}-node-b01"  # Must be in sync with Ansible hostnames listed in inventory.
     max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['regular_big_vm']|list|length }}{% else %}1{% endif %}"
     max_cores_per_node: "{{ groups['regular_big_vm'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
@@ -450,8 +441,8 @@ pfs_mounts:
   - pfs: umcgst04/slice1
     source: '172.23.60.161@tcp20:172.23.60.162@tcp20:/'
     type: lustre
-    rw_options: 'defaults,_netdev,flock'
-    ro_options: 'defaults,_netdev,ro'
+    rw_options: 'defaults,_netdev,flock,noverbose,noencrypt'
+    ro_options: 'defaults,_netdev,ro,noverbose,noencrypt'
     machines: "{{ groups['sys_admin_interface'] }}"
   - pfs: 'medgen_zincfinger$'
     source: '//storage5.umcg.nl'

--- a/roles/mount_volume/defaults/main.yml
+++ b/roles/mount_volume/defaults/main.yml
@@ -8,7 +8,12 @@
 #     mounted_owner: root
 #     mounted_group: root
 #     mounted_mode: '0755'
-#     mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
+#     mount_options: >-
+#       rw,relatime
+#       {%- if ansible_facts['os_family'] == 'RedHat' and
+#              ansible_facts['distribution_major_version'] >= '8' -%}
+#         ,nofail,x-systemd.device-timeout=10
+#       {%- endif -%}
 #     type: ext4
 # ...
 #

--- a/roles/mount_volume/defaults/main.yml
+++ b/roles/mount_volume/defaults/main.yml
@@ -8,7 +8,7 @@
 #     mounted_owner: root
 #     mounted_group: root
 #     mounted_mode: '0755'
-#     mount_options: 'rw,relatime'
+#     mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
 #     type: ext4
 # ...
 #

--- a/roles/pulp_client/tasks/main.yml
+++ b/roles/pulp_client/tasks/main.yml
@@ -13,7 +13,12 @@
     baseurl: "{{ pulp_server_url }}"
     gpgcheck: false
   vars:
-    pulp_server_url: "https://{{ groups['repo'] | first }}/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/{{ item.name }}/"
+    pulp_server_url: >-
+        {%- if repo_manager == 'pulp' -%}
+          https://{{ groups['repo'] | first }}/pulp/content/{{ stack_name | regex_replace('_cluster$', '') }}/{{ item.name }}/
+        {%- else -%}
+          none
+        {%- endif -%}"
   loop: "{{ pulp_repos[os_distribution] | flatten(levels=1) }}"
   loop_control:
     label: "name: {{ item.name }} | desc: {{ item.description }} | url: {{ pulp_server_url }}"

--- a/single_group_playbooks/pre_deploy_checks.yml
+++ b/single_group_playbooks/pre_deploy_checks.yml
@@ -95,6 +95,41 @@
       run_once: true  # noqa run-once
       delegate_to: localhost
       connection: local
+    #
+    # Workaround for bugs related to ansible_remote_tmp dir handling by Mitogen.
+    # See https://github.com/mitogen-hq/mitogen/issues/632
+    # Will patch ..../ansible_mitogen//target.py if Mitogen was installed.
+    #
+    - name: 'Find the path to target.py'
+      ansible.builtin.find:
+        path: "{{ lookup('ansible.builtin.env', 'VIRTUAL_ENV') }}"
+        pattern: 'target.py'
+        recurse: true
+      register: find_target_py_result
+      run_once: true  # noqa run-once
+      delegate_to: localhost
+      connection: local
+    - name: "Report the found path to Mitogen's target.py."
+      ansible.builtin.debug:
+        msg: "INFO: Found {{ item }}"
+      run_once: true  # noqa run-once
+      delegate_to: localhost
+      connection: local
+      loop: "{{ find_target_py_result.files | map(attribute='path') | list }}"
+      when: find_target_py_result.files | map(attribute='path') | first is defined
+    - name: 'Patch Mitogen to disable noexec check for file system hosting ansible_remote_tmp.'
+      ansible.builtin.replace:
+        dest: "{{ item }}"
+        #             if not os.access(tmp.name, os.X_OK):
+        regexp: '^(\s*)if not os\.access\(tmp\.name, os\.X_OK\):$'
+        replace: '\1if False:'
+        after: 'def\s+is_good_temp_dir'
+        backup: true
+      run_once: true  # noqa run-once
+      delegate_to: localhost
+      connection: local
+      loop: "{{ find_target_py_result.files | map(attribute='path') | list }}"
+      when: find_target_py_result.files | map(attribute='path') | first is defined
     - name: "Find all ip_addresses.yml files in {{ playbook_dir }}/group_vars/*."
       ansible.builtin.find:
         paths: "{{ playbook_dir }}/group_vars/"

--- a/single_role_playbooks/nfs_client.yml
+++ b/single_role_playbooks/nfs_client.yml
@@ -1,0 +1,5 @@
+---
+- hosts: cluster
+  roles:
+    - nfs_client
+...

--- a/static_inventories/vaxtron_cluster.yml
+++ b/static_inventories/vaxtron_cluster.yml
@@ -103,7 +103,7 @@ all:
                   mounted_owner: root
                   mounted_group: root
                   mounted_mode: '0755'
-                  mount_options: 'rw,relatime'
+                  mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
                   type: ext4
               local_volume_size_extra: 0  # No extra virtual disk present on bare metal nodes.
               slurm_sockets: 2

--- a/static_inventories/vaxtron_cluster.yml
+++ b/static_inventories/vaxtron_cluster.yml
@@ -103,7 +103,12 @@ all:
                   mounted_owner: root
                   mounted_group: root
                   mounted_mode: '0755'
-                  mount_options: "rw,relatime{% if ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' %},nofail,x-systemd.device-timeout=10{% endif %}"
+                  mount_options: >-
+                    rw,relatime
+                    {%- if ansible_facts['os_family'] == 'RedHat' and
+                           ansible_facts['distribution_major_version'] >= '8' -%}
+                      ,nofail,x-systemd.device-timeout=10
+                    {%- endif -%}
                   type: ext4
               local_volume_size_extra: 0  # No extra virtual disk present on bare metal nodes.
               slurm_sockets: 2

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -143,31 +143,6 @@ all:
             - ens5
     compute_node:
       children:
-        regular:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
-          hosts:
-            wh-node-a[01:02]:
-          vars:
-            cloud_flavor: htc-node
-            host_networks:
-              - name: "{{ stack_prefix }}_internal_management"
-                security_group: "{{ stack_prefix }}_cluster"
-              - name: "{{ stack_prefix }}_internal_storage"
-                security_group: "{{ stack_prefix }}_storage"
-              - name: vlan1068
-                security_group: "{{ stack_prefix }}_storage"
-            # htc-node flavor already includes an extra 200 GB ephemeral disk.
-            # local_volume_size_extra: disabled
-            slurm_sockets: 40
-            slurm_cores_per_socket: 1
-            slurm_real_memory: 180604
-            slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
-            slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
-            slurm_local_disk: 190000
-            slurm_features: 'tmp07'
-            slurm_ethernet_interfaces:
-              - ens3
-              - ens4
-              - ens5
         regular_big_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             wh-node-b01:
@@ -183,10 +158,10 @@ all:
             local_volume_size_extra: 1
             slurm_sockets: 63
             slurm_cores_per_socket: 1
-            slurm_real_memory: 500000
+            slurm_real_memory: 491355
             slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
             slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
-            slurm_local_disk: 975
+            slurm_local_disk: 900
             slurm_features: 'tmp07'
             slurm_ethernet_interfaces:
               - ens3

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -168,6 +168,30 @@ all:
               - ens3
               - ens4
               - ens5
+        regular_big_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
+          hosts:
+            wh-node-b01:
+          vars:
+            cloud_flavor: umcg.v1.vm.63-500
+            host_networks:
+              - name: "{{ stack_prefix }}_internal_management"
+                security_group: "{{ stack_prefix }}_cluster"
+              - name: "{{ stack_prefix }}_internal_storage"
+                security_group: "{{ stack_prefix }}_storage"
+              - name: vlan1068
+                security_group: "{{ stack_prefix }}_storage"
+            local_volume_size_extra: 1
+            slurm_sockets: 63
+            slurm_cores_per_socket: 1
+            slurm_real_memory: 500000
+            slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
+            slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
+            slurm_local_disk: 975
+            slurm_features: 'tmp07'
+            slurm_ethernet_interfaces:
+              - ens3
+              - ens4
+              - ens5
     chaperone:
       hosts:
         wh-chaperone:


### PR DESCRIPTION
* Added new type of compute node based on new flavor `umcg.v1.vm.63-500`.
* Removed old compute nodes.
* Bugfixes:
   * Make sure plays do not trip over undefined variables when the `pulp_client` role is skipped.
   * Added mount options to prevent system from getting stuck on reboot due to missing file system.
   * Added missing `single_role_playbooks/nfs_client.yml`.
   * Added patch for ansible_remote_tmp dir handling issue when Mitogen is installed.