### PR TITLE
Bugfixes for mounts triggering cyclic boot sequence dependencies.

### DIFF
--- a/roles/remote_archive/templates/archive_automount.j2
+++ b/roles/remote_archive/templates/archive_automount.j2
@@ -4,7 +4,19 @@
 
 [Unit]
 Description=Automount for {{ item.1 }}
-After=network.target
+#
+# We need functional network to access the remote archive,
+# but currently cannot depend on any network service / target,
+# because systemd only supports automounts for local file systems:
+# it always inserts a dependency on local-fs.target for automouts to ensure the unit comes early in the boot sequence,
+# but adding a dependency on network services / targets requires the unit to come late in the boot sequence.
+# This results in cyclic depencencies and random units getting dropped from the boot sequence
+# and hence random services, targets or mounts failing.
+# See systemd bug: #17657 automount units below network mounts result in dep cycles
+#                  https://github.com/systemd/systemd/issues/17657
+#
+#After=network-online.target
+#Wants=network-online.target
 
 [Automount]
 Where=/{{ item.0.local_top_level_mount | regex_replace('\/', '') }}/{{ item.1 }}/{{ item.0.name }}

--- a/roles/shared_storage/tasks/main.yml
+++ b/roles/shared_storage/tasks/main.yml
@@ -509,12 +509,26 @@
     path: "/groups/{{ item.1.name }}/{{ item.0.lfs }}"
     src: "{{ parent_mount_point }}/{{ item.1.name }}/{{ item.0.lfs }}"
     fstype: none
-    # Bind mounting read-write will only work of the src was also mounted read-write.
-    opts: "bind,rw,x-systemd.requires-mounts-for={{ parent_mount_point }},x-systemd.mount-timeout=20s,retry=3"
+    opts: "{{ basic_opts }}{{ extra_opts }}"
     state: mounted
   vars:
     pfs_mount: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | first }}"
     parent_mount_point: "/mnt/{{ item.0.pfs | regex_replace('\\$$', '') | regex_replace('/', '_') }}/groups"
+    #
+    # Note: bind mounting read-write will only work if the src was also mounted read-write.
+    #
+    basic_opts: "bind,rw,x-systemd.requires-mounts-for={{ parent_mount_point }}"
+    #
+    # Explicitly add _netdev to the mount options for the bind mount, when the source was mounted with _netdev option.
+    # This prevents systemd-fstab-generator from assuming that the mount is for a local file system
+    # and from inserting the mount unit too early in the boot sequence creating in a cyclic dependency,
+    # which in turn results in systemd randomly dropping units for services or mounts from the boot sequence.
+    # in an attempt to break the cyclic dependency and continue to boot.
+    #
+    extra_opts: >-
+      {%- if '_netdev' in pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='rw_options') | first -%}
+      ,_netdev
+      {%- endif -%}
   loop: "{{ lfs_mounts
             | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
             | rejectattr('type', 'undefined')
@@ -533,11 +547,23 @@
     path: "/groups/{{ item.1.name }}/{{ item.0.lfs }}"
     src: "{{ parent_mount_point }}/{{ item.1.name }}/{{ item.0.lfs }}"
     fstype: none
-    opts: "bind,ro,x-systemd.requires-mounts-for={{ parent_mount_point }},x-systemd.mount-timeout=20s,retry=3"
+    opts: "{{ basic_opts }}{{ extra_opts }}"
     state: mounted
   vars:
     pfs_mount: "{{ pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | first }}"
     parent_mount_point: "/mnt/{{ item.0.pfs | regex_replace('\\$$', '') | regex_replace('/', '_') }}/groups"
+    basic_opts: "bind,ro,x-systemd.requires-mounts-for={{ parent_mount_point }}"
+    #
+    # Explicitly add _netdev to the mount options for the bind mount, when the source was mounted with _netdev option.
+    # This prevents systemd-fstab-generator from assuming that the mount is for a local file system
+    # and from inserting the mount unit too early in the boot sequence creating in a cyclic dependency,
+    # which in turn results in systemd randomly dropping units for services or mounts from the boot sequence.
+    # in an attempt to break the cyclic dependency and continue to boot.
+    #
+    extra_opts: >-
+      {%- if '_netdev' in pfs_mounts | selectattr('pfs', 'equalto', item.0.pfs) | map(attribute='ro_options') | first -%}
+      ,_netdev
+      {%- endif -%}
   loop: "{{ lfs_mounts
             | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
             | rejectattr('type', 'undefined')


### PR DESCRIPTION
* [Fix issue with `bind` mounts when the source is a network file system and resulting in a cyclic boot sequence dependency hell.](https://github.com/rug-cit-hpc/league-of-robots/commit/9388d3f378c8b447aa22b96bb516691e4593bb48)
* [Fix issue with `auto` mounts when the source is a network file system and resulting in a cyclic boot sequence dependency hell.](https://github.com/rug-cit-hpc/league-of-robots/pull/1288/commits/3fb849808933433ebb300a86da1a3375542183b3)