### PR TITLE
Applied fix for "xfs_quota command not found" error.

### DIFF
--- a/roles/logins/templates/set_quota.sh.j2
+++ b/roles/logins/templates/set_quota.sh.j2
@@ -15,8 +15,13 @@ inodes_hard="{{ user_quota_on_root_partition['inodes_hard'] }}"
 
 homedir="$(getent passwd "${PAM_USER}"| cut -d: -f6)"
 if [[ "${homedir}" =~ ^/home/* ]]; then
-	xfs_quota -x -c "limit bsoft=${blocks_soft} bhard=${blocks_hard} isoft=${inodes_soft} ihard=${inodes_hard} ${PAM_USER}" /
-	logger --tag set_quota --priority auth.info "xfs_quota -x -c \"limit bsoft=${blocks_soft} bhard=${blocks_hard} isoft=${inodes_soft} ihard=${inodes_hard} ${PAM_USER}\" /"
+	applied_quota="$(/sbin/xfs_quota -x -c "limit bsoft=${blocks_soft} bhard=${blocks_hard} isoft=${inodes_soft} ihard=${inodes_hard} ${PAM_USER}" / 2>&1)"
+	success="${?}"
+	if [[ "${success}" -eq 0 ]]; then
+		logger --tag set_quota --priority auth.info "xfs_quota -x -c \"limit bsoft=${blocks_soft} bhard=${blocks_hard} isoft=${inodes_soft} ihard=${inodes_hard} ${PAM_USER}\" /"
+	else
+		logger --tag set_quota --priority auth.err "${applied_quota:-}"
+	fi
 else
 	logger --tag set_quota --priority auth.info "Skipping user ${PAM_USER}."
 fi


### PR DESCRIPTION
Applied fix for "`xfs_quota` command not found" error when running in PAM stack. Added check and log failure to syslog.