### PR TITLE
Increased timeouts for mounting mdadm software RAIDs during boot.

### DIFF
--- a/static_inventories/betabarrel_cluster.yml
+++ b/static_inventories/betabarrel_cluster.yml
@@ -65,7 +65,7 @@ all:
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'
-              mount_options: rw,relatime,nofail,x-systemd.device-timeout=10
+              mount_options: rw,relatime,nofail,x-systemd.device-timeout=120
               type: xfs
               md:
                 raid_level: 0

--- a/static_inventories/copperfist_cluster.yml
+++ b/static_inventories/copperfist_cluster.yml
@@ -70,7 +70,7 @@ all:
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'
-              mount_options: rw,relatime,nofail,x-systemd.device-timeout=10
+              mount_options: rw,relatime,nofail,x-systemd.device-timeout=120
               type: ext4
               md:
                 raid_level: 0

--- a/static_inventories/wingedhelix_cluster.yml
+++ b/static_inventories/wingedhelix_cluster.yml
@@ -76,7 +76,7 @@ all:
               mounted_owner: root
               mounted_group: root
               mounted_mode: '0755'
-              mount_options: rw,relatime,nofail,x-systemd.device-timeout=10
+              mount_options: rw,relatime,nofail,x-systemd.device-timeout=120
               type: ext4
               md:
                 raid_level: 0


### PR DESCRIPTION
Prevents mount for /groups missing after reboot.