### PR TITLE
Improved handling of NFS shares.

### DIFF
--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -447,12 +447,11 @@ lustre_client_networks:
     interface: enp5s0
 pfs_mounts:
   - pfs: umcgst12
-    device: /dev/vdb
-    source: "{{ ip_addresses[groups['nfs_server'][0]][stack_prefix + '_internal_storage']['address'] }}:/mnt"
+    source: "{{ ip_addresses['wh-sai'][stack_prefix + '_internal_storage']['address'] }}:/mnt"
     type: nfs4    # checked with cat /proc/filesystem
     rw_options: 'defaults,_netdev,noatime,nodiratime,local_lock=flock'
     ro_options: 'defaults,_netdev,noatime,nodiratime,ro'
-    machines: "{{ groups['sys_admin_interface'] }}"
+    machines: []  # Complete PFS not mounted over NFS anywhere.
   - pfs: umcgst04/slice1
     source: '172.23.60.161@tcp20:172.23.60.162@tcp20:/'
     type: lustre

--- a/roles/local_storage/tasks/main.yml
+++ b/roles/local_storage/tasks/main.yml
@@ -1,19 +1,4 @@
 ---
-- name: Compile list of local file systems to mount for NFS servers.
-  ansible.builtin.set_fact:
-    local_mounts: "{{ local_mounts | default([]) + [local_mount] }}"
-  vars:
-    local_mount:
-      mount_point: "/mnt/{{ item['pfs'] }}"
-      device: "{{ item['device'] }}"
-      mounted_owner: root
-      mounted_group: root
-      mounted_mode: '0755'
-      mount_options: 'rw,relatime'
-      type: ext4
-  when: inventory_hostname in groups['nfs_server'] | default([])
-  with_items: "{{ pfs_mounts | selectattr('type', 'search', 'nfs') | selectattr('device', 'defined') | list }}"
-
 - name: Check if file system source is a device.
   ansible.builtin.stat:
     path: "{{ item.device }}"

--- a/roles/nfs_server/tasks/main.yml
+++ b/roles/nfs_server/tasks/main.yml
@@ -63,14 +63,8 @@
 - name: 'Add NFS share to /etc/exports.'
   ansible.builtin.lineinfile:
     path: /etc/exports
-    line: "/mnt/{{ item.pfs }} {{ stack_networks
-                                  | selectattr('name', 'equalto', stack_prefix + '_internal_storage')
-                                  | map(attribute='cidr')
-                                  | first }}(rw,sync,no_root_squash,no_subtree_check)"
-  with_items: "{{ pfs_mounts
-                  | selectattr('type', 'search', 'nfs')
-                  | selectattr('device', 'defined')
-                  | list }}"
+    line: "{{ item['path'] }} {{ item['clients'] }}"
+  loop: "{{ nfs_server_shares }}"
   notify:
     - export_nfs_shares
   become: true

--- a/roles/nhc_standalone/templates/nhc_standalone.conf
+++ b/roles/nhc_standalone/templates/nhc_standalone.conf
@@ -88,6 +88,23 @@
    * || check_fs_ifree /var 1k
 
 #
+## Extra local file systems.
+#
+# All machines should have their extra local filesystems mounted as specified in the local_mounts variable.
+# When file system type is 'none', then use xfs/etx4.
+#
+{% for local_item in local_mounts %}
+  {% if local_item['type'] == 'none' %}
+    {% set local_type = '/(xfs|ext4)/' %}
+  {% else %}
+    {% set local_type = local_item['type'] %}
+  {% endif %}
+   * || check_fs_mount_rw -f {{ local_item['mount_point'] }} -t '{{ local_type }}'
+   * || check_fs_free {{ local_item['mount_point'] }} {{ local_item['check_fs_free'] | default('20%') }}
+   * || check_fs_ifree {{ local_item['mount_point'] }} 1k
+{% endfor %}
+
+#
 ## PFS mounts.
 #
 # All machines should have their shared physical filesystems (PFSs) mounted as specified in the pfs_mounts variable.

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -11,7 +11,7 @@
     mode: '0600'
     owner: root
     group: root
-  with_items: "{{ pfs_mounts | selectattr('device', 'undefined') | selectattr('type', 'equalto', 'cifs') | list }}"
+  with_items: "{{ pfs_mounts | selectattr('type', 'equalto', 'cifs') | list }}"
   when: inventory_hostname in item.machines | default([])
   become: true
 
@@ -27,7 +27,7 @@
       {%- if item.type == 'cifs' -%}
       ,credentials=/etc/sysconfig/{{ item.pfs | regex_replace('\$$', '') | regex_replace('/', '_') }}.cifs,uid=root,gid=root,dir_mode=02750,file_mode=0640
       {%- endif -%}
-  with_items: "{{ pfs_mounts | selectattr('device', 'undefined') | list }}"
+  with_items: "{{ pfs_mounts | list }}"
   when: inventory_hostname in item.machines | default([])
   become: true
 

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -208,6 +208,12 @@ all:
               mounted_mode: '0755'
               mount_options: 'rw,relatime,nofail,x-systemd.device-timeout=10'
               type: ext4
+          nfs_server_shares:
+            - path: '/mnt/umcgst12'
+              clients: "{{ stack_networks
+                           | selectattr('name', 'equalto', stack_prefix + '_internal_storage')
+                           | map(attribute='cidr')
+                           | first }}(rw,sync,no_root_squash,no_subtree_check)"
     smb_server:
       hosts:
         wh-sai:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -200,6 +200,14 @@ all:
     nfs_server:
       hosts:
         wh-sai:
+          local_mounts:
+            - mount_point: '/mnt/umcgst12'
+              device: /dev/vdb
+              mounted_owner: root
+              mounted_group: root
+              mounted_mode: '0755'
+              mount_options: 'rw,relatime,nofail,x-systemd.device-timeout=10'
+              type: ext4
     smb_server:
       hosts:
         wh-sai:


### PR DESCRIPTION
Previously the code made several assumptions about NFS shares:
 * The `nfs_server` role would parse the `pfs_mounts` and when a PFS of type `nfs` would have a `device` specified, it would add an extra item to the list of `local_mounts`. Other roles that also parse `pfs_mounts` and `local_mounts` like the `nhc_standalone` role were missing that extra logic and hence had an incomplete list of `local_mounts`, which resulted in false positive error messages from NHC.
 * The `nfs_server` role would assume there is only one NFS server and that all NFS exports were hosted by the same server using partially hard-coded settings.

This has been fixed: we now explicitly add which local mount is exported from which NFS server. In addition NHC file system checks were added for all mounts specified in `local_mounts`.