### PR TITLE
Init.yml

### DIFF
--- a/single_group_playbooks/init.yml
+++ b/single_group_playbooks/init.yml
@@ -8,6 +8,8 @@
     - irods
     - ldap_server
     - logs
+    - data_transfer
+    - jenkins
   roles:
     - role: static_hostname_lookup
 


### PR DESCRIPTION
Missing init means misconfigured `/etc/hosts` > failing services.
Data_transfer needs it, but I am not sure for the other > let's talk when we are all back in the office