### PR TITLE
Bugfixes for Dragen machines

### DIFF
--- a/documentation/Patching_Slurm.md
+++ b/documentation/Patching_Slurm.md
@@ -46,8 +46,48 @@ The following packages should be already installed on the DAI, but run ```yum```
 
 Note: Slurm has support for both ```cgroups``` v1 and v2, but support for v2 is only compiled if the dbus development files are present.
 
+The following packages are required to compile Slurm
+ * These packages should be already present on Deploy Admin Interface (DAI) machines 
+ * On Dragen machines they must be added manually
+
 ```
-dnf install munge-devel munge-libs mysql-devel pam-devel pkgconfig readline-devel lua lua-devel lua-posix dbus-devel
+dnf install munge-devel munge-libs mysql-devel pam-devel pkgconfig readline-devel lua lua-devel lua-posix dbus-devel rpm-build autoconf automake
+```
+
+This installs on an Oracle 8.x Dragen machine:
+
+```
+[root@bb-dragen]# dnf install munge-devel munge-libs mysql-devel pam-devel pkgconfig readline-devel lua lua-devel lua-posix dbus-devel rpm-build autoconf automake
+Package munge-libs-0.5.13-2.el8.x86_64 is already installed.
+Package pkgconf-pkg-config-1.4.2-1.el8.x86_64 is already installed.
+Package lua-5.3.4-12.el8.x86_64 is already installed.
+======================================================================
+ Package                        Architecture    Repository            
+======================================================================
+Installing:
+ autoconf                       noarch          ol8_appstream         
+ automake                       noarch          ol8_appstream         
+ dbus-devel                     x86_64          ol8_appstream         
+ lua-devel                      x86_64          ol8_codeready_builder 
+ lua-posix                      x86_64          ol8_codeready_builder 
+ munge-devel                    x86_64          ol8_codeready_builder 
+ mysql-devel                    x86_64          ol8_appstream         
+ pam-devel                      x86_64          ol8_baseos_latest     
+ readline-devel                 x86_64          ol8_baseos_latest     
+ rpm-build                      x86_64          ol8_appstream         
+Upgrading:
+ munge                          x86_64          ol8_appstream         
+ munge-libs                     x86_64          ol8_appstream         
+ mysql-common                   x86_64          ol8_appstream         
+ mysql-libs                     x86_64          ol8_appstream         
+ pam                            x86_64          ol8_baseos_latest     
+Installing dependencies:
+ cmake-filesystem               x86_64          ol8_appstream         
+ elfutils                       x86_64          ol8_baseos_latest     
+ ncurses-c++-libs               x86_64          ol8_baseos_latest     
+ ncurses-devel                  x86_64          ol8_baseos_latest     
+ zstd                           x86_64          ol8_appstream         
+======================================================================
 ```
 
 ### 2. Download and unpack Slurm
@@ -56,7 +96,6 @@ dnf install munge-devel munge-libs mysql-devel pam-devel pkgconfig readline-deve
 wget https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2
 tar -xvjf slurm-${SLURM_VERSION}.tar.bz2
 ```
-
 
 ### 3. Patching slurmd source
 
@@ -157,6 +196,10 @@ and **not** the ```${NHC_VERSION}.tar.gz``` files, which are automatically gener
 rpmbuild -ta --define 'rel 1' ~/rpmbuild/SOURCES/lbnl-nhc-${NHC_VERSION}.tar.gz
 ```
 
-When successful, add the patched RPMs to our custom repo on the Pulp repo servers for the corresponding infra stacks.
-Don't forget to create a new Pulp publication for the updated repo version and then update the Pulp distribution 
-to serve the new Pulp publication. See [Configuring_Pulp](Configuring_Pulp.md) for details.
+When successful, add the patched RPMs
+ * Either - for clusters that use repo servers - to our custom repo on the _Pulp repo server_ for the corresponding infra stack.  
+   Don't forget to create a new Pulp _publication_ for the updated repo version
+   and then update the Pulp _distribution_ to serve the new Pulp _publication_.  
+   See [Configuring_Pulp](Configuring_Pulp.md) for details.
+ * Or - for clusters that do not use repo servers - to the local _yum repo_ on all machines of the correspnding stack that need Slurm.  
+   See `roles/yum_local/README.md` for details.

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -21,7 +21,7 @@ managed_yum_repos:
               | selectattr('tags', 'defined')
               | selectattr('tags', 'intersect', ['distro', 'epel', 'rsyslog', 'irods'])
               | map(attribute='id') }}"
-  oracle8: "{{ yum_repos['rocky9']
+  oracle8: "{{ yum_repos['oracle8']
               | selectattr('tags', 'defined')
               | selectattr('tags', 'intersect', ['core', 'epel', 'uek', 'rsyslog'])
               | map(attribute='id') }}"

--- a/roles/grub/handlers/main.yml
+++ b/roles/grub/handlers/main.yml
@@ -7,9 +7,18 @@
 - name: 'Rebuild GRUB config.'
   ansible.builtin.shell:
     cmd: |
+         set -e
+         set -u
+         set -o pipefail
          timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
          cp -v '/boot/grub2/grub.cfg' "/boot/grub2/grub.cfg.ansible_backup_${timestamp}"
-         grub2-mkconfig --update-bls-cmdline -o '/boot/grub2/grub.cfg'
+         if grub2-mkconfig --help | grep update-bls-cmdline 1>/dev/null; then
+             # For newer grub2-mkconfig on EL >= 9.x
+             grub2-mkconfig --update-bls-cmdline -o '/boot/grub2/grub.cfg'
+         else
+             # For older grub2-mkconfig on EL <= 8.x
+             grub2-mkconfig -o '/boot/grub2/grub.cfg'
+         fi
     executable: '/bin/bash'
   register: grub2_result
   changed_when: grub2_result.rc == 0

--- a/roles/interfaces/handlers/main.yml
+++ b/roles/interfaces/handlers/main.yml
@@ -6,9 +6,18 @@
 #
 - name: Rebuild GRUB config.
   ansible.builtin.shell: |
+         set -e
+         set -u
+         set -o pipefail
          timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
          cp -v '/boot/grub2/grub.cfg' "/boot/grub2/grub.cfg.ansible_backup_${timestamp}"
-         grub2-mkconfig --update-bls-cmdline -o '/boot/grub2/grub.cfg'
+         if grub2-mkconfig --help | grep update-bls-cmdline 1>/dev/null; then
+             # For newer grub2-mkconfig on EL >= 9.x
+             grub2-mkconfig --update-bls-cmdline -o '/boot/grub2/grub.cfg'
+         else
+             # For older grub2-mkconfig on EL <= 8.x
+             grub2-mkconfig -o '/boot/grub2/grub.cfg'
+         fi
   args:
     executable: '/bin/bash'
   changed_when: true

--- a/single_group_playbooks/chaperone.yml
+++ b/single_group_playbooks/chaperone.yml
@@ -5,7 +5,7 @@
 - name: Import initialization playbook for all hosts.
   ansible.builtin.import_playbook: init.yml
 
-- name: '###==-> Roles only for completely managed chaperones <-==###'
+- name: '###==-> Roles only for completely managed chaperones. <-==###'
   hosts: chaperone,!mit_chaperone
   roles:
     - interfaces
@@ -21,10 +21,25 @@
     - sshd
     - basic_security
     - figlet_motd
-    - role: logs_client
-      when: cluster_class is defined
     - resolver
     - coredumps
+
+- name: '###==-> More Roles only for completely managed chaperones. <-==###'
+  hosts:
+    - chaperone,!mit_chaperone
+  #
+  # Use hard coded strategy linear to disable mitogen when present,
+  # because mitogen fails to detect the ansible_python_interpreter correctly
+  # when using delegate_to, which is used in the logs_client role.
+  # There is no problem when the inventory_host for which a task is executed
+  # has the same Python as the host to which the task is delegated.
+  # But if the inventory_host's Python is missing on the delegate_to host,
+  # then the task will fail.
+  #
+  strategy: linear
+  roles:
+    - role: logs_client
+      when: cluster_class is defined
 
 - name: '###==-> Roles for all chaperones. <-==###'
   hosts: chaperone
@@ -41,7 +56,7 @@
     - envsync
     - parallax
 
-- name: '###==-> Roles only for partially managed chaperones <-==###'
+- name: '###==-> Roles only for partially managed chaperones. <-==###'
   hosts: mit_chaperone
   roles:
     - logs_toprm

--- a/single_group_playbooks/cluster_part1.yml
+++ b/single_group_playbooks/cluster_part1.yml
@@ -28,8 +28,6 @@
     #
     # - node_exporter
     - cluster
-    - role: logs_client
-      when: cluster_class is defined
     - gpu  # Needs to run after 'cluster' role.
     - resolver
     - coredumps
@@ -37,4 +35,22 @@
       when: perc_devices is defined and perc_devices
     - role: local_storage
       when: local_mounts is defined and local_mounts | length > 0
+
+- name: '###==-> More basic roles for all cluster machines part 1. <-==###'
+  hosts:
+    - cluster
+  #
+  # Use hard coded strategy linear to disable mitogen when present,
+  # because mitogen fails to detect the ansible_python_interpreter correctly
+  # when using delegate_to, which is used in the logs_client role.
+  # There is no problem when the inventory_host for which a task is executed
+  # has the same Python as the host to which the task is delegated.
+  # But if the inventory_host's Python is missing on the delegate_to host,
+  # then the task will fail.
+  #
+  strategy: linear
+  roles:
+    - role: logs_client
+      when: cluster_class is defined
+
 ...

--- a/single_group_playbooks/jumphost.yml
+++ b/single_group_playbooks/jumphost.yml
@@ -24,11 +24,26 @@
       when: use_sssd | default(false) | bool
     - sshd
     - basic_security
-    - role: logs_client
-      when: logs_class is defined
     - regular_users
     # Disabled monitoring: needs update. See also:
     # https://github.com/rug-cit-hpc/league-of-robots/issues/294
     # - node_exporter
     # - {role: grafana_proxy, when: ansible_hostname == 'airlock'}
+
+- name: '###==-> More roles for jumphosts. <-==###'
+  hosts:
+    - jumphost
+  #
+  # Use hard coded strategy linear to disable mitogen when present,
+  # because mitogen fails to detect the ansible_python_interpreter correctly
+  # when using delegate_to, which is used in the logs_client role.
+  # There is no problem when the inventory_host for which a task is executed
+  # has the same Python as the host to which the task is delegated.
+  # But if the inventory_host's Python is missing on the delegate_to host,
+  # then the task will fail.
+  #
+  strategy: linear
+  roles:
+    - role: logs_client
+      when: cluster_class is defined
 ...

--- a/single_group_playbooks/repo.yml
+++ b/single_group_playbooks/repo.yml
@@ -23,10 +23,26 @@
     - local_storage
     - remove
     - update
+
+- name: '###==-> More roles for repo management servers. <-==###'
+  hosts:
+    - repo
+    - repo_servers
+  #
+  # Use hard coded strategy linear to disable mitogen when present,
+  # because mitogen fails to detect the ansible_python_interpreter correctly
+  # when using delegate_to, which is used in the logs_client role.
+  # There is no problem when the inventory_host for which a task is executed
+  # has the same Python as the host to which the task is delegated.
+  # But if the inventory_host's Python is missing on the delegate_to host,
+  # then the task will fail.
+  #
+  strategy: linear
+  roles:
     - role: logs_client
       when: cluster_class is defined
 
-- name: '###==-> Roles for repo management servers. <-==###'
+- name: '###==-> Roles for Pulp repo management servers. <-==###'
   hosts: repo
   #
   # Use hard coded strategy linear to disable mitogen when present as it

--- a/single_role_playbooks/logs_client.yml
+++ b/single_role_playbooks/logs_client.yml
@@ -8,6 +8,16 @@
     - repo
     - repo_servers
     - logs
+  #
+  # Use hard coded strategy linear to disable mitogen when present,
+  # because mitogen fails to detect the ansible_python_interpreter correctly
+  # when using delegate_to, which is used in the logs_client role.
+  # There is no problem when the inventory_host for which a task is executed
+  # has the same Python as the host to which the task is delegated.
+  # But if the inventory_host's Python is missing on the delegate_to host,
+  # then the task will fail.
+  #
+  strategy: linear
   roles:
     - role: logs_client
       when: ((syslog_external_servers is defined and ( syslog_external_servers|length>0 )) or ( cluster_class is defined ))


### PR DESCRIPTION
* [Fixed typo in managed_yum_repos for oracle8 machines.](https://github.com/rug-cit-hpc/league-of-robots/commit/ff7a78c41bd2938cb1006e84b7f4e075d8b51bd8)
* [Updated instructions how to compile a patched Slurm with details for Dragen machines.](https://github.com/rug-cit-hpc/league-of-robots/commit/60bb720ba7ce23bfe624aea768b27c712cb38229)
* [Updated handlers that use grub2-mkconfig to handle the older version on Oracle 8, that does not have the `--update-bls-cmdline` argument.](https://github.com/rug-cit-hpc/league-of-robots/commit/fc1c85f4b83f9921ca9c74b2d43d0d47e350e355)
* [`logs_client` role: Use "strategy: linear" to disable mitogen, because it fails to discover the correct `ansible_python_interpreter` on `delegate_to` hosts.](https://github.com/rug-cit-hpc/league-of-robots/commit/adc5016d2a06679382480ffb47ca83f6cbc94ac7)
