### PR TITLE
Logs: reverted the incorrect jumphosts handling

### DIFF
--- a/roles/logs_client/handlers/main.yml
+++ b/roles/logs_client/handlers/main.yml
@@ -4,7 +4,7 @@
     /etc/sysconfig/iptables-init.bash
   register: fw_reg
   changed_when: fw_reg.rc == 0
-  delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+  delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   loop: "{{ logs_class_servers }}"
   become: true
   notify: client_restart_rsyslog
@@ -16,7 +16,7 @@
   ansible.builtin.service:
     name: rsyslog.service
     state: restarted
-  delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+  delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   loop: "{{ logs_class_servers }}"
   become: true
   listen: restart_server_rsyslog

--- a/roles/logs_client/tasks/client.yml
+++ b/roles/logs_client/tasks/client.yml
@@ -106,7 +106,7 @@
         mode: '0600'
         force: true
       become: true
-      delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+      delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
       loop: "{{ logs_class_servers }}"
       vars:
         ansible_python_interpreter: /usr/bin/python3
@@ -118,7 +118,7 @@
         mode: '0600'
         force: true
       become: true
-      delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+      delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
       loop: "{{ logs_class_servers }}"
       vars:
         ansible_python_interpreter: /usr/bin/python3
@@ -135,7 +135,7 @@
       changed_when: client_certificates_generate_results.rc == 0
       failed_when: client_certificates_generate_results.rc != 0
       become: true
-      delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+      delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
       loop: "{{ logs_class_servers }}"
       notify: restart_server_rsyslog
       vars:
@@ -149,7 +149,7 @@
         fail_on_missing: true
         validate_checksum: true
       become: true
-      delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+      delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
       loop: "{{ logs_class_servers }}"
       notify: restart_server_rsyslog
       vars:

--- a/roles/logs_client/tasks/firewall.yml
+++ b/roles/logs_client/tasks/firewall.yml
@@ -6,7 +6,7 @@
     group: "root"
     mode: '0770'
     state: 'directory'
-  delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+  delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   register: create_iptables_extras_d
   loop: "{{ logs_class_servers }}"
   become: true
@@ -46,7 +46,7 @@
     create: true
     regexp: "{{ client_public_ip.content | trim }} 41514"
     line: "{{ client_public_ip.content | trim }} 41514"
-  delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+  delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   register: add_ip_to_firewall_extra_allow
   loop: "{{ logs_class_servers }}"
   become: true

--- a/roles/logs_client/tasks/test.yml
+++ b/roles/logs_client/tasks/test.yml
@@ -41,7 +41,7 @@
   until: remote_test_result.rc == 0
   retries: 12
   delay: 5
-  delegate_to: "{% if groups['jumphost'] | first != inventory_hostname %}{{ groups['jumphost'] | first }}+{% endif %}{{ item }}"
+  delegate_to: "{{ groups['jumphost'] | first }}+{{ item }}"
   loop: "{{ logs_class_servers }}"
   become: true
   vars:


### PR DESCRIPTION
Previously I thought the jumphosts were failing due to this lines, but they were correct all along. Reverting to the old lines.