### PR TITLE
Implemented work around for chattr bug in ansible core.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             export ANSIBLE_ROLES_PATH="${VIRTUAL_ENV}/ansible/ansible_roles/:"
             export ANSIBLE_COLLECTIONS_PATH="${VIRTUAL_ENV}/ansible/:"
             pip install jmespath
-            pip install ansible
+            pip install 'ansible<=13'  # Ansible 14.x is broken
             pip install ansible-lint
             attempt=1
             until [[ "${attempt}" -gt 3 ]]; do

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,8 +14,8 @@ collections:
     version: '>=2.21.0'
   - name: community.general
     version: '>=8.6.3'
-  - name: community.mysql
-    version: '>=3.9.0'
+  - name: ansible.mysql
+    version: '>=5.0.1'
   - name: openstack.cloud
     version: '>=2.2.0'
   - name: pulp.pulp_installer

--- a/roles/envsync/defaults/main.yml
+++ b/roles/envsync/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 envsync_ssh_key_type: ed25519
+envsync_key_file_path: /home/{{ envsync_user }}/.ssh/id_{{ envsync_ssh_key_type }}
 ...

--- a/roles/envsync/tasks/main.yml
+++ b/roles/envsync/tasks/main.yml
@@ -90,9 +90,35 @@
     create: false
   become: true
 
+#
+# Work around to prevent
+#   "Error while setting attributes: /home/umcg-envsync/.ssh/id_ed25519.pub: Operation not permitted"
+#   "msg: chattr failed"
+# See
+#   https://github.com/ansible-collections/community.crypto/issues/416
+#   https://github.com/ansible/ansible/issues/77217
+#
+- name: 'Touch key pair files as workround for chattr bug in ansible core.'
+  ansible.builtin.shell: |
+      set -e
+      set -u
+      set -o pipefail
+      if [[ ! -e "{{ envsync_key_file_path }}" ]]; then
+          touch "{{ envsync_key_file_path }}"
+          echo "Touched {{ envsync_key_file_path }}"
+      fi
+      if [[ ! -e "{{ envsync_key_file_path }}.pub" ]]; then
+          touch "{{ envsync_key_file_path }}.pub"
+          echo "Touched {{ envsync_key_file_path }}.pub"
+      fi
+  register: envsync_touch_key_pair
+  changed_when: "'Touched' in envsync_touch_key_pair.stdout"
+  become: true
+  become_user: "{{ envsync_user }}"
+
 - name: 'Create ssh key pair for rsyncing cache to compute nodes.'
   community.crypto.openssh_keypair:
-    path: "/home/{{ envsync_user }}/.ssh/id_{{ envsync_ssh_key_type }}"
+    path: "{{ envsync_key_file_path }}"
     type: "{{ envsync_ssh_key_type }}"
     comment: "{{ envsync_user }}@{{ inventory_hostname }}"
     regenerate: full_idempotence
@@ -104,7 +130,7 @@
     cmd: |
          set -o pipefail
          "{{ get_public_keys_command }}" "{{ envsync_user }}" \
-         | fgrep -f "/home/{{ envsync_user }}/.ssh/id_{{ envsync_ssh_key_type }}.pub"
+         | fgrep -f "{{ envsync_key_file_path }}.pub"
   register: envsync_user_authorized_public_keys
   changed_when: false
   failed_when: false
@@ -119,7 +145,7 @@
          IMPORTANT: Manual work!
          ***********************************************************************************************************
          Ansible created:
-             {{ inventory_hostname }}:/home/{{ envsync_user }}/.ssh/id_{{ envsync_ssh_key_type }}.pub
+             {{ inventory_hostname }}:{{ envsync_key_file_path }}.pub
          But that public key is not yet available for the {{ envsync_user }} user
          in the output of the {{ get_public_keys_command }} command:
              stdout: {{ envsync_user_authorized_public_keys['stdout'] }}
@@ -135,7 +161,7 @@
 - name: "Assign ssh public key to ~/.ssh/authorized_keys for {{ envsync_user }}."
   ansible.posix.authorized_key:
     user: "{{ envsync_user }}"
-    key: "file:///home/{{ envsync_user }}/.ssh/id_ed25519.pub"
+    key: "file://{{ envsync_key_file_path }}.pub"
     state: present
     exclusive: true
   when:

--- a/roles/envsync/tasks/main.yml
+++ b/roles/envsync/tasks/main.yml
@@ -104,11 +104,11 @@
       set -u
       set -o pipefail
       if [[ ! -e "{{ envsync_key_file_path }}" ]]; then
-          touch "{{ envsync_key_file_path }}"
+          $(umask 0077 && touch "{{ envsync_key_file_path }}")
           echo "Touched {{ envsync_key_file_path }}"
       fi
       if [[ ! -e "{{ envsync_key_file_path }}.pub" ]]; then
-          touch "{{ envsync_key_file_path }}.pub"
+          $(umask 0077 && touch "{{ envsync_key_file_path }}.pub")
           echo "Touched {{ envsync_key_file_path }}.pub"
       fi
   register: envsync_touch_key_pair

--- a/roles/mariadb/tasks/set_root_password.yml
+++ b/roles/mariadb/tasks/set_root_password.yml
@@ -15,7 +15,7 @@
 # by setting an 'invalid' password.
 #
 - name: 'Set MariaDB/MySQL root user password.'
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: 'root'
     host: 'localhost'
     password: "{{ MYSQL_ROOT_PASSWORD }}"

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -149,5 +149,5 @@ slurm_daemons: "
            inventory_hostname in groups['user_interface'] | default([]) -%}
       {%- set _slurm_daemons_on_this_host = _slurm_daemons_on_this_host | default([]) + ['slurmd'] -%}
     {%- endif -%}
-    {{- _slurm_daemons_on_this_host -}}"
+    {{- _slurm_daemons_on_this_host -}}"  # noqa jinja[spacing]
 ...

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -141,7 +141,7 @@ slurm_qos_limits:
       cores: "{{ [1, (slurm_total_cores_of_smallest_node | float * slurm_qos_limit_fractions['interactive-short']['user']) | int] | max }}"
       mem: "{{ [1000, (slurm_total_mem_of_smallest_node | float * slurm_qos_limit_fractions['interactive-short']['user']) | int] | max }}"
       gpus: "{{ (slurm_total_gpus_of_smallest_node | float * slurm_qos_limit_fractions['interactive-short']['user']) | round(0, 'ceil') | int }}"
-slurm_daemons: "
+slurm_daemons: >- # noqa jinja[spacing]
     {%- if inventory_hostname in groups['sys_admin_interface'] | default([]) -%}
       {%- set _slurm_daemons_on_this_host = ['slurmdbd', 'slurmctld'] -%}
     {%- endif -%}
@@ -149,5 +149,5 @@ slurm_daemons: "
            inventory_hostname in groups['user_interface'] | default([]) -%}
       {%- set _slurm_daemons_on_this_host = _slurm_daemons_on_this_host | default([]) + ['slurmd'] -%}
     {%- endif -%}
-    {{- _slurm_daemons_on_this_host -}}"  # noqa jinja[spacing]
+    {{- _slurm_daemons_on_this_host -}}
 ...

--- a/roles/slurm/tasks/client.yml
+++ b/roles/slurm/tasks/client.yml
@@ -12,7 +12,7 @@
     # This is fixed in newer versions of Ansible + Mitogen,
     # but EL <= 8.x machines are stuck on the older Ansible 9.x and we cannot upgrade.
     #
-    ansible_python_interpreter: python
+    ansible_python_interpreter: python3
   with_items: "{{ groups['sys_admin_interface'] }}"
 
 - name: 'Add Slurm group.'

--- a/roles/slurm/tasks/management.yml
+++ b/roles/slurm/tasks/management.yml
@@ -113,7 +113,7 @@
   become: true
 
 - name: 'Create a database for Slurm accounting.'
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     login_host: 'localhost'
     login_user: 'root'
     login_password: "{{ MYSQL_ROOT_PASSWORD | default(omit) }}"  # No longer required for MariaDB >= 10.4
@@ -127,7 +127,7 @@
     - 'restart_slurmctld'
 
 - name: 'Make sure the slurm database user is present and grant privileges on the Slurm accounting DB.'
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     login_host: 'localhost'
     login_user: 'root'
     login_password: "{{ MYSQL_ROOT_PASSWORD | default(omit) }}"  # No longer required for MariaDB >= 10.4


### PR DESCRIPTION
Work around to prevent
```
   "Error while setting attributes: <file>: Operation not permitted"
   "msg: chattr failed"
```
when creating a key pair for the envsync user.