### PR TITLE
data transfer: fixed missing repo variable

### DIFF
--- a/group_vars/data_transfer.yml
+++ b/group_vars/data_transfer.yml
@@ -1,4 +1,5 @@
 ---
+repo_manager: 'none'
 iptables_allow_icmp_inbound:
   - ANY
 iptables_allow_https_inbound:


### PR DESCRIPTION
Some data transfer servers had wrong repo setting as they got configured to be using `pulp` (it comes from group vars), but actually they should use the external repositories, to continuously deploy updates.