### PR TITLE
Bugfix for NIC naming

### DIFF
--- a/roles/interfaces/templates/fix_network_interface_names.bash
+++ b/roles/interfaces/templates/fix_network_interface_names.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 {% raw %}
+set -u
+set -e
+set -o pipefail
 #
 # Our custom NamePolicy in /etc/systemd/network/99-default.link
 # (to prevent problematic slot-based network interface names)
@@ -31,8 +34,8 @@ readarray -t network_interfaces_unsorted < <(find '/sys/class/net/' -maxdepth 1 
 declare -a network_interfaces_sorted
 for network_interface in "${network_interfaces_unsorted[@]}"; do
     if_index="$(udevadm info -q property --property=IFINDEX --value "${network_interface}")"
-    network_interfaces_sorted[${if_index}]="${network_interface}"
-    printf 'INFO: Found network interface %s at index %d ...\n' "${network_interface}" ${if_index}
+    network_interfaces_sorted["${if_index}"]="${network_interface}"
+    printf 'INFO: Found network interface %s at index %d ...\n' "${network_interface}" "${if_index}"
 done
 #
 # Apply udev rules to network interfaces sorted by index.

--- a/roles/interfaces/templates/fix_network_interface_names.bash
+++ b/roles/interfaces/templates/fix_network_interface_names.bash
@@ -1,7 +1,5 @@
 #!/bin/bash
-
 {% raw %}
-
 #
 # Our custom NamePolicy in /etc/systemd/network/99-default.link
 # (to prevent problematic slot-based network interface names)
@@ -22,18 +20,33 @@
 #
 #    udevadm test /sys/class/net/ens6
 #
-readarray -t wrong_network_interface_names < <(find '/sys/class/net/' -maxdepth 1 -mindepth 1 -type l -regextype posix-extended -regex '(.*ens.*)|(.*rename.*)')
-for wrong_network_interface_name in "${wrong_network_interface_names[@]}"; do
-    udevadm test "${wrong_network_interface_name}"
+# Find the relevant network interfaces:
+#  * Named by path
+#  * Named by slot
+#  * Renamed by Cloud Init
+# Hence exclude for example on board and loopback devices.
+# And add them to a list sorted by network interface index.
+#
+readarray -t network_interfaces_unsorted < <(find '/sys/class/net/' -maxdepth 1 -mindepth 1 -type l -regextype posix-extended -regex '(.*enp.*)|(.*ens.*)|(.*rename.*)')
+declare -a network_interfaces_sorted
+for network_interface in "${network_interfaces_unsorted[@]}"; do
+    if_index="$(udevadm info -q property --property=IFINDEX --value "${network_interface}")"
+    network_interfaces_sorted[${if_index}]="${network_interface}"
+    printf 'INFO: Found network interface %s at index %d ...\n' "${network_interface}" ${if_index}
 done
-
+#
+# Apply udev rules to network interfaces sorted by index.
+#
+for network_interface_index in "${!network_interfaces_sorted[@]}"; do
+    id_net_name=$(udevadm test "${network_interfaces_sorted[${network_interface_index}]}" | grep 'ID_NET_NAME=')
+    printf 'INFO: (Re-)applied udev rules for network interface %s with index %d: %s.\n' "${network_interfaces_sorted[${network_interface_index}]}" "${network_interface_index}" "${id_net_name}"
+done
 #
 # NetworkManager does not know an interface got renamed;
 # It notices
 #    * the "old" network interface is gone and drops the connection.
 #    * a new network interface appeared and will try to establish a connection.
-# Give NetworkManager some time to configure the new network interface automagically.
+# Give NetworkManager some time to configure the new network interface(s) automagically.
 #
 sleep 5
-
 {% endraw %}


### PR DESCRIPTION
Fixed bug where network interfaces would not get renamed according to `udev` rules, because the new name was already used by another interface, which had the wrong name and needs to be renamed first.