### PR TITLE
Update for interfaces role.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             python -m venv openstacksdk-${openstacksdk_major_version:-1}.venv
             source openstacksdk-${openstacksdk_major_version:-1}.venv/bin/activate
             export ANSIBLE_ROLES_PATH="${VIRTUAL_ENV}/ansible/ansible_roles/:"
-            export ANSIBLE_COLLECTIONS_PATHS="${VIRTUAL_ENV}/ansible/:"
+            export ANSIBLE_COLLECTIONS_PATH="${VIRTUAL_ENV}/ansible/:"
             pip install jmespath
             pip install ansible
             pip install ansible-lint
@@ -45,7 +45,7 @@ jobs:
             set -o pipefail
             source openstacksdk-${openstacksdk_major_version:-1}.venv/bin/activate
             export ANSIBLE_ROLES_PATH="${VIRTUAL_ENV}/ansible/ansible_roles/:"
-            export ANSIBLE_COLLECTIONS_PATHS="${VIRTUAL_ENV}/ansible/:"
+            export ANSIBLE_COLLECTIONS_PATH="${VIRTUAL_ENV}/ansible/:"
             if ansible-lint -p --nocolor --offline *.yml > lint_results 2>&1; then
               lint_errors=0
             else

--- a/roles/interfaces/README.md
+++ b/roles/interfaces/README.md
@@ -1,0 +1,76 @@
+# Network interfaces
+
+### Commands and config files for Debugging
+
+```
+#
+# Track what udev does
+#
+sudo udevadm test /sys/class/net/[current_interface_name]
+
+#
+# Order of naming schemes used by udev
+#
+/usr/lib/systemd/network/99-default.link
+#
+# Slot-based naming scheme has priority over path-based naming scheme,
+# but is not stable: was introduced later and the removed again for virtual network interfaces,
+# because it can cause naming conflicts.
+# To rename an interface based on slot into one based on path, we must:
+#  * 
+#
+# Create override in /etc/systemd/network/99-default.link
+#
+mkdir -m 755 /etc/systemd/network
+cp /usr/lib/systemd/network/99-default.link /etc/systemd/network/99-default.link
+#
+# and change:
+#
+#NamePolicy=keep kernel database onboard slot path
+#AlternativeNamesPolicy=database onboard slot path
+NamePolicy=kernel database onboard path slot
+AlternativeNamesPolicy=database onboard path slot
+#
+# Also delete /etc/udev/rules.d/70-persistent-net.rules, which will contain the outdated info
+#
+rm /etc/udev/rules.d/70-persistent-net.rules
+#
+# reboot
+#
+shutdown -r now
+#
+# When the renaming worked you can no longer login:
+# Need to update the name of the internal network interface in /etc/sysconfig/iptables-init.bash too!
+#
+
+#
+# Note: You have to update-initramfs -u for these changes to take effect during early boot.
+# This copies the /etc/systemd/network/99-default.link file you created into the initramfs 
+# to be around at early system boot when udev needs it.
+#
+# Make backup
+#
+cp /boot/initramfs-$(uname -r).img /boot/initramfs-$(uname -r)-$(date +%Y-%m-%d-%H%M%S).img
+#
+# Regenerate initramfs
+#
+dracut -f /boot/initramfs-$(uname -r).img $(uname -r)
+#
+# lsinitrd show this does not work, the override file is ignored.
+#
+lsinitrd /boot/initramfs-5.14.0-427.31.1.el9_4.x86_64.img | fgrep 99-default.link
+-rw-r--r--   1 root     root          763 Apr  8 01:06 usr/lib/systemd/network/99-default.link
+
+
+
+
+#
+# Change device name for first network connection: 'ens3' in this case.
+# See https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/configuring_and_managing_networking/index#configuring-user-defined-network-interface-names-by-using-udev-rules_consistent-network-interface-device-naming
+#
+nmcli connection modify 'System ens3' connection.interface-name ""
+nmcli connection modify 'System ens3' match.interface-name "enp0s3 ens3"
+shutdown -r now
+nmcli connection modify 'System ens3' match.interface-name "enp0s3"
+nmcli connection up 'System ens3'
+```

--- a/roles/interfaces/tasks/el7.yml
+++ b/roles/interfaces/tasks/el7.yml
@@ -1,0 +1,18 @@
+---
+- name: Create network device configuration file based on template.
+  ansible.builtin.template:
+    src: interface_template.j2
+    dest: "/etc/sysconfig/network-scripts/{{ network_device_file_prefix }}{{ item.device }}"
+    mode: '0644'
+  become: true
+  loop: "{{ interfaces }}"
+  when: interfaces is defined
+  notify: restart_network
+
+- name: Enable network.service at boot.
+  ansible.builtin.systemd:
+    name: network.service
+    enabled: true
+    state: started
+  become: true
+...

--- a/roles/interfaces/tasks/el8.yml
+++ b/roles/interfaces/tasks/el8.yml
@@ -1,0 +1,39 @@
+---
+- name: Create /etc/systemd/network directory.
+  ansible.builtin.file:
+    path: /etc/systemd/network
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+#
+# Slot-based naming scheme has priority over path-based naming scheme,
+# but is not stable: was introduced later and the removed again for virtual network interfaces,
+# because it can cause naming conflicts.
+#
+- name: Deploy /etc/systemd/network/99-default.link for customised udev network device renaming policy ordering.
+  ansible.builtin.template:
+    src: 99-default.link 
+    dest: /etc/systemd/network/99-default.link 
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  become: true
+
+#
+# Network Manager is a mess and not idempotent in most cases creating yet another config.
+#
+# - name: Create network connection with nmcli.
+#   community.general.nmcli:
+#     conn_name: "{{ item['device'] }}"
+#     ifname: "{{ item['device'] }}"
+#     type: ethernet
+#     method4: "{{ item['method4'] }}"
+#     method6: disabled
+#     state: present
+#     autoconnect: true
+#   loop: "{{ interfaces }}"
+#   become: true
+...

--- a/roles/interfaces/tasks/el8.yml
+++ b/roles/interfaces/tasks/el8.yml
@@ -15,8 +15,8 @@
 #
 - name: Deploy /etc/systemd/network/99-default.link for customised udev network device renaming policy ordering.
   ansible.builtin.template:
-    src: 99-default.link 
-    dest: /etc/systemd/network/99-default.link 
+    src: 99-default.link
+    dest: /etc/systemd/network/99-default.link
     owner: 'root'
     group: 'root'
     mode: '0644'

--- a/roles/interfaces/tasks/main.yml
+++ b/roles/interfaces/tasks/main.yml
@@ -1,17 +1,14 @@
 ---
-- name: Create network device configuration file based on template.
-  ansible.builtin.template:
-    src: interface_template.j2
-    dest: "/etc/sysconfig/network-scripts/{{ network_device_file_prefix }}{{ item.device }}"
-    mode: '0644'
-  become: true
-  with_items: "{{ interfaces }}"
-  when: interfaces is defined
-  notify: restart_network
+- name: 'Manage network interfaces on EL <= 7'
+  ansible.builtin.import_tasks:
+    file: el7.yml
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] <= "7"
 
-- name: Enable network.service at boot.
-  ansible.builtin.systemd:
-    name: network.service
-    enabled: true
-    state: started
-  become: true
+- name: 'Manage network connections and devices on EL >= 8'
+  ansible.builtin.import_tasks:
+    file: el8.yml
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] >= "8"

--- a/roles/interfaces/templates/99-default.link
+++ b/roles/interfaces/templates/99-default.link
@@ -1,0 +1,15 @@
+#
+# This file was deployed with the Ansible interfaces role from the league-of-robots repo
+# and overrides the default from /usr/lib/systemd/network/99-default.link
+# to prefer path-based interface naming over slot-based naming.
+# Slot-based naming is unstable as it initially was not implemented yet, added later
+# and then removed again for virtual interfaces, because it can cause naming conflicts.
+#
+
+[Match]
+OriginalName=*
+
+[Link]
+NamePolicy=keep kernel database onboard path slot
+AlternativeNamesPolicy=database onboard path slot
+MACAddressPolicy=none

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -14,12 +14,12 @@
     #
     # ToDo: Management of network interfaces changed in EL >= 8,
     # which uses NetworkManager and a different way of device naming.
-    # This role needs an update...
+    # This role will only modify generic settings for all interfaces on EL >= 8,
+    # but needs an update to manage specific interfaces...
     #
     - role: interfaces
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['distribution_major_version'] <= "7"
     - iptables
     - ssh  # client
     - grub

--- a/single_role_playbooks/interfaces.yml
+++ b/single_role_playbooks/interfaces.yml
@@ -4,10 +4,10 @@
     #
     # ToDo: Management of network interfaces changed in EL >= 8,
     # which uses NetworkManager and a different way of device naming.
-    # This role needs an update...
+    # This role will only modify generic settings for all interfaces on EL >= 8,
+    # but needs an update to manage specific interfaces...
     #
     - role: interfaces
       when:
         - ansible_facts['os_family'] == "RedHat"
-        - ansible_facts['distribution_major_version'] <= "7"
 ...


### PR DESCRIPTION
Management of network interfaces changed in EL >= 8,
which uses _NetworkManager_ and a different way of device naming.
This role was updated to modify some generic settings for all network interfaces on EL >= 8,
but needs additional, future updates to manage specific interfaces...