### PR TITLE
Update of Nibbler config @ scheduled maintenance starting 2025-10-21.

### DIFF
--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -4,7 +4,7 @@ stack_domain: 'hpc.rug.nl'
 stack_name: "{{ slurm_cluster_name }}_cluster"  # stack_name must match the name of the folder that contains this vars.yml file.
 stack_prefix: 'nb'
 stack_dtap_state: production
-slurm_version: '23.02.7-2.el9.umcg'
+slurm_version: '24.11.6-1.el9.umcg'
 slurm_partitions:
   - name: cpu_r6515  # Must be in sync with group listed in Ansible inventory.
     default: no
@@ -17,7 +17,7 @@ slurm_partitions:
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.125G" DenyQos=ds-short,ds-medium,ds-long'
   - name: gpu_a40  # Must be in sync with group listed in Ansible inventory.
     default: no
-    nodes: "{{ stack_prefix }}-node-b[01-02]"  # Must be in sync with Ansible hostnames listed in inventory.
+    nodes: "{{ stack_prefix }}-node-b01"  # Must be in sync with Ansible hostnames listed in inventory.
     max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['gpu_a40']|list|length }}{% else %}1{% endif %}"
     max_cores_per_node: "{{ groups['gpu_a40'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
     max_mem_per_node: "{{ groups['gpu_a40'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
@@ -26,7 +26,7 @@ slurm_partitions:
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.260G,GRES/gpu=3.75" DenyQos=ds-short,ds-medium,ds-long'
   - name: cpu_r630  # Must be in sync with group listed in Ansible inventory.
     default: yes
-    nodes: "{{ stack_prefix }}-node-c[01-10]"  # Must be in sync with Ansible hostnames listed in inventory.
+    nodes: "{{ stack_prefix }}-node-c[01-11]"  # Must be in sync with Ansible hostnames listed in inventory.
     max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['cpu_r630']|list|length }}{% else %}1{% endif %}"
     max_cores_per_node: "{{ groups['cpu_r630'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
     max_mem_per_node: "{{ groups['cpu_r630'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
@@ -234,9 +234,9 @@ regular_groups:
     sponsor: umcg-research-it
   - name: 'umcg-datateam'
     sponsor: umcg-research-it
-  - name: 'umcg-erdera'
-    sponsor: umcg-mswertz
   - name: 'umcg-endocrinology'
+    sponsor: umcg-research-it
+  - name: 'umcg-erdera'
     sponsor: umcg-research-it
   - name: 'umcg-fg'
     sponsor: umcg-research-it
@@ -653,14 +653,14 @@ pfs_mounts:
   - pfs: umcgst01
     source: '172.23.15.186@tcp15:172.23.15.187@tcp15:/umcgdh5'
     type: lustre
-    rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    rw_options: 'defaults,_netdev,flock'
+    ro_options: 'defaults,_netdev,ro'
     machines: "{{ groups['sys_admin_interface'] }}"
   - pfs: umcgst02
     source: '172.23.57.213@tcp14:172.23.57.214@tcp14:/umcg'
     type: lustre
-    rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    rw_options: 'defaults,_netdev,flock'
+    ro_options: 'defaults,_netdev,ro'
     machines: "{{ groups['sys_admin_interface'] }}"
   - pfs: umcgst04/slice2
     source: '172.23.60.161@tcp20:172.23.60.162@tcp20:/'
@@ -671,8 +671,8 @@ pfs_mounts:
   - pfs: umcgst04/slice3
     source: '172.23.60.161@tcp20:172.23.60.162@tcp20:/'
     type: lustre
-    rw_options: 'defaults,_netdev,flock,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
-    ro_options: 'defaults,_netdev,ro,x-systemd.requires=lnet.service,x-systemd.device-timeout=60,x-systemd.automount,x-systemd.idle-timeout=600'
+    rw_options: 'defaults,_netdev,flock'
+    ro_options: 'defaults,_netdev,ro'
     machines: "{{ groups['sys_admin_interface'] }}"
 lfs_mounts:
   - lfs: home
@@ -680,6 +680,7 @@ lfs_mounts:
     rw_machines: "{{ groups['cluster'] }}"
   - lfs: tmp02
     pfs: umcgst04/slice2
+    type: bind
     groups:
       - name: umcg-as
       - name: umcg-atd
@@ -739,6 +740,7 @@ lfs_mounts:
     rw_machines: "{{ groups['user_interface'] + groups['deploy_admin_interface'] + groups['compute_node'] }}"
   - lfs: prm02
     pfs: umcgst01
+    type: bind
     groups:
       - name: umcg-as
       - name: umcg-atd
@@ -796,6 +798,7 @@ lfs_mounts:
     rw_machines: "{{ groups['user_interface'] }}"
   - lfs: prm03
     pfs: umcgst02
+    type: bind
     groups:
       - name: umcg-as
       - name: umcg-atd
@@ -853,6 +856,7 @@ lfs_mounts:
     rw_machines: "{{ groups['user_interface'] }}"
   - lfs: rsc02
     pfs: umcgst04/slice3
+    type: bind
     groups:
       - name: umcg-atd
       - name: umcg-biogen

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -243,10 +243,10 @@ regular_groups:
     sponsor: umcg-research-it
   - name: 'umcg-datateam'
     sponsor: umcg-mswertz
-  - name: 'umcg-erdera'
-    sponsor: umcg-mswertz
   - name: 'umcg-endocrinology'
     sponsor: umcg-mmvanderklauw
+  - name: 'umcg-erdera'
+    sponsor: umcg-mswertz
   - name: 'umcg-fg'
     sponsor: umcg-lfranke
   - name: 'umcg-franke-scrna'

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -9,14 +9,13 @@ all:
       hosts:
         tunnel:
           cloud_flavor: umcg.v1.vm.1-2
-          cloud_image: RockyLinux-9.3_xfs
           host_networks:
             - name: vlan1338
               security_group: "{{ stack_prefix }}_jumphosts"
               assign_floating_ip: true
               add_hostname_to_ip_address: true
-              nmstate_interface:
-                name: ens3
+              #nmstate_interface:
+              #  name: ens3
           basic_security_ssh_challenge_response_auth: 'yes' # Required for MFS in sshd_config.
           local_yum_repository: true
     repo:
@@ -189,37 +188,36 @@ all:
       hosts:
         nibbler:
           cloud_flavor: umcg.v1.vm.16-64
-          cloud_image: RockyLinux-9.3_xfs
           host_networks:
             - name: vlan1338
               security_group: "{{ stack_prefix }}_cluster"
               add_hostname_to_ip_address: true
-              nmstate_interface:
-                name: enp0s6
+              #nmstate_interface:
+              #  name: enp0s6
             - name: vlan985
               security_group: "{{ stack_prefix }}_storage"
-              nmstate_interface:
-                name: enp0s3
-              lnet:
-                name: tcp14
+              #nmstate_interface:
+              #  name: enp0s3
+              #lnet:
+              #  name: tcp14
             - name: vlan1068
               security_group: "{{ stack_prefix }}_storage"
-              nmstate_interface:
-                name: enp0s4
-              lnet:
-                name: tcp20
+              #nmstate_interface:
+              #  name: enp0s4
+              #lnet:
+              #  name: tcp20
             - name: vlan1073
               security_group: "{{ stack_prefix }}_storage"
-              nmstate_interface:
-                name: enp0s5
-              lnet:
-                name: tcp15
+              #nmstate_interface:
+              #  name: enp0s5
+              #lnet:
+              #  name: tcp15
             - name: "{{ stack_prefix }}_internal_management"
               security_group: "{{ stack_prefix }}_cluster"
-              nmstate_interface:
-                name: enp0s7
-                ipv4:
-                  auto-route-metric: 80
+              #nmstate_interface:
+              #  name: enp0s7
+              #  ipv4:
+              #    auto-route-metric: 80
           slurm_sockets: 16
           slurm_cores_per_socket: 1
           slurm_real_memory: 63788
@@ -275,43 +273,65 @@ all:
               slurm_weight: 5
         gpu_a40:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
-            nb-node-b[01:02]:
-              cloud_flavor: umcg.v1.vm.31-120.8a40
-              cloud_image: RockyLinux-9.3_xfs
-              gpu_count: 8
+            nb-node-b01:
+              cloud_flavor: umcg.v1.bm.64-512-0.vlan1338.16a40
+              gpu_count: 16
               gpu_type: 'a40'
               host_networks:
                 - name: vlan1338
                   security_group: "{{ stack_prefix }}_cluster"
                   add_hostname_to_ip_address: true
                   nmstate_interface:
-                    name: enp0s5
+                    name: eth2  # altname enp65s0np0
                 - name: vlan985
                   security_group: "{{ stack_prefix }}_storage"
                   nmstate_interface:
-                    name: enp0s3
+                    name: eth2.985
+                    type: vlan
+                    vlan:
+                      id: 985
+                      base-iface: eth2
+                    ipv4:
+                      dhcp: false
                   lnet:
                     name: tcp14
                 - name: vlan1068
                   security_group: "{{ stack_prefix }}_storage"
                   nmstate_interface:
-                    name: enp0s4
+                    name: eth2.1068
+                    type: vlan
+                    vlan:
+                      id: 1068
+                      base-iface: eth2
+                    ipv4:
+                      dhcp: false
                   lnet:
                     name: tcp20
-              local_volume_extra:
-                - name: local
-                  size: 1
-              slurm_sockets: 31
-              slurm_cores_per_socket: 1
-              slurm_real_memory: 117397
+              perc_devices: true
+              local_mounts:
+                - mount_point: "{{ slurm_local_scratch_dir }}"
+                  device: '/dev/nvme0n1'
+                  mounted_owner: root
+                  mounted_group: root
+                  mounted_mode: '0755'
+                  mount_options: >-
+                    rw,relatime
+                    {%- if ansible_facts['os_family'] == 'RedHat' and
+                           ansible_facts['distribution_major_version'] >= '8' -%}
+                      ,nofail,x-systemd.device-timeout=10
+                    {%- endif -%}
+                  type: ext4
+              slurm_sockets: 1
+              slurm_cores_per_socket: 64
+              slurm_real_memory: 514860
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
-              slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
-              slurm_local_disk: 900
+              slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
+              slurm_local_disk: 3002000
               slurm_features: 'rsc02,tmp02,gpu,A40'
               slurm_weight: 10
         cpu_r630:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
-            nb-node-c[01:10]:
+            nb-node-c[01:11]:
               cloud_flavor: umcg.v1.bm.28-256-0.vlan1338
               host_type: baremetal
               host_networks:


### PR DESCRIPTION
Prepared update of Nibbler config for scheduled maintenance starting 2025-10-21:
 * Switch prm02, prm03, tmp02 and rsc02 from `auto` mounts to `bind` mounts.
 * Added additional `nb-node-c11`
 * Updated Slurm version.
 * Changed GPU node: VMs -> bare metal.
 * Update `tunnel` and `nibbler`: cloud_image: `RockyLinux-9.3_xfs` -> `Rocky-9.5`.

Note:
* This needs to be merged before the maintenance can start.
* Some values/updates are not known yet and need to be changed later on.