### PR TITLE
Updates for new GPU node on Vaxtron and improved handling of Slurm node features.

### DIFF
--- a/group_vars/compute_node.yml
+++ b/group_vars/compute_node.yml
@@ -7,4 +7,22 @@ local_mounts:
     mounted_mode: '0755'
     mount_options: rw,relatime,nofail,x-systemd.device-timeout=10
     type: ext4
+slurm_features: "{%- set slurm_feature_list =
+      lfs_mounts
+        | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+        | rejectattr('rw_machines', 'undefined')
+        | selectattr('rw_machines', 'contains', inventory_hostname)
+      | union(
+        lfs_mounts
+          | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+          | rejectattr('ro_machines', 'undefined')
+          | selectattr('ro_machines', 'contains', inventory_hostname))
+      | map(attribute='lfs') -%}
+    {%- if gpu_count | default(0) >= 1 -%}
+      {%- set slurm_feature_list = slurm_feature_list | default([]) | union(['gpu', gpu_type]) -%}
+    {%- endif -%}
+    {%- if 'dragen' in inventory_hostname -%}
+      {%- set slurm_feature_list = slurm_feature_list | default([]) | union(['dragen']) -%}
+    {%- endif -%}
+    {{ slurm_feature_list | sort | join(',') }}"
 ...

--- a/group_vars/user_interface.yml
+++ b/group_vars/user_interface.yml
@@ -4,4 +4,19 @@ user_quota_on_root_partition:
   blocks_hard: 3G
   inodes_soft: 32000
   inodes_hard: 64000
+slurm_features: "{%- set slurm_feature_list =
+      lfs_mounts
+        | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+        | rejectattr('rw_machines', 'undefined')
+        | selectattr('rw_machines', 'contains', inventory_hostname)
+      | union(
+        lfs_mounts
+          | selectattr('lfs', 'search', '((tmp)|(rsc)|(prm)|(dat))[0-9]+$')
+          | rejectattr('ro_machines', 'undefined')
+          | selectattr('ro_machines', 'contains', inventory_hostname))
+      | map(attribute='lfs') -%}
+    {%- if gpu_count | default(0) >= 1 -%}
+      {%- set slurm_feature_list = slurm_feature_list | default([]) | union(['gpu', gpu_type]) -%}
+    {%- endif -%}
+    {{ slurm_feature_list | sort | join(',') }}"
 ...

--- a/group_vars/vaxtron_cluster/ip_addresses.yml
+++ b/group_vars/vaxtron_cluster/ip_addresses.yml
@@ -99,6 +99,13 @@ ip_addresses:
     vt_internal_management:
       address: 10.10.1.198
       netmask: /32
+  vt-node-c01:
+    lustre:
+      address: 172.23.12.236
+      netmask: /32
+    vt_internal_management:
+      address: 10.10.1.162
+      netmask: /32
   vt-repo:
     vt_internal_management:
       address: 10.10.1.71

--- a/group_vars/vaxtron_cluster/ssh_client_settings.yml
+++ b/group_vars/vaxtron_cluster/ssh_client_settings.yml
@@ -1,12 +1,11 @@
 ---
 ssh_client_jumphosts:
   - alias: foyer
-    hostname: 195.169.23.114
+    hostname: foyer.hpc.rug.nl
 
 ssh_client_known_hosts: "\
   @cert-authority \
   foyer*,\
-  195.169.23.114,\
   *vt-sai,\
   *vt-dai,\
   *vaxtron,\

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -24,14 +24,14 @@ slurm_partitions:
     local_disk: "{{ groups['cpu_r6625'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
     features: "{{ groups['cpu_r6625'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.25G" DenyQos=ds-short,ds-medium,ds-long'
-  - name: cpu_xe7745  # Must be in sync with group listed in Ansible inventory.
+  - name: gpu_xe7745  # Must be in sync with group listed in Ansible inventory.
     default: no
     nodes: "{{ stack_prefix }}-node-c01"  # Must be in sync with Ansible hostnames listed in inventory.
-    max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['cpu_xe7745']|list|length }}{% else %}1{% endif %}"
-    max_cores_per_node: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
-    max_mem_per_node: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
-    local_disk: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
-    features: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
+    max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['gpu_xe7745']|list|length }}{% else %}1{% endif %}"
+    max_cores_per_node: "{{ groups['gpu_xe7745'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
+    max_mem_per_node: "{{ groups['gpu_xe7745'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
+    local_disk: "{{ groups['gpu_xe7745'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
+    features: "{{ groups['gpu_xe7745'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.1G" DenyQos=ds-short,ds-medium,ds-long'
   - name: user_interface  # Must be in sync with group listed in Ansible inventory.
     default: no

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -24,6 +24,15 @@ slurm_partitions:
     local_disk: "{{ groups['cpu_r6625'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
     features: "{{ groups['cpu_r6625'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
     extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.25G" DenyQos=ds-short,ds-medium,ds-long'
+  - name: cpu_xe7745  # Must be in sync with group listed in Ansible inventory.
+    default: no
+    nodes: "{{ stack_prefix }}-node-c01"  # Must be in sync with Ansible hostnames listed in inventory.
+    max_nodes_per_job: "{% if slurm_allow_jobs_to_span_nodes is defined and slurm_allow_jobs_to_span_nodes is true %}{{ groups['cpu_xe7745']|list|length }}{% else %}1{% endif %}"
+    max_cores_per_node: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_max_cpus_per_node') | first }}"
+    max_mem_per_node: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
+    local_disk: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
+    features: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
+    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
   - name: user_interface  # Must be in sync with group listed in Ansible inventory.
     default: no
     nodes: "{{ slurm_cluster_name }}"  # Must be in sync with Ansible hostnames listed in inventory.

--- a/group_vars/vaxtron_cluster/vars.yml
+++ b/group_vars/vaxtron_cluster/vars.yml
@@ -14,7 +14,7 @@ slurm_partitions:
     max_mem_per_node: "{{ groups['cpu_r750'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
     local_disk: "{{ groups['cpu_r750'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
     features: "{{ groups['cpu_r750'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
-    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
+    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.05G" DenyQos=ds-short,ds-medium,ds-long'
   - name: cpu_r6625  # Must be in sync with group listed in Ansible inventory.
     default: yes
     nodes: "{{ stack_prefix }}-node-b[01-06]"  # Must be in sync with Ansible hostnames listed in inventory.
@@ -32,7 +32,7 @@ slurm_partitions:
     max_mem_per_node: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_max_mem_per_node') | first }}"
     local_disk: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_local_disk') | first | default(0, true) }}"
     features: "{{ groups['cpu_xe7745'] | map('extract', hostvars, 'slurm_features') | first | default('none') }}"
-    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.5G" DenyQos=ds-short,ds-medium,ds-long'
+    extra_options: 'TRESBillingWeights="CPU=1.0,Mem=0.1G" DenyQos=ds-short,ds-medium,ds-long'
   - name: user_interface  # Must be in sync with group listed in Ansible inventory.
     default: no
     nodes: "{{ slurm_cluster_name }}"  # Must be in sync with Ansible hostnames listed in inventory.
@@ -638,7 +638,6 @@ sudoers:
 #           - regular_group_placeholder
 #         mode: '2770'
 #         owner: root
-
 #
 # Shared storage related variables
 #

--- a/roles/gpu/README.md
+++ b/roles/gpu/README.md
@@ -32,25 +32,38 @@ automatically when a new kernel is installed.
     - reboots the machine
     - checks if number of GPU devices reported from `nvidia-smi` is same as in `gpu_count`
 
-## Solved issues - described
+The `nvidia-persistenced.service` service script was modified based on trial and error,
+but is taken mostly from the example files that come with the driver installation,
+and can be found in the folder 
 
-`gpu_count` is needed to install the driver, since any other `automatic` detection is
-failing sooner or later. To list few:
+    /usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2
+
+## Known issues and workarounds
+
+#### Finding the correct number of GPUs
+
+`gpu_count` is required to install the driver, since any other `automatic` detection is failing sooner or later.
+To list few:
 
  - `lspci` found one nvidia device when there were 8,
  - `nvidia-smi` reported no device found, when it actually should found some,
  - and `nvidia-smi` had up-and-running 3 GPU's when it should be 8
 
-This was just while testing, but I can expect more.
+Therefore `gpu_count` instead defines the correct "truth", which the role can test - that is if all the GPUs are actually working correctly. 
 
-`gpu_count` instead defines the correct "truth", and can test aginst it - that is
-if all the GPUs are actually working correctly.
+#### A40
 
-Persistenced service script was modified based on trial and error, but is taken
-mostly from the example files that come with the driver installation, and can be
-found in the folder 
+When the NVIDIA GSP firmware is anabled the cards may vanish from PCI bus in a Liqid chassis when the server is rebooted,
+which then requires rebooting the entire Liqid chassis. Therefore the GSP firmware is disabled for A40 cards.
 
-    /usr/share/doc/NVIDIA_GLX-1.0/samples/nvidia-persistenced-init.tar.bz2
+#### RTX6000
+
+These cards have issues with CUDA 13.2.x and Kernel Address Space Layout Randomization (KASLR).
+With some NVidia driver + Linux kernel combinations you may get errors, whith others the kernel may crash taking the machine offline.
+
+See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#known-issues
+
+Therefore KASLR is currently disabled for the RTX6000 cards.
 
 ## Other comments
 

--- a/roles/gpu/README.md
+++ b/roles/gpu/README.md
@@ -1,4 +1,4 @@
-# NVidia GPU installation role for Centos 7
+# NVidia GPU installation role
 
 This role follows the latest instructions of the newest version of available
 drivers, avaiable at [NVIDIA CUDA Installation Guide for
@@ -11,18 +11,19 @@ installed by downloading and running the cuda .run file.
 The driver features Dynamic Kernel Module Support (DKMS) and will be recompiled
 automatically when a new kernel is installed.
 
-
 ## Role outline
 
-- it expects `gpu_count` variable to be defined per invididual machine, and then
+- it expects the `gpu_count`, `gpu_type` and `gpu_driver_version` variables to be defined, and then
   - it attempts to gather the GPU device status by running `nvidia-smi` command
   - it detects the NVidia driver version
   - executes the GPU driver installation tasks
     - checks if machine needs to be rebooted and reboots it, if needed
-    - yum install on machine packages that is needed for driver install and compile
-    - yum also installs a (after a reboot - is correctly matching) version of kernel
-    - downloads the cuda .run driver file from nvidia website (version defined in defualts)
+    - installs packages that are required for installing and compiling the driver
+    - installs a (after a reboot) a matching version of kernel
+    - downloads the cuda .run driver file from nvidia website (version defined in `gpu_driver_version`)
     - installs and compile the Dynamic Kernel Module Support driver
+    - by default it tries to install `gpu_kernel_module_type: open`, which is the only version available for newer NVidia GPUs.
+      For older cards like the A40 you may need to set `gpu_kernel_module_type: proprietary`
   - execute configuration if `gpu_count` defined
     - creates a local nvidia (defaults GID 601) group
     - creates a local nvidia (defaults UID 601) user

--- a/roles/gpu/defaults/main.yml
+++ b/roles/gpu/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-gpu_driver_version: '590.48.01'
+# gpu_driver_version has no defaults: must be specified for specific machines in static_inventory/{{ stackname }}.yml
 gpu_url_dir: 'https://download.nvidia.com/XFree86/Linux-x86_64/{{ gpu_driver_version }}/'
 gpu_runfile: 'NVIDIA-Linux-x86_64-{{ gpu_driver_version }}.run'
 nvidia_user: nvidia

--- a/roles/gpu/handlers/main.yml
+++ b/roles/gpu/handlers/main.yml
@@ -1,5 +1,21 @@
 ---
-- name: Enable / restart nvidia-persistenced service
+#
+# Important: maintain correct handler order.
+# Handlers are executed in the order in which they are defined
+# and not in the order in which they are listed in a "notify: handler_name" statement!
+#
+- name: Rebuild GRUB config.
+  ansible.builtin.shell: |
+         timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+         cp -v '/boot/grub2/grub.cfg' "/boot/grub2/grub.cfg.ansible_backup_${timestamp}"
+         grub2-mkconfig --update-bls-cmdline -o '/boot/grub2/grub.cfg'
+  args:
+    executable: '/bin/bash'
+  changed_when: true
+  become: true
+  listen: rebuild_grub_config_by_gpu_role
+
+- name: Enable / restart nvidia-persistenced service.
   ansible.builtin.systemd:
     name: nvidia-persistenced.service
     state: restarted
@@ -8,17 +24,17 @@
   become: true
   listen: 'nvidia_service'
 
-- name: Rebuild initramfs
+- name: Rebuild initramfs.
   ansible.builtin.command: dracut -f
-  notify: reboot_server
+  notify: reboot_by_gpu_role
   register: dracut_reg
   changed_when: dracut_reg.rc == 0
   listen: 'dracut'
   become: true
 
-- name: Restart server
+- name: Restart server.
   ansible.builtin.reboot:
-    msg: "Reboot initiated by Ansible"
-  listen: 'reboot_server'
+    msg: 'Reboot initiated by Ansible "gpu" role from League of Robots playbook/repo.'
+  listen: reboot_by_gpu_role
   become: true
 ...

--- a/roles/gpu/tasks/disable_kaslr.yml
+++ b/roles/gpu/tasks/disable_kaslr.yml
@@ -28,30 +28,13 @@
     - "'GRUB_CMDLINE_LINUX=' not in search_grub_cmdline_linux_in_grub_config_by_gpu_role['stdout']"
     - "'GRUB_CMDLINE_LINUX_DEFAULT=' not in search_grub_cmdline_linux_default_in_grub_config_by_gpu_role['stdout']"
 
-- name: Check if we need to add or update "nokaslr" for GRUB_CMDLINE_LINUX* in /etc/default/grub.
+- name: Check if we need to add "nokaslr" to GRUB_CMDLINE_LINUX* in /etc/default/grub.
   ansible.builtin.command:
     cmd: |
-         grep 'GRUB_CMDLINE_LINUX\(_DEFAULT\)\?=.*kaslr.*' /etc/default/grub
-  register: search_kaslr_in_grub_config_by_gpu_role
+         grep 'GRUB_CMDLINE_LINUX\(_DEFAULT\)\?=.*nokaslr.*' /etc/default/grub
+  register: search_nokaslr_in_grub_config_by_gpu_role
   changed_when: false
-  failed_when: search_kaslr_in_grub_config_by_gpu_role['rc'] >= 2
-
-- name: Update "nokaslr" in GRUB config.
-  ansible.builtin.lineinfile:
-    path: /etc/default/grub
-    backup: true
-    backrefs: true
-    regexp: '^(GRUB_CMDLINE_LINUX(_DEFAULT)?=\")([^\"]*)\s+(no)?kaslr([^\"]*\")$'
-    line: '\1\3 nokaslr\5'
-    owner: root
-    group: root
-    mode: '0644'
-  when:
-    - "'kaslr' in search_kaslr_in_grub_config_by_gpu_role['stdout']"
-  notify:
-    - rebuild_grub_config_by_gpu_role
-    - reboot_by_gpu_role
-  become: true
+  failed_when: search_nokaslr_in_grub_config_by_gpu_role['rc'] >= 2
 
 - name: Add "nokaslr" to GRUB config.
   ansible.builtin.lineinfile:
@@ -63,7 +46,7 @@
     owner: root
     group: root
     mode: '0644'
-  when: "'kaslr' not in search_kaslr_in_grub_config_by_gpu_role['stdout']"
+  when: "'nokaslr' not in search_nokaslr_in_grub_config_by_gpu_role['stdout']"
   notify:
     - rebuild_grub_config_by_gpu_role
     - reboot_by_gpu_role
@@ -72,9 +55,9 @@
 - name: 'Check if GRUB configs needs to be rebuild for the running kernel.'
   ansible.builtin.command:
     cmd: grep 'nokaslr' /proc/cmdline
-  register: search_kaslr_in_kernel_params
-  changed_when: search_kaslr_in_kernel_params['rc'] == 1
-  failed_when: search_kaslr_in_kernel_params['rc'] >= 2
+  register: search_nokaslr_in_kernel_params
+  changed_when: search_nokaslr_in_kernel_params['rc'] == 1
+  failed_when: search_nokaslr_in_kernel_params['rc'] >= 2
   notify:
     - rebuild_grub_config_by_gpu_role
     - reboot_by_gpu_role

--- a/roles/gpu/tasks/disable_kaslr.yml
+++ b/roles/gpu/tasks/disable_kaslr.yml
@@ -82,4 +82,3 @@
 - name: Flush handlers.
   ansible.builtin.meta: flush_handlers
 ...
-

--- a/roles/gpu/tasks/disable_kaslr.yml
+++ b/roles/gpu/tasks/disable_kaslr.yml
@@ -1,0 +1,85 @@
+---
+- name: Check if GRUB_CMDLINE_LINUX is present in /etc/default/grub.
+  ansible.builtin.command:
+    cmd: "grep 'GRUB_CMDLINE_LINUX=' /etc/default/grub"
+  register: search_grub_cmdline_linux_in_grub_config_by_gpu_role
+  changed_when: false
+  failed_when: search_grub_cmdline_linux_in_grub_config_by_gpu_role['rc'] >= 2
+
+- name: Check if GRUB_CMDLINE_LINUX_DEFAULT is present in /etc/default/grub.
+  ansible.builtin.command:
+    cmd: "grep 'GRUB_CMDLINE_LINUX_DEFAULT=' /etc/default/grub"
+  register: search_grub_cmdline_linux_default_in_grub_config_by_gpu_role
+  changed_when: false
+  failed_when: search_grub_cmdline_linux_default_in_grub_config_by_gpu_role['rc'] >= 2
+
+- name: Fail if Grub config is in an unsupported state.
+  ansible.builtin.debug:
+    msg: |
+         ***********************************************************************************************************
+         IMPORTANT: Manual work!
+                    Both GRUB_CMDLINE_LINUX and GRUB_CMDLINE_LINUX_DEFAULT are missing from /etc/default/grub
+                    Check the Grub config and documentation ...
+         ***********************************************************************************************************
+  when:
+    - "'GRUB_CMDLINE_LINUX=' not in search_grub_cmdline_linux_in_grub_config_by_gpu_role['stdout']"
+    - "'GRUB_CMDLINE_LINUX_DEFAULT=' not in search_grub_cmdline_linux_default_in_grub_config_by_gpu_role['stdout']"
+  failed_when:
+    - "'GRUB_CMDLINE_LINUX=' not in search_grub_cmdline_linux_in_grub_config_by_gpu_role['stdout']"
+    - "'GRUB_CMDLINE_LINUX_DEFAULT=' not in search_grub_cmdline_linux_default_in_grub_config_by_gpu_role['stdout']"
+
+- name: Check if we need to add or update "nokaslr" for GRUB_CMDLINE_LINUX* in /etc/default/grub.
+  ansible.builtin.command:
+    cmd: |
+         grep 'GRUB_CMDLINE_LINUX\(_DEFAULT\)\?=.*kaslr.*' /etc/default/grub
+  register: search_kaslr_in_grub_config_by_gpu_role
+  changed_when: false
+  failed_when: search_kaslr_in_grub_config_by_gpu_role['rc'] >= 2
+
+- name: Update "nokaslr" in GRUB config.
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    backup: true
+    backrefs: true
+    regexp: '^(GRUB_CMDLINE_LINUX(_DEFAULT)?=\")([^\"]*)\s+(no)?kaslr([^\"]*\")$'
+    line: '\1\3 nokaslr\5'
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - "'kaslr' in search_kaslr_in_grub_config_by_gpu_role['stdout']"
+  notify:
+    - rebuild_grub_config_by_gpu_role
+    - reboot_by_gpu_role
+  become: true
+
+- name: Add "nokaslr" to GRUB config.
+  ansible.builtin.lineinfile:
+    path: '/etc/default/grub'
+    backup: true
+    backrefs: true
+    regexp: '^(GRUB_CMDLINE_LINUX(_DEFAULT)?=\")([^\"]*)(\")$'
+    line: '\1\3 nokaslr\4'
+    owner: root
+    group: root
+    mode: '0644'
+  when: "'kaslr' not in search_kaslr_in_grub_config_by_gpu_role['stdout']"
+  notify:
+    - rebuild_grub_config_by_gpu_role
+    - reboot_by_gpu_role
+  become: true
+
+- name: 'Check if GRUB configs needs to be rebuild for the running kernel.'
+  ansible.builtin.command:
+    cmd: grep 'nokaslr' /proc/cmdline
+  register: search_kaslr_in_kernel_params
+  changed_when: search_kaslr_in_kernel_params['rc'] == 1
+  failed_when: search_kaslr_in_kernel_params['rc'] >= 2
+  notify:
+    - rebuild_grub_config_by_gpu_role
+    - reboot_by_gpu_role
+
+- name: Flush handlers.
+  ansible.builtin.meta: flush_handlers
+...
+

--- a/roles/gpu/tasks/driver.yml
+++ b/roles/gpu/tasks/driver.yml
@@ -5,7 +5,7 @@
   failed_when: 'needs_restarting.rc > 1'
   changed_when: 'needs_restarting.rc == 1'
   become: true
-  notify: 'reboot_server'
+  notify: reboot_by_gpu_role
 
 - name: Copy blacklist-nouveau.conf file into modprobe.d to disable Nouveau drivers
   ansible.builtin.copy:
@@ -15,7 +15,20 @@
     group: root
     mode: '0644'
   become: true
-  notify: 'reboot_server'
+  notify: reboot_by_gpu_role
+
+#
+# Workaround: Disable the Kernel Address Space Layout Randomization (KASLR) security feature
+# for GPUs that use the CUDA memory management feature "Heterogeneous Memory Management (HMM)" for
+# "NVIDIA Unified Virtual Memory (UVM)", which currently crashes machines when KASLR is enabled.
+#
+# See https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#known-issues
+#
+- name: "Workaround - disable KASLR or {{ gpu_type }} GPUs that use NVIDIA HMM for NVIDIA UVM."
+  ansible.builtin.include_tasks: disable_kaslr.yml
+  when:
+    - gpu_count|default(0) >= 1 
+    - gpu_type == 'rtx6000'
 
 - name: Reboot system if needed
   ansible.builtin.meta: flush_handlers
@@ -43,24 +56,24 @@
       - wget
   become: true
 
-- name: Download a driver installation file from NVidia
+- name: Download GPU driver installation file.
   ansible.builtin.get_url:
-    url: '{{ gpu_url_dir }}/{{ gpu_runfile }}'
+    url: "{{ gpu_url_dir }}/{{ gpu_runfile }}"
     dest: '/root/{{ gpu_runfile }}'
     mode: '0700'
   become: true
 
-- name: Install driver from .run file
+- name: Install GPU driver.
   ansible.builtin.command:
     cmd: |
          "/root/{{ gpu_runfile }}" --silent --kernel-module-type="{{ gpu_kernel_module_type | default('open') }}"
   register: install_result
   failed_when: install_result.rc != 0
   changed_when: true
-  notify: reboot_server
+  notify: reboot_by_gpu_role
   become: true
 
-- name: Disable NVIDIA GSP firmware
+- name: Disable NVIDIA GSP firmware.
   ansible.builtin.copy:
     dest: /etc/modprobe.d/nvidia-gsp.conf
     content: "options nvidia NVreg_EnableGpuFirmware=0"
@@ -70,15 +83,9 @@
   when: gpu_type == 'a40'
   notify:
     - dracut
-    - reboot_server
+    - reboot_by_gpu_role
   become: true
 
-- name: Flush handlers to trigger dracut and server restart
+- name: Flush handlers.
   ansible.builtin.meta: flush_handlers
-
-- name: Remove installation file
-  ansible.builtin.file:
-    path: '/root/{{ gpu_runfile }}'
-    state: absent
-  become: true
 ...

--- a/roles/gpu/tasks/driver.yml
+++ b/roles/gpu/tasks/driver.yml
@@ -27,7 +27,7 @@
 - name: "Workaround - disable KASLR or {{ gpu_type }} GPUs that use NVIDIA HMM for NVIDIA UVM."
   ansible.builtin.include_tasks: disable_kaslr.yml
   when:
-    - gpu_count|default(0) >= 1 
+    - gpu_count|default(0) >= 1
     - gpu_type == 'rtx6000'
 
 - name: Reboot system if needed

--- a/roles/gpu/tasks/driver.yml
+++ b/roles/gpu/tasks/driver.yml
@@ -88,4 +88,10 @@
 
 - name: Flush handlers.
   ansible.builtin.meta: flush_handlers
+
+- name: Remove installation file.
+  ansible.builtin.file:
+    path: '/root/{{ gpu_runfile }}'
+    state: absent
+  become: true
 ...

--- a/roles/gpu/tasks/driver.yml
+++ b/roles/gpu/tasks/driver.yml
@@ -51,7 +51,9 @@
   become: true
 
 - name: Install driver from .run file
-  ansible.builtin.command: '/root/{{ gpu_runfile }} --silent --kernel-module-type=proprietary'
+  ansible.builtin.command:
+    cmd: |
+         "/root/{{ gpu_runfile }}" --silent --kernel-module-type="{{ gpu_kernel_module_type | default('open') }}"
   register: install_result
   failed_when: install_result.rc != 0
   changed_when: true

--- a/roles/gpu/tasks/main.yml
+++ b/roles/gpu/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check how many NVidia devices are up and running (might take some time).
   ansible.builtin.command: 'nvidia-smi -L'
   register: smi
-  when: gpu_count|default(0) >= 1
+  when: gpu_count | default(0) >= 1
   changed_when: false
   failed_when: false
 
@@ -11,15 +11,16 @@
   register: modinfo
   changed_when: false
   failed_when: false
-  when: gpu_count|default(0) >= 1
+  when: gpu_count | default(0) >= 1
 
 - name: Install GPU driver if not all GPU devices are present and working.
   ansible.builtin.include_tasks: driver.yml
-  when: gpu_count|default(0) >= 1 and
-        (( smi.stdout|default([])|lower|regex_findall('nvidia')|length != gpu_count ) or
-        gpu_driver_version not in modinfo.stdout|default("")|regex_search("version:.*"))
+  when:
+    - gpu_count | default(0) >= 1
+    - (( smi.stdout | default([]) | lower | regex_findall('nvidia') | length != gpu_count ) or
+         gpu_driver_version not in modinfo.stdout | default("") | regex_search("version:.*"))
 
 - name: Configure GPU - users, files and services.
   ansible.builtin.include_tasks: configuration.yml
-  when: gpu_count|default(0) >= 1
+  when: gpu_count | default(0) >= 1
 ...

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -189,7 +189,6 @@ all:
           slurm_cores_per_socket: 64
           slurm_real_memory: 515456
           slurm_local_disk: 0
-          slurm_features: 'tmp05'  # Beta-Barrel will replace Zinc-Finger
           slurm_ethernet_interfaces:
             - em1
             - em3
@@ -204,7 +203,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 8 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - 8 * 2048 }}"
               slurm_local_disk: 0
-              slurm_features: 'tmp05,tmp15'
               slurm_ethernet_interfaces:
                 - em1
                 - em3
@@ -283,7 +281,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket * slurm_threads_per_core - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 102400
-              slurm_features: 'tmp15,dragen'
               slurm_weight: 10
               local_yum_repository: true # enable local yum repository
     mit_chaperone:

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -181,7 +181,6 @@ all:
           slurm_cores_per_socket: 64
           slurm_real_memory: 515456
           slurm_local_disk: 0
-          slurm_features: 'tmp06'  # Copper-Fist will replace Leucine-Zipper
           slurm_ethernet_interfaces:
             - em1
             - em3
@@ -196,7 +195,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 8 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - 8 * 2048 }}"
               slurm_local_disk: 0
-              slurm_features: 'tmp06,tmp16'
               slurm_ethernet_interfaces:
                 - em1
                 - em3
@@ -266,7 +264,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket * slurm_threads_per_core - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 102400
-              slurm_features: 'tmp16,dragen'
               slurm_weight: 10
               local_yum_repository: true # enable local yum repository
     mit_chaperone:

--- a/static_inventories/forkhead_cluster.yml
+++ b/static_inventories/forkhead_cluster.yml
@@ -37,7 +37,6 @@ all:
           slurm_cores_per_socket: 4
           slurm_real_memory: 15884
           slurm_local_disk: 0
-          slurm_features: 'tmp12'
           slurm_ethernet_interfaces:
             - eth0
     compute_node:
@@ -51,7 +50,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 0
-              slurm_features: 'tmp12'
               slurm_ethernet_interfaces:
                 - eth0
     chaperone:

--- a/static_inventories/hyperchicken_cluster.yml
+++ b/static_inventories/hyperchicken_cluster.yml
@@ -80,7 +80,6 @@ all:
           slurm_cores_per_socket: 1
           slurm_real_memory: 7680
           slurm_local_disk: 0
-          slurm_features: 'prm09,tmp09'
     compute_node:
       children:
         cpu_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -108,7 +107,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 900
-              slurm_features: 'tmp09'
 administration:
   children:
     sys_admin_interface:

--- a/static_inventories/nibbler_cluster.yml
+++ b/static_inventories/nibbler_cluster.yml
@@ -220,7 +220,6 @@ all:
           slurm_cores_per_socket: 1
           slurm_real_memory: 63786
           slurm_local_disk: 0
-          slurm_features: 'prm02,prm03,rsc02,tmp02'
     compute_node:
       children:
         cpu_r6515:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -267,7 +266,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
-              slurm_features: 'rsc02,tmp02'
               slurm_weight: 5
         gpu_a40:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
@@ -275,7 +273,9 @@ all:
               cloud_flavor: umcg.v1.bm.64-256-440.vlan1338.16a40
               host_type: baremetal
               gpu_count: 12
-              gpu_type: 'a40'
+              gpu_type: a40
+              gpu_driver_version: 590.48.01
+              gpu_kernel_module_type: proprietary
               enable_predictable_network_interface_names: true
               host_networks:
                 - name: vlan1338
@@ -316,7 +316,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 1420000
-              slurm_features: 'rsc02,tmp02,gpu,A40'
               slurm_weight: 10
         cpu_r630:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
@@ -366,7 +365,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
-              slurm_features: 'rsc02,tmp02'
 administration:
   children:
     sys_admin_interface:

--- a/static_inventories/talos_cluster.yml
+++ b/static_inventories/talos_cluster.yml
@@ -123,7 +123,6 @@ all:
           slurm_cores_per_socket: 1
           slurm_real_memory: 7681
           slurm_local_disk: 0
-          slurm_features: 'prm08,tmp08'
     compute_node:
       children:
         cpu_r630:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -173,7 +172,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
-              slurm_features: 'tmp08'
         cpu_r6515:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             tl-node-b01:
@@ -218,7 +216,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 3002000
-              slurm_features: 'tmp08'
         cpu_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             tl-node-c01:
@@ -244,7 +241,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 256 }}"
               slurm_local_disk: 900
-              slurm_features: 'tmp08'
     chaperone:
       hosts:
         tl-chaperone:

--- a/static_inventories/vaxtron_cluster.yml
+++ b/static_inventories/vaxtron_cluster.yml
@@ -115,9 +115,8 @@ all:
                 name: tcp15
           slurm_sockets: 16
           slurm_cores_per_socket: 1
-          slurm_real_memory: 63786
+          slurm_real_memory: 63785
           slurm_local_disk: 0
-          slurm_features: 'prm02,prm03,rsc04,tmp04'
     compute_node:
       children:
         cpu_r750:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -160,7 +159,6 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 3420400
-              slurm_features: 'rsc04,tmp04'
               slurm_weight: 10
         cpu_r6625:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
@@ -202,7 +200,53 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 2850100
-              slurm_features: 'rsc04,tmp04'
+        cpu_xe7745:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
+          hosts:
+            vt-node-c01:
+              cloud_flavor: umcg.v1.bm.128-1536-849.8rtx6000
+              host_type: baremetal
+              gpu_count: 8
+              gpu_type: rtx6000
+              gpu_driver_version: 595.58.03
+              host_networks:
+                - name: "{{ stack_prefix }}_internal_management"
+                  security_group: "{{ stack_prefix }}_cluster"
+                  add_hostname_to_ip_address: true
+                  nmstate_interface:
+                    name: eno16695np0
+                - name: lustre
+                  security_group: "{{ stack_prefix }}_storage"
+                  nmstate_interface:
+                    name: eno17095np0
+                  lnet:
+                    name: tcp15
+              perc_devices: true
+              local_mounts:
+                - mount_point: "{{ slurm_local_scratch_dir }}"
+                  device: '/dev/md0'
+                  label: local
+                  mounted_owner: root
+                  mounted_group: root
+                  mounted_mode: '0755'
+                  mount_options: rw,relatime,nofail,x-systemd.device-timeout=10
+                  type: ext4
+                  md:
+                    raid_level: 0
+                    raid_devices: 5
+                    component_devices:
+                      - /dev/nvme0n1
+                      - /dev/nvme1n1
+                      - /dev/nvme2n1
+                      # NOT /dev/nvme3n1, which is the DELL BOSS card and contains the OS!
+                      - /dev/nvme4n1
+                      - /dev/nvme5n1
+              slurm_sockets: 2
+              slurm_cores_per_socket: 64
+              slurm_real_memory: 1546619
+              slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
+              slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
+              slurm_local_disk: 14376000
+              slurm_weight: 20
 administration:
   children:
     sys_admin_interface:

--- a/static_inventories/vaxtron_cluster.yml
+++ b/static_inventories/vaxtron_cluster.yml
@@ -200,7 +200,7 @@ all:
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
               slurm_local_disk: 2850100
-        cpu_xe7745:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
+        gpu_xe7745:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
           hosts:
             vt-node-c01:
               cloud_flavor: umcg.v1.bm.128-1536-849.8rtx6000

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -216,7 +216,6 @@ all:
           slurm_cores_per_socket: 1
           slurm_real_memory: 15724
           slurm_local_disk: 0
-          slurm_features: 'tmp07'
     compute_node:
       children:
         regular_big_vm:  # Must be item from {{ slurm_partitions }} variable defined in group_vars/{{ stack_name }}/vars.yml
@@ -249,7 +248,6 @@ all:
             slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 2 }}"
             slurm_max_mem_per_node: "{{ slurm_real_memory - slurm_sockets * slurm_cores_per_socket * 512 }}"
             slurm_local_disk: 900
-            slurm_features: 'tmp07'
     mit_chaperone:
       hosts:
         wh-chaperone:


### PR DESCRIPTION
* Added `vt-node-c01` GPU node to Vaxtron cluster.
* `slurm_features` no longer need to specified: they are now automatically gathered based on other vars.