### PR TITLE
Update for automounts on Nibbler

### DIFF
--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -535,16 +535,14 @@ pfs_mounts:
   - pfs: umcgst01
     source: '172.23.15.186@tcp15:172.23.15.187@tcp15:/umcgdh5'
     type: lustre
-    #rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    #ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    rw_options: 'defaults,_netdev,flock'
-    ro_options: 'defaults,_netdev,ro'
+    rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
     machines: "{{ groups['sys_admin_interface'] }}"
   - pfs: umcgst02
     source: '172.23.57.213@tcp14:172.23.57.214@tcp14:/umcg'
     type: lustre
-    rw_options: 'defaults,_netdev,flock'
-    ro_options: 'defaults,_netdev,ro'
+    rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
     machines: "{{ groups['sys_admin_interface'] }}"
   - pfs: umcgst04/slice2
     source: '172.23.60.161@tcp20:172.23.60.162@tcp20:/'

--- a/roles/shared_storage/templates/set_quota.bash
+++ b/roles/shared_storage/templates/set_quota.bash
@@ -308,7 +308,20 @@ function processGroupDirs () {
 			# Just append unit: all quota values from the IDVault are in GB.
 			size_hard_limit="${size_hard_limit}G"
 		fi
-		if [[ "${_fs_type}" == 'lustre' ]]; then
+		#
+		# Check if we have a lustre file system.
+		# Note that when automounts are used for a lustre file system,
+		# then /proc/mounts and hence _fs_type contains redundant entries
+		# in random order. Hence _fs_type can contain either
+		#     lustre
+		# or
+		#     autofs
+		#     lustre
+		# or
+		#     lustre
+		#     autofs
+		#
+		if [[ "${_fs_type}" == *lustre* ]]; then
 				applyLustreQuota "${_lfs_path}" 'project' "${project_id}" "${size_soft_limit}" "${size_hard_limit}"
 		else
 			log4Bash 'WARN' "${LINENO}" "${FUNCNAME:-main}" '0' "   Cannot configure quota due to unsupported file system type: ${_fs_type}."


### PR DESCRIPTION
* Bugfix: correct handling of file system type to allow setting quota when automounts are used.
* Switched `prm02` and `prm03` on Nibbler to automounts.