### PR TITLE
Allow gd-ateambot to access OGM data.

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -234,7 +234,7 @@ regular_users:
   - name: 'umcg-gap-dm'
     groups: ['umcg-gap', "{{ functional_users_group }}"]
   - name: 'umcg-gd-ateambot'
-    groups: ['umcg-gd', 'umcg-gap', "{{ functional_users_group }}"]
+    groups: ['umcg-gd', 'umcg-gap', 'umcg-ogm', "{{ functional_users_group }}"]
   - name: 'umcg-gd-dm'
     groups: ['umcg-gd', "{{ functional_users_group }}"]
   - name: 'umcg-genomescan-ateambot'

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -235,7 +235,7 @@ regular_users:
   - name: 'umcg-gap-dm'
     groups: ['umcg-gap', "{{ functional_users_group }}"]
   - name: 'umcg-gd-ateambot'
-    groups: ['umcg-gd', 'umcg-gap', "{{ functional_users_group }}"]
+    groups: ['umcg-gd', 'umcg-gap', 'umcg-ogm', "{{ functional_users_group }}"]
   - name: 'umcg-gd-dm'
     groups: ['umcg-gd', "{{ functional_users_group }}"]
   - name: 'umcg-genomescan-ateambot'

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -232,7 +232,7 @@ regular_users:
   - name: 'umcg-gap-dm'
     groups: ['umcg-gap', "{{ functional_users_group }}"]
   - name: 'umcg-gd-ateambot'
-    groups: ['umcg-gd', 'umcg-gap', "{{ functional_users_group }}"]
+    groups: ['umcg-gd', 'umcg-gap', 'umcg-ogm', "{{ functional_users_group }}"]
   - name: 'umcg-gd-dm'
     groups: ['umcg-gd', "{{ functional_users_group }}"]
   - name: 'umcg-genomescan-ateambot'


### PR DESCRIPTION
Allow gd-ateambot read-only (by design) access to OGM data for trend analysis reports.