### PR TITLE
Flush handlers at the end of the lustre_client role.

### DIFF
--- a/roles/lustre_client/tasks/install.yml
+++ b/roles/lustre_client/tasks/install.yml
@@ -230,4 +230,7 @@
     state: started
     daemon_reload: true
   become: true
+
+- name: Flush handlers for Lustre client.
+  ansible.builtin.meta: flush_handlers
 ...


### PR DESCRIPTION
Bugfix: Flush handlers at the end of the `lustre_client` role to make sure machine is rebooted of necessary and `lnet` is restarted with updated settings.