### PR TITLE
Fix: local_storage before shared_storage

### DIFF
--- a/roles/openstack_computing/tasks/servers.yml
+++ b/roles/openstack_computing/tasks/servers.yml
@@ -88,9 +88,10 @@
         - {{ public_key }}
         {% endif %}
       {% endfor %}
-      {% if local_mounts | default([]) is defined and local_mounts | default([]) | length > 0 %}
+      {% if local_mounts | default([]) is defined
+        and local_mounts | default([]) | rejectattr('device', 'equalto', 'dynamic') | list | length > 0 %}
       mounts:
-        {% for extra_mount in local_mounts | default([]) %}
+        {% for extra_mount in local_mounts | default([]) | rejectattr('device', 'equalto', 'dynamic') | list %}
         - - {{ extra_mount['device'] }}
           - {{ extra_mount['mount_point'] }}
           - {{ extra_mount['type'] }}

--- a/single_group_playbooks/beegfs_server.yml
+++ b/single_group_playbooks/beegfs_server.yml
@@ -10,9 +10,6 @@
   hosts:
     - beegfs_server
   roles:
-    - role: perc_cli
-      when: perc_devices is defined and perc_devices
-    - local_storage
     - beegfs_server
     #
     # beegfs_client is preferred on server too and will be installed as part of cluster_part2.yml

--- a/single_group_playbooks/chaperone.yml
+++ b/single_group_playbooks/chaperone.yml
@@ -33,7 +33,8 @@
     - cluster
     - regular_users
     - sudoers
-    - local_storage
+    - role: local_storage
+      when: local_mounts is defined and local_mounts | length > 0
     - shared_storage
     - build_environment
     - envsync

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -41,4 +41,8 @@
     - gpu  # Needs to run after 'cluster' role.
     - resolver
     - coredumps
+    - role: perc_cli
+      when: perc_devices is defined and perc_devices
+    - role: local_storage
+      when: local_mounts is defined and local_mounts | length > 0
 ...

--- a/single_group_playbooks/compute_node.yml
+++ b/single_group_playbooks/compute_node.yml
@@ -11,8 +11,5 @@
   hosts:
     - compute_node
   roles:
-    - role: perc_cli
-      when: perc_devices is defined
-    - local_storage
     - slurm
 ...

--- a/single_group_playbooks/data_transfer.yml
+++ b/single_group_playbooks/data_transfer.yml
@@ -22,7 +22,8 @@
     - basic_security
     - rsyncd
     - regular_users
-    - local_storage
+    - role: local_storage
+      when: local_mounts is defined and local_mounts | length > 0
     - role: cleanup_gs_data
       when: '"umcg-genomescan" in regular_groups'
 ...

--- a/single_group_playbooks/deploy_admin_interface.yml
+++ b/single_group_playbooks/deploy_admin_interface.yml
@@ -11,7 +11,6 @@
   hosts:
     - deploy_admin_interface
   roles:
-    - local_storage
     - build_environment
     - envsync
     - backup_local

--- a/single_group_playbooks/nfs_server.yml
+++ b/single_group_playbooks/nfs_server.yml
@@ -10,8 +10,5 @@
   hosts:
     - nfs_server
   roles:
-    - role: perc_cli
-      when: perc_devices is defined and perc_devices
-    - local_storage
     - nfs_server
 ...

--- a/single_role_playbooks/local_storage.yml
+++ b/single_role_playbooks/local_storage.yml
@@ -6,5 +6,6 @@
      - data_transfer
      - chaperone
   roles:
-     - local_storage
+     - role: local_storage
+       when: local_mounts is defined and local_mounts | length > 0
 ...


### PR DESCRIPTION
* [Do not add local mounts to cloud init config for which we first must install a commandline tool to configure a RAID card and format a file system.](https://github.com/rug-cit-hpc/league-of-robots/pull/1199/commits/7d7495158d99e4ebc2aaf866e10b48144fe67d0b)
* [Fix dependencies and order of roles: relocated `perc_cli` and `local_storage` roles to `cluster_part1.yml` to simplify plays and make sure `local_storage` is always run before `shared_storage`, which may rely on shares from an NFS, BeeGFS or CIFS server or on bind mounts that need an extra local disk first.](https://github.com/rug-cit-hpc/league-of-robots/pull/1199/commits/a68ad68d6da277c241997772ff16f3fa2a1ce505)