### PR TITLE
Bugfix to re-enable automatic cleanup on data transfer servers.

### DIFF
--- a/roles/sssd/templates/readonly-ldapsearch-credentials.bash
+++ b/roles/sssd/templates/readonly-ldapsearch-credentials.bash
@@ -14,7 +14,7 @@ declare -A domain_configs=(
     [{{ ldap_domain }}_user_object_class]='{{ ldap_config['user_object_class'] | default('posixAccount') }}'
     [{{ ldap_domain }}_user_ssh_public_key]='{{ ldap_config['user_ssh_public_key'] | default('sshPublicKey') }}'
     [{{ ldap_domain }}_user_expiration_date]='{{ ldap_config['user_expiration_date'] | default('loginExpirationTime') }}'
-    [{{ ldap_domain }}_user_expiration_regex]='{{ ldap_config['user_expiration_regex'] | default('^([0-9]{4})([0-9]{2})([0-9]{2}).+Z$') }}'
+    [{{ ldap_domain }}_user_expiration_regex]='{{ ldap_config['user_expiration_regex'] | default('^' + ldap_config['user_expiration_date'] | default('loginExpirationTime') + ': +([0-9]{4})([0-9]{2})([0-9]{2}).+Z$') }}'
     [{{ ldap_domain }}_group_object_class]='{{ ldap_config['group_object_class'] | default('posixGroup') }}'
 {% endfor %}
 )


### PR DESCRIPTION
Bugfix to get the correct account expiration dates from the LDAP instances in order to make the automatic cleanup on nb-transfer work again.