### PR TITLE
Fixed bug when setting XFS inode quota limits.

### DIFF
--- a/group_vars/data_transfer.yml
+++ b/group_vars/data_transfer.yml
@@ -52,6 +52,6 @@ local_mounts:
 user_quota_on_root_partition:
   blocks_soft: 512K
   blocks_hard: 1024K
-  inodes_soft: 8k
-  inodes_hard: 10k
+  inodes_soft: 500
+  inodes_hard: 1000
 ...

--- a/group_vars/jumphost.yml
+++ b/group_vars/jumphost.yml
@@ -37,6 +37,6 @@ managed_yum_repos:
 user_quota_on_root_partition:
   blocks_soft: 512K
   blocks_hard: 1024K
-  inodes_soft: 8k
-  inodes_hard: 10k
+  inodes_soft: 500
+  inodes_hard: 1000
 ...

--- a/group_vars/user_interface.yml
+++ b/group_vars/user_interface.yml
@@ -2,6 +2,6 @@
 user_quota_on_root_partition:
   blocks_soft: 2G
   blocks_hard: 3G
-  inodes_soft: 32k
-  inodes_hard: 64k
+  inodes_soft: 32000
+  inodes_hard: 64000
 ...


### PR DESCRIPTION
Fixed bug when setting XFS inode quota limits: values do not support units and must be integer.