### PR TITLE
ldap_backup v2

### DIFF
--- a/roles/sssd/tasks/main.yml
+++ b/roles/sssd/tasks/main.yml
@@ -154,7 +154,6 @@
   when:
     - ldap_domains is defined
     - ldap_domains | length > 0
-    - create_ldap is false
     - inventory_hostname in groups['sys_admin_interface'] | default([])
 
 - name: Flush handlers.

--- a/roles/sssd/templates/ldap_backup.sh.j2
+++ b/roles/sssd/templates/ldap_backup.sh.j2
@@ -9,27 +9,23 @@ if ! test -e "${_ldap_credentials}"; then
 fi
 source "${_ldap_credentials}"
 
-_ldap_dest="/root/ldap_backup"
-cd "${_ldap_dest}"
+_ldap_root="/root/ldap_backup"
+cd "${_ldap_root}"
 
 for _each_ldap in "${domain_names[@]}"; do
-   test -e "${_ldap_dest}/${_each_ldap}" || mkdir -p -m 700 "${_ldap_dest}/${_each_ldap}"
-   for _scope in person group; do
-      _scope_destination="${_ldap_dest}/${_each_ldap}/${_scope}"
-      test -e "${_scope_destination}" || mkdir "${_scope_destination}"
-      cd "${_scope_destination}" || { logger -t ldap_backup "${0}: Error, problem with changing dir to ${_scope_destination}"; exit 1; }
-      logger -t ldap_backup "$0: running backup for ${_each_ldap} / ${_scope}"
-      /usr/bin/ldapsearch -H "${domain_configs[${_each_ldap}'_uri']}" -D"${domain_configs[${_each_ldap}'_bind_dn']}" -b"${domain_configs[${_each_ldap}'_search_base']}" -w"${domain_configs[${_each_ldap}'_bind_pw']}" "(objectClass=person)" -LLL | gzip > "${_scope_destination}/daily-$(date +%u).ldif.gz"
-
-      ## Check if this weeks backup has been made and if not, make it
-      if ! test -e "${_scope_destination}/weekly-$(date +%Y%U).ldif.gz"; then
-         # Make a copy of the _latest backup as a weekly backup
-         _latest=$(ls -1 "${_scope_destination}"/*.ldif.gz | tail -n 1)
-         logger -t ldap_backup "${0}: Making WEEKLY backup (weekly-$(date +%Y%U).ldif.gz) out of today's backup"
-         cp "${_scope_destination}/daily-$(date +%u).ldif.gz" "${_scope_destination}/weekly-$(date +%Y%U).ldif.gz"
-      fi
-
-      # Backup-compress all files that are not from this year
-      find . ! -path . ! -name "daily-*.ldif.gz" ! -name "weekly-$(date +%Y)*.ldif.gz" -exec tar --remove-files -czf ${_ldap_dest}/${_each_ldap}/backup-${_scope}-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8).tar.gz {} +
-   done
+   test -e "${_ldap_root}/${_each_ldap}" || mkdir -p -m 700 "${_ldap_root}/${_each_ldap}"
+   _destination="${_ldap_root}/${_each_ldap}"
+   test -e "${_destination}" || mkdir "${_destination}"
+   cd "${_destination}" || { logger -t ldap_backup "${0}: Error, problem with changing dir to ${_destination}"; exit 1; }
+   logger -t ldap_backup "$0: running backup for ${_each_ldap}"
+   /usr/bin/ldapsearch -H "${domain_configs[${_each_ldap}'_uri']}" -D"${domain_configs[${_each_ldap}'_bind_dn']}" -b"${domain_configs[${_each_ldap}'_search_base']}" -w"${domain_configs[${_each_ldap}'_bind_pw']}" -LLL | gzip > "${_destination}/daily-$(date +%u).ldif.gz"
+   ## Check if this weeks backup has been made and if not, make it
+   if ! test -e "${_destination}/weekly-$(date +%Y%U).ldif.gz"; then
+      # Make a copy of the _latest backup as a weekly backup
+      _latest=$(ls -1 "${_destination}"/*.ldif.gz | tail -n 1)
+      logger -t ldap_backup "${0}: Making WEEKLY backup (weekly-$(date +%Y%U).ldif.gz) out of today's backup"
+      cp "${_destination}/daily-$(date +%u).ldif.gz" "${_destination}/weekly-$(date +%Y%U).ldif.gz"
+   fi
+   # Backup-compress all files that are not from this year
+   find . ! -path . ! -name "daily-*.ldif.gz" ! -name "weekly-$(date +%Y)*.ldif.gz" -exec tar --remove-files -czf ${_ldap_root}/${_each_ldap}/backup-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8).tar.gz {} +
 done


### PR DESCRIPTION
1. Backup limitations
   - There was a restriction that backups were made only when `ldap_create` variable has been provided.
   - Since backups are so small, I see no reason not to make backups on any system that is using LDAP.
3. Backup content
   - So far the backups have specifically collected the subscope of LDAP of only groups and only users.
   -  I checked those results against full database backups and there were some ACL's missing.
   -  Now I have changed the backups to collect everything and not separating groups and users.
   -  This should provide the possibility of recreating the entire LDAP from one backup.