### PR TITLE
Enabled CRB repo on OL 8.x.

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -551,7 +551,7 @@ yum_repos:
       baseurl: https://yum$ociregion.$ocidomain/repo/OracleLinux/OL8/codeready/builder/$basearch/
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
       gpgcheck: 1
-      enabled: 0
+      enabled: 1
     - file: oracle-linux-ol8.repo
       id: ol8_distro_builder
       name: 'Oracle Linux 8 Distro Builder ($basearch) - Unsupported'


### PR DESCRIPTION
Enabled Code Ready Builder repo for Oracle Linux 8. Required to prevent version conflict when updating due to missing `lua-devel` packages.