### PR TITLE
Feature: tmp16 mounts on CopperFist

### DIFF
--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -490,8 +490,8 @@ pfs_mounts:
   - pfs: umcgst16
     source: "{{ ip_addresses[stack_prefix + '-storage']['vlan990']['address'] }}:/mnt"
     type: nfs4    # checked with cat /proc/filesystem
-    rw_options: 'defaults,_netdev,noatime,nodiratime,local_lock=flock'
-    ro_options: 'defaults,_netdev,noatime,nodiratime,ro'
+    rw_options: 'defaults,_netdev,noatime,nodiratime,nofail,local_lock=flock'
+    ro_options: 'defaults,_netdev,noatime,nodiratime,nofail,ro'
     machines: "{{ groups['sys_admin_interface'] }}"
 lfs_mounts:
   - lfs: home
@@ -510,13 +510,24 @@ lfs_mounts:
         mode: '2750'
       - name: umcg-labgnkbh
       - name: umcg-patho
-#      - name: umcg-pr
+      # - name: umcg-pr
       - name: umcg-vipt
     rw_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] }}"
   - lfs: tmp16
     pfs: 'umcgst16'
     groups:
       - name: umcg-atd
+      - name: umcg-gap
+      - name: umcg-gd
+      - name: umcg-genomescan
+      - name: umcg-gsad
+      - name: umcg-gst
+      - name: umcg-lab
+        mode: '2750'
+      - name: umcg-labgnkbh
+      - name: umcg-patho
+      # - name: umcg-pr
+      - name: umcg-vipt
     rw_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] + groups['compute_node'] }}"
   - lfs: prm05
     pfs: 'medgen_zincfinger$'

--- a/roles/slurm/tasks/client.yml
+++ b/roles/slurm/tasks/client.yml
@@ -86,6 +86,8 @@
       - 'lbnl-nhc'
   notify:
     - 'restart_slurmd'
+  tags:
+    - nhc
   become: true
 
 - name: 'Install munge_keyfile.'
@@ -188,6 +190,8 @@
     mode: '0644'
   when: (inventory_hostname in groups['user_interface']) or
         (inventory_hostname in groups['compute_node'])
+  tags:
+    - nhc
   become: true
 
 - name: 'Install logrotate config file for slurmd.'


### PR DESCRIPTION
* [Added tmp16 mounts for all groups on CopperFist stack.](https://github.com/rug-cit-hpc/league-of-robots/commit/f262e075951b9f602ab46470f18aa7519e6828e7)
* [Added `nhc` tags to two tasks in `slurm` role to easily update only the NHC config, which comes in handy after adding or removing mounts.](https://github.com/rug-cit-hpc/league-of-robots/commit/12b2c1bf3276d918bc63f3874cb7a4b47f47b6b9)