### PR TITLE
ogm: redirect manage backup script output to journal

### DIFF
--- a/roles/ogm/templates/ogm_cron_clean_psql_backups.sh.j2
+++ b/roles/ogm/templates/ogm_cron_clean_psql_backups.sh.j2
@@ -35,8 +35,8 @@ cd "${PSQL_DUMP_LOCATION:-does_not_exists}" || { echo "Failed to change director
 if ! ls ${PSQL_DUMP_LOCATION}/*-weekly-$(date +%Y%U).sql.gz 1>/dev/null 2>&1; then
    # Make a copy of the latest backup as a weekly backup
    LATEST=$(ls -1 ${PSQL_DUMP_LOCATION}/*.sql.gz | tail -n 1)
-   echo "Making WEEKLY backup: $(date +%Y%m%d-%H%M%S)-weekly-$(date +%Y%U).sql.gz"
-   cp "${LATEST}" "${PSQL_DUMP_LOCATION}/$(date +%Y%m%d-%H%M%S)-weekly-$(date +%Y%U).sql.gz"
+   logger -t ogm_backup "${0}: Making WEEKLY backup: $(date +%Y%m%d-%H%M%S)-weekly-$(date +%Y%U).sql.gz"
+   cp -l "${LATEST}" "${PSQL_DUMP_LOCATION}/$(date +%Y%m%d-%H%M%S)-weekly-$(date +%Y%U).sql.gz"
 fi
 
 ## CLEANING up DAILY backups
@@ -46,7 +46,7 @@ DAILY_COUNT="$(ls -1 *.sql.gz | grep -v weekly | wc -l)"
 if [[ "${DAILY_COUNT}" -gt "${DAILY_KEEP}" ]]; then
   DELETE_DAILY_COUNT=$((DAILY_COUNT - DAILY_KEEP))
   # find the oldest files and delete them (not weekly)
-  echo -e "Deleted DAILY backups:\n$(ls -1 *.sql.gz | grep -v weekly | head -n "${DELETE_DAILY_COUNT}" | sed 's/^/  - /')"
+  logger -t ogm_backup "${0}: $(echo -e "Deleted DAILY backups:\n$(ls -1 *.sql.gz | grep -v weekly | head -n "${DELETE_DAILY_COUNT}" | sed 's/^/  - /')")"
   ls -1 *.sql.gz | grep -v weekly | head -n "${DELETE_DAILY_COUNT}" | xargs rm -f
 fi
 
@@ -56,7 +56,7 @@ WEEKLY_COUNT="$(ls -1 *-weekly-*.sql.gz | wc -l)"
 if [[ "${WEEKLY_COUNT}" -gt "${WEEKLY_KEEP}" ]]; then
   DELETE_WEEKLY_COUNT=$((WEEKLY_COUNT - WEEKLY_KEEP))
   # find the oldest weekly backups and delete them
-  echo -e "Deleted WEEKLY backups:\n$(ls -1 *-weekly-*.sql.gz | head -n "${DELETE_WEEKLY_COUNT}" | sed 's/^/  - /')"
+  logger -t ogm_backup "${0}: $(echo -e "Deleted WEEKLY backups:\n$(ls -1 *-weekly-*.sql.gz | head -n "${DELETE_WEEKLY_COUNT}" | sed 's/^/  - /')")"
   ls -1 *-weekly-*.sql.gz | head -n "${DELETE_WEEKLY_COUNT}" | xargs rm -f
 fi
 


### PR DESCRIPTION
Tiny update:
 - forgot to redirect the output back to journal on script for managing logs, fixed now.
 - test deployed - done

Improvement: using hardlink for copy.