### PR TITLE
storage: added delayed boot option, to support LVM cache

### DIFF
--- a/roles/local_storage/tasks/main.yml
+++ b/roles/local_storage/tasks/main.yml
@@ -19,6 +19,7 @@
 - name: Check if file system source is a device.
   ansible.builtin.stat:
     path: "{{ item.device }}"
+    follow: true
   register: local_storage_device_stat
   loop: "{{ local_mounts }}"
 

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -329,10 +329,7 @@ all:
           perc_devices: true
           local_mounts:
             - mount_point: '/mnt/umcgst15'
-              device: dynamic  # A value must be present in order to update it on-the-fly during role execution.
-              label: local
-              perc_controller: 0
-              perc_virtual_drive: 239
+              device: '/dev/mapper/data-hdd'
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'
@@ -340,7 +337,7 @@ all:
                 rw,relatime
                 {%- if ansible_facts['os_family'] == 'RedHat' and
                        ansible_facts['distribution_major_version'] >= '8' -%}
-                  ,nofail,x-systemd.device-timeout=10
+                  ,nofail,x-systemd.device-timeout=10,x-systemd.automount
                 {%- endif -%}
               type: xfs
     smb_server:

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -329,7 +329,7 @@ all:
           perc_devices: true
           local_mounts:
             - mount_point: '/mnt/umcgst15'
-              device: '/dev/mapper/data-hdd'
+              device: '/dev/data/hdd'
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -310,7 +310,7 @@ all:
           perc_devices: true
           local_mounts:
             - mount_point: '/mnt/umcgst16'
-              device: '/dev/mapper/data-hdd'
+              device: '/dev/data/hdd'
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -310,7 +310,7 @@ all:
           perc_devices: true
           local_mounts:
             - mount_point: '/mnt/umcgst16'
-              device: '/dev/data/hdd'
+              device: '/dev/mapper/data-hdd'
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'
@@ -318,7 +318,7 @@ all:
                 rw,relatime
                 {%- if ansible_facts['os_family'] == 'RedHat' and
                        ansible_facts['distribution_major_version'] >= '8' -%}
-                  ,nofail,x-systemd.device-timeout=10
+                  ,nofail,x-systemd.device-timeout=10,x-systemd.automount
                 {%- endif -%}
               type: xfs
     smb_server:


### PR DESCRIPTION
I realized why the caching option was not enabled at the `cf-storage`

 - it initially works, but after a reboot it is not automatically mounted - this has to do with how `systemd` handles boot of `/etc/fstab` - I guess I hit this issue when working on cf-storage but not realized it back then,
 - if I use only LVM (without nvme caching) the storage gets mounted just fine, but not when nvme caching is enabled.

Adding the `x-systemd.automount` to fstab fixed it.