### PR TITLE
Minor update for slurm role.

### DIFF
--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 - name: Deploy Slurm management.
-  ansible.builtin.include_tasks:
+  ansible.builtin.import_tasks:
     file: management.yml
   when: inventory_hostname in groups['sys_admin_interface']
 
 - name: Deploy Slurm clients.
-  ansible.builtin.include_tasks:
+  ansible.builtin.import_tasks:
     file: client.yml
   when: inventory_hostname in groups['compute_node'] or
         inventory_hostname in groups['user_interface']
 
 - name: Deploy Slurm notifications for admins.
-  ansible.builtin.include_tasks:
+  ansible.builtin.import_tasks:
     file: notifications.yml
   when:
     - inventory_hostname in groups['sys_admin_interface']


### PR DESCRIPTION
Changed _dynamic_ `ansible.builtin.include_tasks` into _static_ `ansible.builtin.import_tasks` for `slurm` role, so we can use `--start-at-task` on the command line, which does not work with dynamic includes.
This enables quickly deploying updates to `nhc.conf` when there was an update to the mounted group folders without having to redeploy the entire `slurm` role.