### PR TITLE
Slurm role: Bugfix job_submit.lua plugin.

### DIFF
--- a/roles/slurm/templates/job_submit.lua.el8.with_sponsors.j2
+++ b/roles/slurm/templates/job_submit.lua.el8.with_sponsors.j2
@@ -365,7 +365,7 @@ function slurm_job_submit(job_desc, part_list, submit_uid)
                 slurm.log_debug("QoS %s listed in AllowQos %s: Assigned partition %s to job.", tostring(job_desc.qos), tostring(part.allow_qos), tostring(name))
             end
         elseif part.deny_qos ~= nil then
-            if not string.find(string(part.deny_qos), string(job_desc.qos), 1, true) then
+            if not string.find(tostring(part.deny_qos), tostring(job_desc.qos), 1, true) then
                 part_names[#part_names+1] = tostring(name)
                 slurm.log_debug("QoS %s not listed in DenyQos %s: Assigned partition %s to job.", tostring(job_desc.qos), tostring(part.deny_qos), tostring(name))
             end

--- a/roles/slurm/templates/job_submit.lua.el8.with_sponsors.j2
+++ b/roles/slurm/templates/job_submit.lua.el8.with_sponsors.j2
@@ -360,12 +360,12 @@ function slurm_job_submit(job_desc, part_list, submit_uid)
     for name, part in pairs(part_list) do
         slurm.log_debug("Parsed partition %s with AllowQos %s and DenyQos %s.", tostring(name), tostring(part.allow_qos), tostring(part.deny_qos))
         if part.allow_qos ~= nil then
-            if string.match(part.allow_qos, job_desc.qos) then
+            if string.find(tostring(part.allow_qos), tostring(job_desc.qos), 1, true) then
                 part_names[#part_names+1] = tostring(name)
                 slurm.log_debug("QoS %s listed in AllowQos %s: Assigned partition %s to job.", tostring(job_desc.qos), tostring(part.allow_qos), tostring(name))
             end
         elseif part.deny_qos ~= nil then
-            if not string.match(part.deny_qos, job_desc.qos) then
+            if not string.find(string(part.deny_qos), string(job_desc.qos), 1, true) then
                 part_names[#part_names+1] = tostring(name)
                 slurm.log_debug("QoS %s not listed in DenyQos %s: Assigned partition %s to job.", tostring(job_desc.qos), tostring(part.deny_qos), tostring(name))
             end


### PR DESCRIPTION
Bugfix for `job_submit.lua plugin`: Switch from `string.match` to `string.find` to ensure literal string matching and prevent dashes in sub-QoS levels from getting interpreted as special characters.