### PR TITLE
Logs_clients: limit single role to run on RHEL version greater than 7

### DIFF
--- a/single_role_playbooks/logs_client.yml
+++ b/single_role_playbooks/logs_client.yml
@@ -7,6 +7,6 @@
     - logs
   roles:
     - role: logs_client
-      when: (syslog_external_servers is defined and ( syslog_external_servers|length>0 )) or
-        ( logs_class is defined )
+      when: ((syslog_external_servers is defined and ( syslog_external_servers|length>0 )) or ( logs_class is defined ))
+            and ( ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] > "7" )
 ...


### PR DESCRIPTION
This does mean that the `logs_client` role will NOT run on GS (we never deployed it there), BB and CF (IS already deployed, it is scheduled for and upgrade)