### PR TITLE
Bugfix to prevent false positive nhc_standalone warnings.

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -505,7 +505,7 @@ pfs_mounts:
 lfs_mounts:
   - lfs: home
     pfs: umcgst12
-    rw_machines: "{{ groups['cluster'] }}"
+    rw_machines: "{{ groups['cluster'] | difference(groups['nfs_server']) }}"
   - lfs: tmp07
     pfs: umcgst04/slice1
     groups:

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -208,7 +208,6 @@
   with_items: "{{ lfs_mounts | selectattr('lfs', 'search', 'home') | list }}"
   when:
     - inventory_hostname in item.rw_machines | default ([])
-    - not inventory_hostname in groups['nfs_server'] | default([])
   become: true
 
 - name: 'Mount "home" Logical File System (LFS) from shared storage read-only.'
@@ -222,7 +221,6 @@
   with_items: "{{ lfs_mounts | selectattr('lfs', 'search', 'home') | list }}"
   when:
     - inventory_hostname in item.ro_machines | default ([])
-    - not inventory_hostname in groups['nfs_server'] | default([])
   become: true
 
 - name: 'Create root /groups folder.'


### PR DESCRIPTION
Exclude `nfs_server` group from list of machines that should mount /home read-write (as opposed to excluding `nfs_server` group in `shared_storage` role) to have config in sync with `nhc_standalone` checks.