### PR TITLE
known_hosts: deploy on all nodes

### DIFF
--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -34,7 +34,5 @@
     external_stack: "{{ item }}"
   when:
     - ssh_client_configs is defined
-    - inventory_hostname in groups['jumphost'] | default([]) or
-      inventory_hostname in groups['cluster'] | default([])
   loop: "{{ ssh_client_configs }}"
 ...


### PR DESCRIPTION
I think these two lines are too restrictive for a part of this role which simply adds extra certificate authorities to a system's known_hosts file.

Logs library does not have jumphost and cluster server. Same goes for Jenkins and new p2solo. This makes those machines skip. If there is `ssh_config` defined for another cluster, then it should not skip them at all.