### PR TITLE
Cleanup: removed deprecated way of managing quota limits.

### DIFF
--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -98,8 +98,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     create_ldap: false
 totp:
   machines: "{{ groups['jumphost'] }}"

--- a/group_vars/copperfist_cluster/vars.yml
+++ b/group_vars/copperfist_cluster/vars.yml
@@ -100,8 +100,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     create_ldap: false
 totp:
   machines: "{{ groups['jumphost'] }}"

--- a/group_vars/forkhead_cluster/vars.yml
+++ b/group_vars/forkhead_cluster/vars.yml
@@ -43,8 +43,6 @@ ldap_domains:
     user_member_of: groupMembership
     group_member: memberUid
     group_object_class: groupofnames
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     create_ldap: true
     # ldap_db_index: 3  # Indices up to 2 are already used by default for the "config", "monitor" and "example" databases.
     replication_provider_uri: ldap://172.19.34.180

--- a/group_vars/nibbler_cluster/vars.yml
+++ b/group_vars/nibbler_cluster/vars.yml
@@ -126,21 +126,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    #
-    # LDAP is case insensitive, but we use lowercase only for quota field names,
-    # so we can use simple literal strings in comparisons as opposed to regexes
-    # to handle differences in UPPERCASE vs. lowercase.
-    #
-    # The UPPERCASE "LFS" in {{ ldap_domains[domain]['group_quota_*_limit_template'] }} Ansible variables
-    # is a required placeholder that will get replaced with the value of the Logical File System (LFS)
-    # for which we will try to fetch quota limits from the LDAP.
-    # E.g. with
-    #     group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
-    # the fieldname/key used to lookup the soft quota limit for the prm01 LFS is
-    #     ruggroupumcgquotaprm01soft
-    #
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     listserv_mailinglist: UMCG-HPC
 pam_weblogin:
   machines: "{{ groups['jumphost'] }}"

--- a/group_vars/talos_cluster/vars.yml
+++ b/group_vars/talos_cluster/vars.yml
@@ -98,21 +98,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    #
-    # LDAP is case insensitive, but we use lowercase only for quota field names,
-    # so we can use simple literal strings in comparisons as opposed to regexes
-    # to handle differences in UPPERCASE vs. lowercase.
-    #
-    # The UPPERCASE "LFS" in {{ ldap_domains[domain]['group_quota_*_limit_template'] }} Ansible variables
-    # is a required placeholder that will get replaced with the value of the Logical File System (LFS)
-    # for which we will try to fetch quota limits from the LDAP.
-    # E.g. with
-    #     group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
-    # the fieldname/key used to lookup the soft quota limit for the prm01 LFS is
-    #     ruggroupumcgquotaprm01soft
-    #
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     # listserv_mailinglist: Be careful not to use a production mailinglist for testing!
 pam_weblogin:
   machines: "{{ groups['jumphost'] }}"

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -111,21 +111,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    #
-    # LDAP is case insensitive, but we use lowercase only for quota field names,
-    # so we can use simple literal strings in comparisons as opposed to regexes
-    # to handle differences in UPPERCASE vs. lowercase.
-    #
-    # The UPPERCASE "LFS" in {{ ldap_domains[domain]['group_quota_*_limit_template'] }} Ansible variables
-    # is a required placeholder that will get replaced with the value of the Logical File System (LFS)
-    # for which we will try to fetch quota limits from the LDAP.
-    # E.g. with
-    #     group_quota_soft_limit_template: 'ruggroupumcgquotaLFSsoft'
-    # the fieldname/key used to lookup the soft quota limit for the prm01 LFS is
-    #     ruggroupumcgquotaprm01soft
-    #
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
 pam_weblogin:
   machines: "{{ groups['jumphost'] }}"
   excluded:

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -137,8 +137,6 @@ ldap_domains:
     user_expiration_date: loginExpirationTime
     group_member: memberUid
     group_object_class: groupofnames
-    group_quota_soft_limit_template: ruggroupumcgquotaLFSsoft
-    group_quota_hard_limit_template: ruggroupumcgquotaLFS
     listserv_mailinglist: GD
     create_ldap: false
 totp:

--- a/roles/sssd/defaults/main.yml
+++ b/roles/sssd/defaults/main.yml
@@ -13,8 +13,6 @@ use_ldap: true  # needed for the sshd template
 #    user_object_class: posixAccount
 #    user_ssh_public_key_attr: sshPublicKey
 #    group_object_class: ''
-#    group_quota_soft_limit_template: ''
-#    group_quota_hard_limit_template: ''
 #
 # Example of structure of ldap_credentials variable in group_vars/.../secrets.yml
 # At least a read-only account is required to query the LDAP.

--- a/roles/sssd/templates/readonly-ldapsearch-credentials.bash
+++ b/roles/sssd/templates/readonly-ldapsearch-credentials.bash
@@ -16,7 +16,5 @@ declare -A domain_configs=(
     [{{ ldap_domain }}_user_expiration_date]='{{ ldap_config['user_expiration_date'] | default('loginExpirationTime') }}'
     [{{ ldap_domain }}_user_expiration_regex]='{{ ldap_config['user_expiration_regex'] | default('^([0-9]{4})([0-9]{2})([0-9]{2}).+Z$') }}'
     [{{ ldap_domain }}_group_object_class]='{{ ldap_config['group_object_class'] | default('posixGroup') }}'
-    [{{ ldap_domain }}_group_quota_soft_limit_template]='{{ ldap_config['group_quota_soft_limit_template'] | default('quotaLFSsoft') }}'
-    [{{ ldap_domain }}_group_quota_hard_limit_template]='{{ ldap_config['group_quota_hard_limit_template'] | default('quotaLFShard') }}'
 {% endfor %}
 )


### PR DESCRIPTION
Deleted old variables that were used when we managed quota using fields from the IDVault. This functionality is no longer used.