### PR TITLE
Removed redundant variables.

### DIFF
--- a/roles/slurm/templates/nhc_slurm_client.conf
+++ b/roles/slurm/templates/nhc_slurm_client.conf
@@ -54,9 +54,22 @@
 # Check for some sort of free memory of either type.
    * || check_hw_mem_free {{ [2048, (ansible_memtotal_mb | float * 0.02) | int] | min }}MB
 
-# Checks for an active ethernet interfaces.
-{% for ethernet_interface in slurm_ethernet_interfaces %}
-   * || check_hw_eth {{ ethernet_interface }}
+# Checks for active network interfaces.
+{% set network_interfaces =
+    (
+        host_networks
+        | rejectattr('nmstate_interface', 'undefined')
+        | map(attribute='nmstate_interface')
+        | rejectattr('name', 'undefined')
+        | map(attribute='name')
+        | default([])
+      + slurm_ethernet_interfaces
+        | default([])
+    )
+  | community.general.version_sort
+  | unique %}
+{% for network_interface in network_interfaces %}
+   * || check_hw_eth {{ network_interface }}
 {% endfor %}
 
 # Check the mcelog daemon for any pending errors.

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -212,11 +212,6 @@ all:
           slurm_real_memory: 63788
           slurm_local_disk: 0
           slurm_features: 'prm02,prm03,rsc02,tmp02'
-          slurm_ethernet_interfaces:
-            - enp0s3
-            - enp0s4
-            - enp0s5
-            - enp0s6
     compute_node:
       children:
         cpu_r6515:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -268,9 +263,6 @@ all:
               slurm_local_disk: 3002000
               slurm_features: 'rsc02,tmp02'
               slurm_weight: 5
-              slurm_ethernet_interfaces:
-                - eth2
-                - eth2.1068
         gpu_a40:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             nb-node-b[01:02]:
@@ -304,13 +296,6 @@ all:
               slurm_local_disk: 900
               slurm_features: 'rsc02,tmp02,gpu,A40'
               slurm_weight: 10
-              slurm_ethernet_interfaces:
-                - enp0s3
-                - enp0s4
-                - enp0s5
-                # DH4 and DH5 not used on compute nodes (yet).
-                #- ens6
-                #- ens7
         cpu_r630:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             nb-node-c[01:10]:
@@ -360,9 +345,6 @@ all:
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
               slurm_features: 'rsc02,tmp02'
-              slurm_ethernet_interfaces:
-                - enp130s0f0
-                - enp130s0f0.1068
 administration:
   children:
     sys_admin_interface:

--- a/static_inventories/talos_cluster.yml
+++ b/static_inventories/talos_cluster.yml
@@ -119,10 +119,6 @@ all:
           slurm_real_memory: 7684
           slurm_local_disk: 0
           slurm_features: 'prm08,tmp08'
-          slurm_ethernet_interfaces:
-            - enp3s0
-            - enp4s0
-            - enp5s0
     compute_node:
       children:
         cpu_r630:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -177,11 +173,6 @@ all:
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
               slurm_features: 'tmp08'
-              slurm_ethernet_interfaces:
-                #- enp130s0f0
-                #- enp130s0f0.1068
-                - eth2
-                - eth2.1068
         cpu_r6515:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             tl-node-b01:
@@ -228,9 +219,6 @@ all:
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
               slurm_features: 'tmp08'
-              slurm_ethernet_interfaces:
-                - enp65s0np0
-                - enp65s0np0.1068
         cpu_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             tl-node-c01:
@@ -257,9 +245,6 @@ all:
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 900
               slurm_features: 'tmp08'
-              slurm_ethernet_interfaces:
-              - eth0
-              - eth1
     chaperone:
       hosts:
         tl-chaperone:

--- a/static_inventories/vaxtron_cluster.yml
+++ b/static_inventories/vaxtron_cluster.yml
@@ -114,10 +114,6 @@ all:
           slurm_real_memory: 31072
           slurm_local_disk: 0
           slurm_features: 'prm02,prm03,rsc04,tmp04'
-          slurm_ethernet_interfaces:
-            - ens3
-            - ens4
-            - ens5
     compute_node:
       children:
         cpu_r750:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -163,9 +159,6 @@ all:
               slurm_local_disk: 3420400
               slurm_features: 'rsc04,tmp04'
               slurm_weight: 10
-              slurm_ethernet_interfaces:
-                - eno12409np1
-                - eno12399np0
         cpu_r6625:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             vt-node-b[01:06]:
@@ -208,9 +201,6 @@ all:
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 2850100
               slurm_features: 'rsc04,tmp04'
-              slurm_ethernet_interfaces:
-                - eno12409
-                - eno12399
 administration:
   children:
     sys_admin_interface:

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -175,10 +175,6 @@ all:
           slurm_real_memory: 15724
           slurm_local_disk: 0
           slurm_features: 'tmp07'
-          slurm_ethernet_interfaces:
-            - enp3s0
-            - enp4s0
-            - enp5s0
     compute_node:
       children:
         regular_big_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -210,10 +206,6 @@ all:
             slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
             slurm_local_disk: 900
             slurm_features: 'tmp07'
-            slurm_ethernet_interfaces:
-              - enp3s0
-              - enp4s0
-              - enp5s0
     mit_chaperone:
       hosts:
         wh-chaperone:


### PR DESCRIPTION
Use `nmstate_interface` info to create a list of network interfaces for the Node Health Check config when available. This means redundant network interface names listed in `slurm_ethernet_interfaces` can be removed when `nmstate_interface` is defined.