### PR TITLE
BetaBarrel upgrade 2026-04-28

### DIFF
--- a/documentation/Patching_Slurm.md
+++ b/documentation/Patching_Slurm.md
@@ -42,12 +42,6 @@ This must be performed on a _DAI_ with configured ```rpmbuild```.
 
 The following packages should be already installed on the DAI, but run ```yum```/```dnf``` as root to make sure they are there and up to date:
 
-##### On RHEL <= 7.x
-
-```
-yum install munge-devel munge-libs mysql-devel pam-devel pkgconfig readline-devel lua lua-devel lua-posix
-```
-
 ##### On RHEL >= 8.x
 
 Note: Slurm has support for both ```cgroups``` v1 and v2, but support for v2 is only compiled if the dbus development files are present.
@@ -71,26 +65,7 @@ Disabled UID check in **_rpc_stat_jobacct** function of
 slurm-${SLURM_VERSION}/src/slurmd/slurmd/req.c
 ```
 to allow all users to retrieve job stats for all jobs with ```sstat```.
-In Slurm versions <= `22.05.x`:
-```
-    /*
-     * check that requesting user ID is the SLURM UID or root
-     * DISABLED to allow sstat to retrieve job stats for all running jobs of all users.
-     * This may have a negative impact on highly parallellized apps or large clusters.
-     */
-    /*if ((req_uid != uid) && (!_slurm_authorized_user(req_uid))) {
-    *    error("stat_jobacct from uid %ld for job %u " 
-    *             "owned by uid %ld",
-    *             (long) req_uid, req->job_id, (long) uid);
-    *
-    *    if (msg->conn_fd >= 0) {
-    *               slurm_send_rc_msg(msg, ESLURM_USER_ID_MISSING);
-    *               close(fd);
-    *               return ESLURM_USER_ID_MISSING;
-    *    }
-    }*/
-```
-In Slurm versions >= ```23.02.x```:
+
 ```
 	/*
 	 * check that requesting user ID is the Slurm UID or root
@@ -118,11 +93,11 @@ Patch the SLURM ```slurm-${SLURM_VERSION}/slurm.spec``` file.
    Example for Slurm 18.08.8 where the patch level (last number) is ```8```:
    Change:
    ```
-       Release: 8%{?dist}
+       Release:        %{rel}%{?extraver}%{?dist}
    ```
    into:
    ```
-       Release: 8%{?dist}.umcg
+       Release:        %{rel}%{?extraver}%{?dist}.umcg
    ```
    The patch level number may be different for other releases.
  * Change:
@@ -139,22 +114,24 @@ Patch the SLURM ```slurm-${SLURM_VERSION}/slurm.spec``` file.
        %global slurm_source_dir %{name}-%{version}-%{rel}.umcg
    ```
 
-Make sure to also add the ```.umcg``` suffix to the folder name:
+Make sure to also add the ```%{rel}``` and ```.umcg``` suffix to the folder name.
+E.g. when ```%{rel}``` is 1, then:
 
 ```
-mv slurm-${SLURM_VERSION} slurm-${SLURM_VERSION}.umcg
+SLURM_REL=1
+mv slurm-${SLURM_VERSION} slurm-${SLURM_VERSION}-${SLURM_REL}.umcg
 ```
 
 ### 5. Create new tar.bz2 source code archive with patched code
 
 ```
-tar -cvjf ~/rpmbuild/SOURCES/slurm-${SLURM_VERSION}.umcg.tar.bz2  slurm-${SLURM_VERSION}.umcg
+tar -cvjf ~/rpmbuild/SOURCES/slurm-${SLURM_VERSION}-${SLURM_REL}.umcg.tar.bz2  slurm-${SLURM_VERSION}-${SLURM_REL}.umcg
 ```
 
 ### 6. Build patched RPMs
 
 ```
-rpmbuild -ta --with lua --with mysql ~/rpmbuild/SOURCES/slurm-${SLURM_VERSION}.umcg.tar.bz2
+rpmbuild -ta --with lua --with mysql ~/rpmbuild/SOURCES/slurm-${SLURM_VERSION}-${SLURM_REL}.umcg.tar.bz2
 ```
 When successful, add the patched RPMs to our custom repo on the Pulp repo servers for the corresponding infra stacks.
 Don't forget to create a new Pulp publication for the updated repo version and then update the Pulp distribution 

--- a/group_vars/betabarrel_cluster/ssh_client_settings.yml
+++ b/group_vars/betabarrel_cluster/ssh_client_settings.yml
@@ -2,15 +2,11 @@
 ssh_client_jumphosts:
   - alias: bb-porch
     hostname: 195.169.22.140
-  - alias: bb-porch-1336
-    hostname: 195.169.22.156
 
 ssh_client_known_hosts: "\
   @cert-authority \
   bb-porch*,\
   195.169.22.140,\
-  bb-porch-1336*,\
-  195.169.22.156,\
   *bb-transfer*,\
   *bb-storage,\
   *betabarrel,\

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -173,7 +173,7 @@ functional_admin_group: 'umcg-funad'
 functional_users_group: 'umcg-funus'  # For all functional accounts. Used in /etc/security/access.conf.
 hpc_env_prefix: '/apps'
 sponsors:
-  - name: umcg-gd
+  - name: umcg-gd-owners
     slurm_shares: 120
   - name: umcg-mswertz
     slurm_shares: 8
@@ -183,29 +183,29 @@ regular_groups:
   - name: "{{ functional_admin_group }}"
   - name: "{{ functional_users_group }}"
   - name: 'umcg-atd'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-gap'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-gd'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-genomescan'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-gsad'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-gst'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-lab'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-labgnkbh'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-logstoprm'
-    sponsor: umcg-gd
+    # No sponsor as this group does not use Slurm.
   - name: 'umcg-ogm'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-patho'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-pr'
-    sponsor: umcg-gd
+    sponsor: umcg-gd-owners
   - name: 'umcg-vipt'
     sponsor: umcg-mswertz
 regular_users:

--- a/group_vars/betabarrel_cluster/vars.yml
+++ b/group_vars/betabarrel_cluster/vars.yml
@@ -371,7 +371,8 @@ remote_users_in_local_groups:
 soft_partitions:
   - path: /mnt/local_raid/groups/umcg-lab/tmp05/sequencers_incoming
     src: /mnt/local_raid/groups/umcg-lab/tmp05/sequencers_incoming.disk.img
-    fstype: btrfs             # btrfs supports the 4k formatting and works on sequencers
+    fstype: xfs                        # xfs and btrfs support 4k that works on sequencers
+    fsopts: ' -b size=4k -s size=4k'   # extra options for 4k filesystem formatting
     size: 600                 # in GB
     user: sbsuser
     group: umcg-lab

--- a/group_vars/wingedhelix_cluster/vars.yml
+++ b/group_vars/wingedhelix_cluster/vars.yml
@@ -402,7 +402,6 @@ ogm_servers:
       me=${trendanalysis_api_username}&password={{ ogm_api_password }}\" | grep -oP '\"to\
       ken\":\\s*\"\\K[^\"]+')\"'; userrole=3; userpk=24' https://${ogm_server}:3005/proje\
       ctbrowser/bnx/bnx_app/api/downloadQcMetricsCSV?period=90 > ${prm_location}/TrendAnalysis/${ogm_server}-$(date +%F)-${stack_prefix}.csv"
-
 #
 # Local storage variables.
 #

--- a/roles/envsync/tasks/main.yml
+++ b/roles/envsync/tasks/main.yml
@@ -52,7 +52,8 @@
 #
 - name: 'Initialize envsync account creating home dir if it did not exist yet.'
   ansible.builtin.command:
-    cmd: "mkhomedir_helper {{ envsync_user }} 0077"
+    cmd: |
+         /sbin/mkhomedir_helper '{{ envsync_user }}' 0077
     creates: "/home/{{ envsync_user }}"
   become: true
 

--- a/roles/interfaces/tasks/network_manager.yml
+++ b/roles/interfaces/tasks/network_manager.yml
@@ -80,8 +80,8 @@
          set -u
          set -e
          set -o pipefail
-         nmcli --fields UUID,TIMESTAMP-REAL con show \
-           | awk '$2 ~ /never/ {print $1}'
+         nmcli --fields UUID,DEVICE,TIMESTAMP-REAL con show \
+           | awk '$2 == "--" || $3 ~ /never/ {print $1}'
   register: nmcli_con_show_never_used
   changed_when: nmcli_con_show_never_used['stdout'] | length > 1
 

--- a/roles/slurm/files/cgroup.conf.24.11.7-1.el9.umcg
+++ b/roles/slurm/files/cgroup.conf.24.11.7-1.el9.umcg
@@ -1,0 +1,13 @@
+###
+#
+# Slurm cgroup support configuration file
+#
+# See man slurm.conf and man cgroup.conf for further
+# information on cgroup configuration parameters
+#
+# With slurm 23.02.x on el9 we use default settings for cgroups v2.
+### 
+ConstrainCores=yes
+ConstrainDevices=yes
+ConstrainRAMSpace=yes
+ConstrainSwapSpace=yes

--- a/roles/slurm/templates/slurm.conf.24.11.7-1.el9.umcg
+++ b/roles/slurm/templates/slurm.conf.24.11.7-1.el9.umcg
@@ -1,0 +1,138 @@
+#jinja2: trim_blocks:True, lstrip_blocks:True
+ClusterName={{ slurm_cluster_name }}
+SlurmctldHost={{ hostvars[groups['sys_admin_interface'][0]]['ansible_hostname'] }}
+SlurmUser=slurm
+SlurmctldPort=6817
+SlurmdPort=6818
+AuthType=auth/munge
+StateSaveLocation={{ slurm_slurmctld_spool_dir }}
+SlurmdSpoolDir=/var/spool/slurmd
+SwitchType=switch/none
+MpiDefault=none
+MpiParams=ports=12000-12999
+SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmdPidFile=/var/run/slurm/slurmd.pid
+ProctrackType=proctrack/cgroup
+ReturnToService=1
+TaskPlugin=task/affinity,task/cgroup
+JobSubmitPlugins=lua
+TmpFS={{ slurm_local_scratch_dir }}
+# Terminate job immediately when one of the processes is crashed or aborted.
+KillOnBadExit=1
+# Job with invalid dependency (by default) stay pending with DependencyNeverSatisfied. This option kills it and sets JOB_CANCELLED.
+DependencyParameters=kill_invalid_depend
+# Automatically requeue jobs after a node failure or preemption by a higher prio job.
+JobRequeue=1
+# Increase security and prevent credential replay attacks.
+CommunicationParameters=block_null_hash
+#
+# Prologs and Epilogs.
+#
+PrologFlags=Alloc
+Prolog=/etc/slurm/slurm.prolog
+Epilog=/etc/slurm/slurm.epilog*
+TaskProlog=/etc/slurm/slurm.taskprolog
+#TaskEpilog=/etc/slurm/slurm.taskepilog
+#
+# Timers
+#
+SlurmctldTimeout=300
+SlurmdTimeout=300
+MessageTimeout=60
+GetEnvTimeout=20
+BatchStartTimeout=30
+InactiveLimit=0
+MinJobAge=300
+KillWait=30
+UnkillableStepTimeout=300
+Waittime=15
+#
+# Scheduling
+#
+SchedulerType=sched/backfill
+SchedulerParameters=bf_continue,bf_max_job_test=10000,bf_max_job_user=5000,default_queue_depth=1000,bf_window=10080,bf_resolution=300,bf_busy_nodes,preempt_reorder_count=100,preempt_youngest_first
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core_Memory
+PriorityType=priority/multifactor
+PriorityDecayHalfLife=3-0
+PriorityFavorSmall=NO
+PriorityWeightAge=1000
+PriorityWeightFairshare=100000
+PriorityWeightJobSize=0
+PriorityWeightPartition=0
+PriorityWeightQOS=1000000
+PriorityMaxAge=14-0
+PriorityFlags=FAIR_TREE,MAX_TRES
+PreemptType=preempt/qos
+PreemptMode=REQUEUE
+#
+# Logging
+#
+# Log levels for Slurm*Debug:
+#   1 = fatal
+#   2 = error
+#   3 = info (default)
+#   4 = verbose
+#   5 = debug
+#   6 = debug2
+#   7 = debug3
+#   8 = debug4
+#   9 = debug5
+#
+SlurmctldDebug=3
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdDebug=3
+SlurmdLogFile=/var/log/slurm/slurmd.log
+JobCompType=jobcomp/filetxt
+JobCompLoc=/var/log/slurm/jobcomp.log
+#
+# Email notifications
+#
+# Disable sending of email notifications, because it may cause a spam flood,
+# when thousands of scripts with the same bug crash shortly after another.
+# We also don't want jobs to fail when email notifications were requested,
+# so therefore we alias the mail program to /bin/true
+#
+MailProg=/bin/true
+#
+# Accounting
+#
+# Note: Users and their associations must be in the accounting database to make fair share work.
+#
+JobAcctGatherType=jobacct_gather/linux
+JobAcctGatherParams=UsePss,NoOverMemoryKill
+AccountingStorageEnforce=limits,qos  # Will also enable: associations
+AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageHost={{ hostvars[groups['sys_admin_interface'][0]]['ansible_hostname'] }}
+MaxJobCount=100000
+{% if slurm_cluster_gpus_total | int > 0 %}
+GresTypes=gpu
+AccountingStorageTRES=gres/gpu
+{% endif %}
+#
+# Node Health Check (NHC)
+#
+HealthCheckProgram=/usr/sbin/nhc
+HealthCheckInterval=300
+#
+# Partitions
+#
+EnforcePartLimits=Any
+PartitionName=DEFAULT State=UP DefMemPerCPU=1024 MaxNodes=1 MaxTime=7-00:00:01
+{% for partition in slurm_partitions %}
+PartitionName={{ partition.name }} Default={{ partition.default }} Nodes={{ partition.nodes }} MaxNodes={{ partition.max_nodes_per_job }} MaxCPUsPerNode={{ partition.max_cores_per_node }} MaxMemPerNode={{ partition.max_mem_per_node }} {{ partition.extra_options }}
+{% endfor %}
+#
+# Compute nodes
+#
+{% for node in groups['compute_node'] %}
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore={{ hostvars[node]['slurm_threads_per_core'] | default(1) }} State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif %}{% if hostvars[node]['slurm_weight'] is defined %} Weight={{ hostvars[node]['slurm_weight'] }}{% endif +%}
+{% endfor %}
+#
+# User Interface nodes (only for data staging jobs).
+#
+{% for node in groups['user_interface'] %}
+  {% if node not in groups['compute_node'] %}{# this checks if the cluster is a single machine and prevents double entry of UI and node #}
+NodeName={{ node }} Sockets={{ hostvars[node]['slurm_sockets'] }} CoresPerSocket={{ hostvars[node]['slurm_cores_per_socket'] }} ThreadsPerCore={{ hostvars[node]['slurm_threads_per_core'] | default(1) }} State=UNKNOWN RealMemory={{ hostvars[node]['slurm_real_memory'] }} TmpDisk={{ hostvars[node]['slurm_local_disk'] | default(0, true) }} Feature={{ hostvars[node]['slurm_features'] }}{% if hostvars[node]['gpu_type'] is defined %} Gres=gpu:{{ hostvars[node]['gpu_type'] }}:{{ hostvars[node]['gpu_count'] | string }}{% endif +%}
+  {% endif %}
+{% endfor %}

--- a/roles/soft_partition/tasks/soft_partition.yml
+++ b/roles/soft_partition/tasks/soft_partition.yml
@@ -34,7 +34,7 @@
     force: false        # prevent formatting the existing filesystem!
     fstype: "{{ item.fstype }}"
     dev: "{{ item.src }}"
-    opts: "{{ item.fsopts | default('omit') }}"
+    opts: "{{ item.fsopts | default(omit) }}"
   with_items: "{{ soft_partitions }}"
   when:
     - ansible_mounts | selectattr('mount', 'equalto', item.path) | list | length == 0

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -142,24 +142,24 @@ all:
     sys_admin_interface:
       hosts:
         betabarrel:
-          cloud_flavor: umcg.v2.bm.128-512-12000.vlan1336
+          cloud_flavor: umcg.v2.bm.128-512-11900.vlan1336
           host_type: baremetal
           host_networks:
             - name: vlan1336
               security_group: "{{ stack_prefix }}_cluster"
               add_hostname_to_ip_address: true
               nmstate_interface:
-                name: em3
+                name: eno12409np1
             - name: vlan990
               security_group: "{{ stack_prefix }}_storage"
               attach_port_on_instance_launch: false  # Not possible for bare metal on Merlin. Must configure NICs after boot.
               nmstate_interface:
-                name: em3.990
-                mtu: 1500
+                name: eno12399np0.990
+                #mtu: 1500
                 type: vlan
                 vlan:
                   id: 990
-                  base-iface: em3
+                  base-iface: eno12399np0
                 ipv4:
                   dhcp: false
           local_yum_repository: true # enable local yum repository for PERC CLI utility.

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -214,7 +214,7 @@ all:
             betabarrel:
               slurm_sockets: 2
               slurm_cores_per_socket: 64
-              slurm_real_memory: 515456
+              slurm_real_memory: 515041
               slurm_max_cpus_per_node: "{{ slurm_sockets * slurm_cores_per_socket - 8 }}"
               slurm_max_mem_per_node: "{{ slurm_real_memory - 8 * 2048 }}"
               slurm_local_disk: 0

--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -155,7 +155,7 @@ all:
               attach_port_on_instance_launch: false  # Not possible for bare metal on Merlin. Must configure NICs after boot.
               nmstate_interface:
                 name: eno12399np0.990
-                #mtu: 1500
+                mtu: 1500
                 type: vlan
                 vlan:
                   id: 990
@@ -184,6 +184,13 @@ all:
               mounted_owner: root
               mounted_group: root
               mounted_mode: '2755'
+              mount_options: 'bind,nofail'
+              type: none
+            - mount_point: '/apps'
+              device: '/mnt/env05/apps/'
+              mounted_owner: root
+              mounted_group: "{{ envsync_group }}"
+              mounted_mode: '2775'
               mount_options: 'bind,nofail'
               type: none
           local_mount_subfolders:


### PR DESCRIPTION
- Updated various settings for the BetaBarrel stack.
- [Updated `documentation/Patching_Slurm.md` for slightly changed handling of version numbers and removed instructions for older Slurm versions.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/153edac9d267228038185c5b4ac31e02698d7726)
- [Updated `interfaces` role to also delete NetworkManager automagically generated connection profiles, which do not use a network device/interface.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/f2207dc8e5c336b458c6be29115210907bed187d)
- [Bugfix for `soft_partition` role: ensure variable is optional using `default(omit)` as opposed inserting the literal string "omit" as default value.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/eae9c462f9e05d550c42c2744d0083d79ce019d9)
- [Bugfix for BetaBarrel Slurm config: name of a sponsor cannot be the same as the name for a sponsored group.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/44df6c2e0d41985d06cb07f4843774a1d720456d)
- [Added new config files for new Slurm version.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/c63076e7c388d2216c3b01e9e3643a3d6a66f185)
- [Bugfix for envsync role: make sure mkhomedir_helper command can be found.](https://github.com/rug-cit-hpc/league-of-robots/pull/1413/commits/6f2e3c62627392c800109553d764e8c227d7780f)
