### PR TITLE
lor-init: faster initialization for mitogen

### DIFF
--- a/lor-init
+++ b/lor-init
@@ -115,7 +115,7 @@ function lor-config() {
 	# Enable ansible_mitogen strategy plugin for improved speed of plays when available.
 	#
 	_ansible_mitogen_search_path='.*/lib/python.*/site-packages/ansible_mitogen/plugins/strategy'
-	_ansible_mitogen_path=$(find ${VIRTUAL_ENV:-.} -regex "${_ansible_mitogen_search_path}" | sort -V | tail -1)
+	_ansible_mitogen_path=$(find ${VIRTUAL_ENV:-.}/lib -type d -name mitogen | sort -V | tail -1)
 	if [[ -n "${_ansible_mitogen_path}" ]]; then
 		export ANSIBLE_STRATEGY_PLUGINS="${_ansible_mitogen_path}"
 		export ANSIBLE_STRATEGY='mitogen_linear'

--- a/lor-init
+++ b/lor-init
@@ -114,7 +114,6 @@ function lor-config() {
 	#
 	# Enable ansible_mitogen strategy plugin for improved speed of plays when available.
 	#
-	_ansible_mitogen_search_path='.*/lib/python.*/site-packages/ansible_mitogen/plugins/strategy'
 	_ansible_mitogen_path=$(find ${VIRTUAL_ENV:-.}/lib -type d -name mitogen | sort -V | tail -1)
 	if [[ -n "${_ansible_mitogen_path}" ]]; then
 		export ANSIBLE_STRATEGY_PLUGINS="${_ansible_mitogen_path}"

--- a/lor-init
+++ b/lor-init
@@ -114,7 +114,7 @@ function lor-config() {
 	#
 	# Enable ansible_mitogen strategy plugin for improved speed of plays when available.
 	#
-	_ansible_mitogen_path=$(find ${VIRTUAL_ENV:-.}/lib -type d -name mitogen | sort -V | tail -1)
+	_ansible_mitogen_path=$(find ${VIRTUAL_ENV:-.}/lib/python*/site-packages/ansible_mitogen/plugins -type d -name "strategy" | sort -V | tail -1)
 	if [[ -n "${_ansible_mitogen_path}" ]]; then
 		export ANSIBLE_STRATEGY_PLUGINS="${_ansible_mitogen_path}"
 		export ANSIBLE_STRATEGY='mitogen_linear'


### PR DESCRIPTION
time find ${VIRTUAL_ENV:-.} -regex "${_ansible_mitogen_search_path}" | sort -V | tail -1
    real     0m0.883s
    user	0m0.563s
    sys	0m0.251s

vs

time find ${VIRTUAL_ENV:-.}/lib -type d -name mitogen | sort -V | tail -1
    real	0m0.311s
    user	0m0.122s
    sys	0m0.189s
