### PR TITLE
Removed unused variable from static inventory for CopperFist.

### DIFF
--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -239,7 +239,6 @@ all:
               security_group: "{{ stack_prefix }}_cluster"
             - name: vlan990
               security_group: "{{ stack_prefix }}_storage"
-          lustre_client_networks: "{{ lustre_client_networks_baremetal }}"
           local_yum_repository: true # enable local yum repository for PERC CLI utility.
           perc_devices: true
           local_mounts:


### PR DESCRIPTION
Removed erroneously added var from `static_inventories/copperfist_cluster.yml`