### PR TITLE
Bugfixes for automounts

### DIFF
--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -530,8 +530,8 @@ pfs_mounts:
   - pfs: umcgst01
     source: '172.23.15.186@tcp15:172.23.15.187@tcp15:/umcgdh5'
     type: lustre
-    #rw_options: 'defaults,_netdev,flock,nofail,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    #ro_options: 'defaults,_netdev,ro,nofail,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    #rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    #ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
     rw_options: 'defaults,_netdev,flock'
     ro_options: 'defaults,_netdev,ro'
     machines: "{{ groups['sys_admin_interface'] }}"

--- a/roles/lustre_client/tasks/install.yml
+++ b/roles/lustre_client/tasks/install.yml
@@ -200,7 +200,11 @@
     backup: true
     insertafter: '\[Service\]'
     regexp: '^#?SuccessExitStatus='
-    line: 'SuccessExitStatus=239'  # lustre NID already loaded.
+    #
+    # 142 = Operation already in progress; In this case it usually means network already configured, peer already added, etc.
+    # 239 = Lustre NID already loaded.
+    #
+    line: 'SuccessExitStatus=142 239'
     owner: root
     group: root
     mode: '0644'


### PR DESCRIPTION
* [Bugfix for Lustre client role: treat exit code 142 "Operation already in progress" for lnet.service as `success` instead of `failure`.](https://github.com/rug-cit-hpc/league-of-robots/commit/e265a9539bbb7ca7cda9b64e6ebc262edcdf46ab)
* [Removed `nofail` mount option for Lustre as it is not supported.](https://github.com/rug-cit-hpc/league-of-robots/commit/1de754d26a5a3cdcfd1ce0d5f9d1e745592eb38a)